### PR TITLE
Update env templates with current urls

### DIFF
--- a/apps/public-ala/.env.template
+++ b/apps/public-ala/.env.template
@@ -1,5 +1,5 @@
 ## == IMPORTANT REMINDER: ANY EDITS HERE MUST BE UPDATED IN ALL ENVIRONMENTS (incl. CI) == ##
-LISTING_SERVICE_URL=http://localhost:3001
-HOUSING_COUNSELOR_SERVICE_URL=https://housing.sfgov.org/assets/housing_counselors-7b0f260dac22dfa20871edd36135b62f1a25a9dad78faf2cf8e8e2514b80cf61.json
+LISTING_SERVICE_URL="http://localhost:3001/?jsonpath=%24%5B%3F(%40.buildingAddress.county%3D%3D%22Alameda%22)%5D"
+HOUSING_COUNSELOR_SERVICE_URL=https://www.acgov.org/cda/hcd/index.htm
 NEXTJS_PORT=3000
 MAPBOX_TOKEN=pk.eyJ1IjoibWplZHJhcyIsImEiOiJjazI2OHA5YzQycTBpM29xdDVwbXNyMDlwIn0.XS5ilGzTh_yVl3XY-8UKeA

--- a/apps/public-sj/.env.template
+++ b/apps/public-sj/.env.template
@@ -1,5 +1,5 @@
 ## == IMPORTANT REMINDER: ANY EDITS HERE MUST BE UPDATED IN ALL ENVIRONMENTS (incl. CI) == ##
-LISTING_SERVICE_URL=http://localhost:3001
-HOUSING_COUNSELOR_SERVICE_URL=https://housing.sfgov.org/assets/housing_counselors-7b0f260dac22dfa20871edd36135b62f1a25a9dad78faf2cf8e8e2514b80cf61.json
+LISTING_SERVICE_URL="http://localhost:3001/?jsonpath=%24%5B%3F(%40.buildingAddress.city%3D%3D%22San+Jose%22)%5D"
+HOUSING_COUNSELOR_SERVICE_URL=https://www.sanjoseca.gov/your-government/departments/housing/renters-apartment-owners
 NEXTJS_PORT=3000
 MAPBOX_TOKEN=pk.eyJ1IjoibWplZHJhcyIsImEiOiJjazI2OHA5YzQycTBpM29xdDVwbXNyMDlwIn0.XS5ilGzTh_yVl3XY-8UKeA

--- a/apps/public-smc/.env.template
+++ b/apps/public-smc/.env.template
@@ -1,5 +1,5 @@
 ## == IMPORTANT REMINDER: ANY EDITS HERE MUST BE UPDATED IN ALL ENVIRONMENTS (incl. CI) == ##
-LISTING_SERVICE_URL=http://localhost:3001
-HOUSING_COUNSELOR_SERVICE_URL=https://housing.sfgov.org/assets/housing_counselors-7b0f260dac22dfa20871edd36135b62f1a25a9dad78faf2cf8e8e2514b80cf61.json
+LISTING_SERVICE_URL="http://localhost:3001/?jsonpath=%24%5B%3F(%40.buildingAddress.county%3D%3D%22San+Mateo%22)%5D"
+HOUSING_COUNSELOR_SERVICE_URL=https://housing.smcgov.org/find-rental-assistance
 NEXTJS_PORT=3000
 MAPBOX_TOKEN=pk.eyJ1IjoibWplZHJhcyIsImEiOiJjazI2OHA5YzQycTBpM29xdDVwbXNyMDlwIn0.XS5ilGzTh_yVl3XY-8UKeA


### PR DESCRIPTION
fixes both the listings JSONPath query strings to match what's in use and also the HOUSING_COUNSELOR_SERVICE_URLs