### PR TITLE
Fix preference language for Reilly Station

### DIFF
--- a/services/listings/listings/reilly_station.json
+++ b/services/listings/listings/reilly_station.json
@@ -1517,7 +1517,7 @@
   "preferences": [
     {
       "title": "Live/work in the City of Fremont",
-      "subtitle": "Household that currently live or work in the City of Fremont are given priority none Fremont",
+      "subtitle": "Households that currently live or work in the City of Fremont are given priority.",
       "ordinal": "1st"
     }
   ],


### PR DESCRIPTION
Per request. I felt bad for what looked like a copy/paste error I introduced, but the incorrect language is actually copied verbatim from the spreadsheet.

Note the second sentence they wanted to add is already right below the box, so I elected not to duplicate it.