### PR TITLE
Set Bridgepointe to use 2020 AMI chart instead of 2019

### DIFF
--- a/services/listings/listings/bridgepointe.json
+++ b/services/listings/listings/bridgepointe.json
@@ -103,7 +103,7 @@
       "createdAt": "2019-06-03T10:42:43.134Z",
       "updatedAt": "2019-07-10T09:44:01.384Z",
       "listingId": 3,
-      "amiChartId": 1,
+      "amiChartId": 7,
       "monthlyRentAsPercentOfIncome": null
     },
     {
@@ -127,7 +127,7 @@
       "createdAt": "2019-06-03T10:42:43.134Z",
       "updatedAt": "2019-07-10T09:44:01.384Z",
       "listingId": 3,
-      "amiChartId": 1,
+      "amiChartId": 7,
       "monthlyRentAsPercentOfIncome": null
     },
     {
@@ -151,7 +151,7 @@
       "createdAt": "2019-06-03T10:42:43.134Z",
       "updatedAt": "2019-07-10T09:44:01.384Z",
       "listingId": 3,
-      "amiChartId": 1,
+      "amiChartId": 7,
       "monthlyRentAsPercentOfIncome": null
     }
   ],


### PR DESCRIPTION
Fixes #106.

Hopefully Eastlake final QA will be done shortly, and then we can roll both listings to production together.