### PR TITLE
disable Eastlake listing

### DIFF
--- a/services/listings/listings/eastlake-never-launched.json
+++ b/services/listings/listings/eastlake-never-launched.json
@@ -20,7 +20,7 @@
   "blankPaperApplicationCanBePickedUp": false,
   "buildingAddress": {
     "city": "Oakland",
-    "county": "Alameda",
+    "county": "Alameda Listings Never Launched",
     "street": "2505 10th Avenue",
     "zipCode": "94606",
     "state": "CA",


### PR DESCRIPTION
It sounds like the Eastlake team was able to lease up their building faster than they were able to approve the listing so it's not going to launch on Bloom. We'll keep it around in a permanently disabled state in case they have another need in the future.