### PR TITLE
Disable income validation for the ala site

### DIFF
--- a/apps/public-ala/pages/applications/financial/income.tsx
+++ b/apps/public-ala/pages/applications/financial/income.tsx
@@ -65,9 +65,11 @@ export default () => {
   const onSubmit = (data) => {
     const { income, incomePeriod } = data
     // Skip validation of total income if the applicant has income vouchers.
-    const validationError = application.incomeVouchers
-      ? null
-      : verifyIncome(listing, income, incomePeriod)
+    // Not running this validation for the time being -JW
+    //const validationError = application.incomeVouchers
+    //  ? null
+    //  : verifyIncome(listing, income, incomePeriod)
+    const validationError = null
     setIncomeError(validationError)
 
     if (!validationError) {


### PR DESCRIPTION
For the pilot, disable income validation during the application process (Alameda site).