### PR TITLE
Comment out language choice from Application

### DIFF
--- a/apps/public-ala/pages/applications/start/choose-language.tsx
+++ b/apps/public-ala/pages/applications/start/choose-language.tsx
@@ -76,9 +76,9 @@ export default () => {
         <div className="form-card__pager">
           <Form className="" onSubmit={handleSubmit(onSubmit)}>
             <div className="form-card__pager-row primary px-4">
-              <h3 className="mb-4 font-alt-sans field-label--caps block text-base text-black">
+              {/* <h3 className="mb-4 font-alt-sans field-label--caps block text-base text-black">
                 {t("application.chooseLanguage.chooseYourLanguage")}
-              </h3>
+              </h3> */}
 
               <Button
                 className="mx-1"
@@ -89,7 +89,7 @@ export default () => {
                 Begin
               </Button>
 
-              <Button
+              {/* <Button
                 className="mx-1"
                 onClick={() => {
                   //
@@ -105,7 +105,7 @@ export default () => {
                 }}
               >
                 開始
-              </Button>
+              </Button> */}
             </div>
           </Form>
 

--- a/services/listings/listings/jones.json
+++ b/services/listings/listings/jones.json
@@ -59,6 +59,10 @@
     {
       "fileUrl": "http://jonesberkeley.com/",
       "type": 1
+    },
+    {
+      "fileUrl": "/applications/start/choose-language?listingId=HOLNx_F7fUCeax5GCoIr5g",
+      "type": 2
     }
   ],
   "applicationFee": "52.46",


### PR DESCRIPTION
Temporary comment-out of the language choice for the Jones application pilot, to be returned once translations have been done and validated.

Also hard-codes (ish) the application ID link for Jones. This will be replaced in the short-term with a hard-coded UUID directly in the database until the proper ApplicationMethods code lands upstream and is incorporated.