### PR TITLE
extend Skylyne deadline to 1 Nov per request

### DIFF
--- a/backend/core/listing_data/skylyne.json
+++ b/backend/core/listing_data/skylyne.json
@@ -66,12 +66,12 @@
   "rentalHistory": "Applicant must be able to provide sufficient residential information for at least the past two years to enable the Property Manager to adequately evaluate rental history and/or place of residence. If two years of prior residential information proves insufficient for obtaining adequate references, additional residential history may be requested. Negative rental history will be grounds for denial, including: Any evictions with an outstanding judgement, 4 or more evictions filings, 4 or more late payments being reported on the rental history report",
   "preferences": [
     {
-      "ordinal": "1st",
+      "ordinal": "1",
       "title": "Displaced Preference",
       "description": "Households who have been displaced as a result of the City of Oakland’s public projects or the City’s code enforcement activities."
     },
     {
-      "ordinal": "2nd",
+      "ordinal": "2",
       "title": "Live or Work Preference",
       "description": "1. Oakland Resident - Households who are current residents of the City of Oakland. 2. Oakland Worker - Households with at least one member who is currently employed in the city of Oakland, have been notified that they are hired to work in the city of Oakland, or are active participants in an educational or job training program located in the city of Oakland."
     }

--- a/backend/core/listing_data/skylyne.json
+++ b/backend/core/listing_data/skylyne.json
@@ -10,7 +10,7 @@
     "latitude": null,
     "longitude": null
   },
-  "applicationDueDate": "2020-10-01T17:00:00.000-07:00",
+  "applicationDueDate": "2020-11-01T17:00:00.000-07:00",
   "applicationOrganization": "",
   "applicationPhone": "510-747-5817",
   "buildingAddress": {

--- a/backend/core/listing_data/skylyne.json
+++ b/backend/core/listing_data/skylyne.json
@@ -10,7 +10,7 @@
     "latitude": null,
     "longitude": null
   },
-  "applicationDueDate": "2020-11-01T17:00:00.000-07:00",
+  "applicationDueDate": "2020-11-01T17:00:00.000-08:00",
   "applicationOrganization": "",
   "applicationPhone": "510-747-5817",
   "buildingAddress": {


### PR DESCRIPTION
Fixes #162.

Notes: 

- I'm actually going to apply this on staging and production via a direct SQL query hotfix so IDs stay the same, but updating the JSON here for tracking, QA, and future imports.
- I updated the ordinals here so imports work
- NB that the time zone for the Bay Area as of 1 Nov 20 is back to GMT-8, so we'll need to keep that in mind for listings through the winter.