### PR TITLE
fix/remove duplicate get assistance link

### DIFF
--- a/sites/public/layouts/application.tsx
+++ b/sites/public/layouts/application.tsx
@@ -54,12 +54,9 @@ const Layout = (props) => {
           <LocalizedLink href="/listings" className="navbar-item">
             {t("nav.listings")}
           </LocalizedLink>
-          <a href="https://www.acgov.org/cda/hcd/index.htm" target="_blank" className="navbar-item">
-            {t("nav.getAssistance")}
-          </a>
           {/* Only show Get Assistance if housing counselor data is available */}
           {process.env.housingCounselorServiceUrl && (
-            <LocalizedLink href="/housing-counselors" className="navbar-item">
+            <LocalizedLink href={process.env.housingCounselorServiceUrl} className="navbar-item">
               {t("nav.getAssistance")}
             </LocalizedLink>
           )}


### PR DESCRIPTION
Removes the duplicate Get Assistance link

Potentially the solution here should have been to ignore the env variable and that we always just show the hard-coded link? Honestly not sure, just missing some context