### PR TITLE
fix: updated resource content

### DIFF
--- a/sites/public/page_content/AdditionalResourcesSidebar.md
+++ b/sites/public/page_content/AdditionalResourcesSidebar.md
@@ -5,7 +5,7 @@
 
 For listing and application questions, please contact the Property Agent displayed on the listing.
 
-For general program inquiries, you may call the Housing Department at 408-535-3860 or email <sjhousingportal@sanjoseca.gov>.
+For general program inquiries, you may call the Housing Department at [408-535-3860](tel:+1-408-535-3860) or email <sjhousingportal@sanjoseca.gov>.
 
 </RenderIf>
 

--- a/sites/public/page_content/AdditionalResourcesSidebar.md
+++ b/sites/public/page_content/AdditionalResourcesSidebar.md
@@ -5,7 +5,7 @@
 
 For listing and application questions, please contact the Property Agent displayed on the listing.
 
-For general program inquiries, you may call the Housing Department at [408-535-3860](tel:+1-408-535-3860).
+For general program inquiries, you may call the Housing Department at 408-535-3860 or email <sjhousingportal@sanjoseca.gov>.
 
 </RenderIf>
 

--- a/sites/public/sentry.server.config.js
+++ b/sites/public/sentry.server.config.js
@@ -1,6 +1,7 @@
 // This file configures the initialization of Sentry on the server.
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
+/* eslint-env node */
 
 // eslint-disable-next-line no-undef
 if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
Description: Update content on the 'Additional Housing Opportunities and Resources' page on the San Jose public site to match #408 

Testing: This can be testing by going to the San Jose public site and ensuring that the contact info on the right side matches the following text: "For general program inquiries, you may call the Housing Department at 408-535-3860 or email [sjhousingportal@sanjoseca.gov](mailto:sjhousingportal@sanjoseca.gov)"

Question: Do I incorporate this into translations as well in this PR?