### PR TITLE
fix: resource and translation updates

### DIFF
--- a/sites/public/page_content/AdditionalResources.md
+++ b/sites/public/page_content/AdditionalResources.md
@@ -274,7 +274,7 @@ Call [510-574-2000](tel:+1-510-574-2000)
 
 <RenderIf language="es">
 
-<InfoCardGrid title="Immediate Housing Assistance" subtitle="Si está huyendo de violencia doméstica, agresión sexual o trata de personas y está en peligro inmediato, llame al 911.
+<InfoCardGrid title="Asistencia de vivienda inmediata" subtitle="Si está huyendo de violencia doméstica, agresión sexual o trata de personas y está en peligro inmediato, llame al 911.
 ">
 <InfoCard title="211 Buscador de recursos del Condado de Alameda" externalHref="https://achousingchoices.org/">
 
@@ -538,18 +538,16 @@ Llame al [510-574-2000](tel:+1-510-574-2000)
 
 <RenderIf language="zh">
 
-  <InfoCardGrid title="Immediate Housing Assistance">
+  <InfoCardGrid title="即時住房援助" subtitle="如果您正在逃離家庭暴力、性侵害，或人口販賣，而且處於直接危險之中，請撥打 911">
   <InfoCard title="211 阿拉米達縣資源搜尋工具" externalHref="https://achousingchoices.org/">
 
-如果您需要立即入住緊急收容所和尋求住房協助，請致電 [510-537-2552](tel:+1-510-537-2552) 與 Eden Information & Referral（伊甸資訊和轉介中心）聯絡，或致電 1-800-273-6222 與 Bay Area Helpline（灣區求助熱線）聯絡；或可瀏覽 https://achousingchoices.org/ 。
+如果您需要緊急避難所和住宅協助，請撥打 [211](tel:+1-510-537-2552) 聯絡伊甸資訊與轉介 (Eden Information & Referral) ，或撥打灣區協助熱線 (Bay Area Helpline) [1-800-273-6222](tel:+1-800-273-6222)。
 
   </InfoCard>
 
-  <InfoCard title="Bay Area Community Services" externalHref="https://www.bayareacs.org/">
+  <InfoCard title="獨立生活" externalHref="https://ilacalifornia.org/alameda-county/directory/">
 
-BACS 住房資源中心，聯絡電話：[510-613-0330](tel:+1-510-613-0330)。
-
-Albany、Berkeley、Emeryville 及 Oakland
+尋找適合於殘障人士，包括精神疾病，和其他可能受益於共享生活環境的成年人，由私人擁有或經營的住宅或大樓。
 
   </InfoCard>
 
@@ -558,11 +556,23 @@ Albany、Berkeley、Emeryville 及 Oakland
 提供租屋援助、住房援助、租客／房東諮詢、房屋尋找、房屋共享以及抵押和購買房屋諮詢服務。
 
   </InfoCard>
-  </InfoCardGrid>
-  
+  <InfoCard title="住宅資源中心 (Housing Resource Centers, HRC)" externalHref="https://drive.google.com/file/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/view?usp=sharing">
+
+Alameda 縣內都設有住宅資源中心 (Housing Resource Centers, HRCs)，為目前無家可歸的人提供支援。
+
+如果您人在 Alameda 縣內，且目前無家可歸，您可以撥打伊甸資訊與轉介 (Eden Information & Referral) 的電話 [510-537-2552](tel:+1-510-537-2552) 與 HRC 聯絡，或是搜尋[您附近的服務據點]((https://drive.google.com/file/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/view?usp=sharing)，直接與 HRC 聯絡
+
+  </InfoCard>
+  <InfoCard title="押金和租金協助" externalHref="https://achousingchoices.org/deposit-rental-assistance-housing-search-assistance-resources/">
+
+搜尋租金和押金協助資源。
+
+  </InfoCard>
+</InfoCardGrid>
+
   <br />
 
-  <InfoCardGrid title="阿拉米達縣房屋及社區發展部 (HCD) 住房計劃">
+  <InfoCardGrid title="Alameda 縣房屋及社區發展部 (Housing & Community Development, HCD) 住宅計畫">
   <InfoCard title="阿拉米達縣房屋及社區發展部 (HCD)" externalHref="https://www.acgov.org/cda/hcd/rhd/index.htm">
     
   有關阿拉米達縣房屋及社區發展部 (HCD) 政策和計劃的資訊。 
@@ -609,12 +619,13 @@ Albany、Berkeley、Emeryville 及 Oakland
 
   <br />
 
-  <InfoCardGrid title="城市及地區相關服務">
-
+<section className="info-cards">
+  <header className="info-cards__header">
+    <h2 className="info-cards__title">城市及地區相關服務</h2>
+    <p className="info-cards__subtitle">隨著詳細資訊的變化，您可以<a href = "https://docs.google.com/document/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/edit?usp=sharing&ouid=104857760863458372387&rtpof=true&sd=true">查看有關免預約辦公室辦公時間的最新資訊</a>.</p>
+  </header>
 ### Oakland
-
-  </InfoCardGrid>
-
+</section>
   <section className="info-cards"><div className="info-cards__grid">
   <InfoCard title="灣區社區服務–奧克蘭市中心 (Bay Area Community Services - Downtown Oakland)" externalHref="http://www.bayareacs.org/">
 
@@ -623,11 +634,11 @@ Albany、Berkeley、Emeryville 及 Oakland
 致電 BACS 協調入口專線 [510-658-9480](tel:+1-510-658-9480)
 
 直接前往 629 Oakland Ave.  
- 辦公室服務時間：週一、週二及週三下午 1-4 點
+辦公室服務時間：週一、週二及週三下午 1-4 點
 
   </InfoCard>
 
-  <InfoCard title="柏克萊住房管理局 – 西奧克蘭 (Berkeley Housing Authority - West Oakland)" externalHref="http://www.self-sufficiency.org/">
+  <InfoCard title="BOSS 協調進入 - West Oakland" externalHref="http://www.self-sufficiency.org/">
 
 無居所的成年人
 
@@ -635,6 +646,15 @@ Albany、Berkeley、Emeryville 及 Oakland
 
 直接前往 2811 Adeline St.  
  辦公室服務時間：週一、週二、週四及週五上午 10 點至下午 2 點
+
+  </InfoCard>
+   <InfoCard title="EOCP 協調進入 - East Oakland">
+
+無居所的成年人
+
+撥打 [510-463-4601](tel:+1-510-463-4601) 聯絡 EOCP 協調進入
+
+或在以下辦公時間，親洽 7515 International Blvd.星期四和星期五上午 10 點至下午 3 點
 
   </InfoCard>
 
@@ -704,14 +724,20 @@ Emeryville
 
   <section className="info-cards"><div className="info-cards__grid">
 
-  <InfoCard title="Building Futures - West (San Leandro 及 Alameda)" externalHref="https://bfwc.org">
+  <InfoCard title="Building Futures - West (San Leandro)" externalHref="https://bfwc.org">
 
 無居所的成年人／家庭
 
 致電 [510-357-0205](tel:+1-510-357-0205)
 
   </InfoCard>
+  <InfoCard title="Building Futures - West (Alameda)" externalHref="https://bfwc.org/">
 
+無居所的成年人／家庭
+
+撥打 [510-201-0203](tel:+1-510-201-0203)
+
+  </InfoCard>
   <InfoCard title="灣區社區服務 - 東部 (Hayward 及 Unincorporated)" externalHref="http://www.bayareacs.org/">
 
 無居所的成年人／家庭

--- a/sites/public/page_content/AdditionalResources.md
+++ b/sites/public/page_content/AdditionalResources.md
@@ -1,37 +1,39 @@
 <RenderIf language="default">
 
-  <InfoCardGrid title="Immediate Housing Assistance">
+  <InfoCardGrid title="Immediate Housing Assistance" subtitle="If you're fleeing domestic violence, sexual assault or human trafficking and in immediate danger, call 911.">
   <InfoCard title="211 Alameda County Resource Finder" externalHref="https://achousingchoices.org/">
+If you are in need of immediate emergency shelter and housing assistance, please contact Eden Information & Referral at [211](tel:+1-510-537-2552) or the Bay Area Helpline at [1-800-273-6222](tel:+1-800-273-6222).
 
-  If you are in need of immediate emergency shelter and housing assistance, please contact Eden Information & Referral at [510-537-2552](tel:+1-510-537-2552) or the Bay Area Helpline at [1-800-273-6222](tel:+1-800-273-6222), or visit https://achousingchoices.org/.
+You can also visit the [companion website](https://achousingchoices.org/) for housing-related services and general services.
 
   </InfoCard>
 
-  <InfoCard title="Bay Area Community Services" externalHref="https://www.bayareacs.org/">
+  <InfoCard title="Independent Living" externalHref="https://ilacalifornia.org/alameda-county/directory/">
 
-  BACS Housing Resource Center, contact number: [510-613-0330](tel:+1-510-613-0330).
-
-  Albany, Berkeley, Emeryville, and Oakland
+Search for privately-owned or operated homes or complexes that provide shared housing for adults with disabilities, including mental illness, and others who may benefit from a shared living environment.
 
   </InfoCard>
 
   <InfoCard title="ECHO Housing" externalHref="https://www.echofairhousing.org/">
 
-  Provides rental assistance, housing assistance, tenant/landlord counseling, home-seeking, home-sharing, and mortgage and home purchase counseling.
+Provides rental assistance, housing assistance, tenant/landlord counseling, home-seeking, home-sharing, and mortgage and home purchase counseling.
 
   </InfoCard>
 
-  <InfoCard title="Alameda County Housing Resource Centers (HRC)">
+  <InfoCard title="Housing Resource Centers (HRC)" externalHref="https://drive.google.com/file/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/view?usp=sharing">
 
-  If you are fleeing domestic violence, sexual assault or human trafficking and in immediate danger, call 911.
+Alameda County has Housing Resource Centers (HRCs) throughout the County to support people currently experiencing homelessness.
 
-  For services, shelter and housing information call 211 or the hotline at [1-800-799-7233](tel:+1-800-799-7233) or 1-800-787-3224 (TTY).
-  </InfoCard>
-  </InfoCardGrid>
+If you are experiencing homelessness in Alameda County you may connect with an HRC by calling Eden Information & Referral at [510-537-2552](tel:+1-510-537-2552) or you may connect with an HRC directly by [finding an access point near you](https://drive.google.com/file/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/view?usp=sharing).
+</InfoCard>
+<InfoCard title="Deposit and Rental Assistance" externalHref="https://achousingchoices.org/deposit-rental-assistance-housing-search-assistance-resources/">
+Find resources for rental and deposit assistance.
+</InfoCard>
+</InfoCardGrid>
 
   <br />
 
-  <InfoCardGrid title="Housing & Community Development (HCD) Housing Programs">
+  <InfoCardGrid title="Alameda County Housing & Community Development (HCD) Housing Programs">
   <InfoCard title="Housing & Community Development (HCD) Department" externalHref="https://www.acgov.org/cda/hcd/rhd/index.htm">
     
   Information on the Alameda County Housing & Community Development (HCD) Department’s policies and programs. 
@@ -40,31 +42,31 @@
 
   <InfoCard title="AC Boost - Down Payment Loan Assistance Program" externalHref="https://www.acboost.org/">
 
-  Provides down payment assistance loans to eligible, middle-income, first-time homebuyers.
+Provides down payment assistance loans to eligible, middle-income, first-time homebuyers.
 
   </InfoCard>
 
   <InfoCard title="AC Housing Secure - Anti-Displacement Program" externalHref="https://www.centrolegal.org/achousingsecure/">
 
-  Provides free legal services and emergency financial assistance to tenants and homeowners.
+Provides free legal services and emergency financial assistance to tenants and homeowners.
 
   </InfoCard>
 
   <InfoCard title="AC Housing Secure - Emergency Rental Assistance Program" externalHref="https://www.ac-housingsecure.org/?fbclid=IwAR0186ykll8tKe-brqbLkMHiguYJQc0buUF1o6SjhXg_EKebR9fYSJs5hus">
 
-  If you’re an Alameda County renter who has fallen behind on rent or utilities payments due to the COVID-19 pandemic, you may qualify for assistance. Income-eligible households pay up to 15 months of rent and utilities, both for past due and future payments.
+If you’re an Alameda County renter who has fallen behind on rent or utilities payments due to the COVID-19 pandemic, you may qualify for assistance. Income-eligible households pay up to 15 months of rent and utilities, both for past due and future payments.
 
   </InfoCard>
 
   <InfoCard title="AC Housing Secure - Homeowner Services" externalHref="https://www.ac-housingsecure.org/otherresources">
 
-  Resources for homeowners at risk of foreclosure.
+Resources for homeowners at risk of foreclosure.
 
   </InfoCard>
 
   <InfoCard title="Renew AC - Housing Preservation Loan Program" externalHref="https://www.renewac.org/">
 
-  Provides affordable, low-interest deferred payment loans to assist residents with making home improvements that are necessary to stay, grow, and thrive in their homes.
+Provides affordable, low-interest deferred payment loans to assist residents with making home improvements that are necessary to stay, grow, and thrive in their homes.
 
   </InfoCard>
   </InfoCardGrid>
@@ -90,162 +92,179 @@
 
   <br />
 
-  <InfoCardGrid title="City and Region-Related Services">
-
-  ### Oakland
-
-  </InfoCardGrid>
+<section className="info-cards">
+  <header className="info-cards__header">
+    <h2 className="info-cards__title">City and Region-Related Services</h2>
+    <p className="info-cards__subtitle">As details change, you can <a href="https://docs.google.com/document/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/edit?usp=sharing&ouid=104857760863458372387&rtpof=true&sd=true">view the most up to date information on drop-in office hours</a>.</p>
+  </header>
+### Oakland
+</section>
 
   <section className="info-cards"><div className="info-cards__grid">
   <InfoCard title="Bay Area Community Services - Downtown Oakland" externalHref="http://www.bayareacs.org/">
 
-  Unsheltered adults
+Unsheltered adults
 
-  Call BACS Coordinated Entry line at [510-658-9480](tel:+1-510-658-9480)
+Call BACS Coordinated Entry line at [510-658-9480](tel:+1-510-658-9480)
 
-  Walk in at 629 Oakland Ave.  
-  Office hours: 1-4pm, Monday, Tuesday, and Wednesday
-
-  </InfoCard>
-
-  <InfoCard title="Berkeley Housing Authority - West Oakland" externalHref="http://www.self-sufficiency.org/">
-
-  Unsheltered adults
-
-  Call BOSS Coordinated Entry line at [510-844-8221](tel:+1-510-844-8221)
-
-  Walk in at 2811 Adeline St.  
-  Offce hours: 10am-2pm, Monday, Tuesday, Thurday, and Friday
+Walk in at 629 Oakland Ave.  
+ Office hours: 1-4pm, Monday, Tuesday, and Wednesday
 
   </InfoCard>
+
+  <InfoCard title="BOSS Coordinated Entry - West Oakland" externalHref="http://www.self-sufficiency.org/">
+
+Unsheltered adults
+
+Call BOSS Coordinated Entry line at [510-844-8221](tel:+1-510-844-8221)
+
+Walk in at 2811 Adeline St.  
+ Offce hours: 10am-2pm, Monday, Tuesday, Thurday, and Friday
+
+  </InfoCard>
+  <InfoCard title="EOCP Coordinated Entry - East Oakland">
+
+Unsheltered Adults
+
+Call EOCP Coordinated Entry at [510-463-4601](tel:+1-510-463-4601)
+
+Walk in at 7515 International Blvd. Office hours: 10am-3pm, Thursday and Friday
+
+</InfoCard>
 
   <InfoCard title="Family Front Door">
 
-  Unsheltered families (with a child under 18) 
+Unsheltered families (with a child under 18)
 
-  Call [510-808-7410](tel:+1-510-808-7410) ext. 282 
+Call [510-808-7410](tel:+1-510-808-7410) ext. 282
 
-  If you are already receiving services and need to update your information, text your full name and your updated/new information to [510-435-2772](sms:+1-510-435-2772).
+If you are already receiving services and need to update your information, text your full name and your updated/new information to [510-435-2772](sms:+1-510-435-2772).
 
   </InfoCard>
 
   <InfoCard title="Keep Oakland Housed Program" externalHref="https://www.keepoaklandhoused.org">
 
-  Any families or individuals who are still sheltered but face a crisis such as a 3 day pay or quit notice, an eviction notice.
+Any families or individuals who are still sheltered but face a crisis such as a 3 day pay or quit notice, an eviction notice.
 
-  Call [510-613-0330](tel:+1-510-613-0330) ext. 2
+Call [510-613-0330](tel:+1-510-613-0330) ext. 2
 
   </InfoCard>
 
   </div></section>
 
-  ### North County (Berkeley, Albany, Emeryville) 
+### North County (Berkeley, Albany, Emeryville)
 
   <section className="info-cards"><div className="info-cards__grid">
 
   <InfoCard title="Bay Area Community Services" externalHref="http://www.bayareacs.org/">
 
-  Unsheltered adults
+Unsheltered adults
 
-  Call [510-495-0131](tel:+1-510-495-0131)  
-  Email [housinghub@bayareacs.org](mailto:housinghub@bayareacs.org)
+Call [510-495-0131](tel:+1-510-495-0131)  
+ Email [housinghub@bayareacs.org](mailto:housinghub@bayareacs.org)
 
-  Walk in at 2809 Telegraph Ave.  
-  Office hours: 9am-12pm, Monday, Wednesday, and Friday
+Walk in at 2809 Telegraph Ave.  
+ Office hours: 9am-12pm, Monday, Wednesday, and Friday
 
   </InfoCard>
 
   <InfoCard title="Family Front Door">
 
-  Unsheltered families (with a child under 18) 
+Unsheltered families (with a child under 18)
 
-  Call [510-808-7410](tel:+1-510-808-7410) ext. 282 
+Call [510-808-7410](tel:+1-510-808-7410) ext. 282
 
-  If you are already receiving services and need to update your information, text your full name and your updated/new information to [510-435-2772](sms:+1-510-435-2772).
+If you are already receiving services and need to update your information, text your full name and your updated/new information to [510-435-2772](sms:+1-510-435-2772).
 
-  Emeryville
+Emeryville
 
   </InfoCard>
 
   <InfoCard title="Women’s Daytime Drop-in Center" externalHref="https://www.womensdropin.org/">
 
-  Unsheltered families
+Unsheltered families
 
-  Call [510-548-2884](tel:+1-510-548-2884)  
-  Email [help@womensdropin.org](mailto:help@womensdropin.org)
+Call [510-548-2884](tel:+1-510-548-2884)  
+ Email [help@womensdropin.org](mailto:help@womensdropin.org)
 
-  Walk in at 2218 Acton St.  
-  Office hours: 8am-4pm, Monday-Friday 
+Walk in at 2218 Acton St.  
+ Office hours: 8am-4pm, Monday-Friday
 
   </InfoCard>
 
   </div></section>
 
-  ### Mid-County
+### Mid-County
 
   <section className="info-cards"><div className="info-cards__grid">
 
-  <InfoCard title="Building Futures - West (San Leandro and Alameda)" externalHref="https://bfwc.org">
+  <InfoCard title="Building Futures - West (San Leandro)" externalHref="https://bfwc.org">
 
-  Unsheltered adults/families
+Unsheltered adults/families
 
-  Call [510-357-0205](tel:+1-510-357-0205)
+Call [510-357-0205](tel:+1-510-357-0205)
 
   </InfoCard>
+  <InfoCard title="Building Futures - West (Alameda)" externalHref="https://bfwc.org/">
 
+Unsheltered adults/families
+
+Call [510-201-0203](tel:+1-510-201-0203)
+
+  </InfoCard>
   <InfoCard title="Bay Area Community Services - East (Hayward and Unincorporated)" externalHref="http://www.bayareacs.org/">
 
-  Unsheltered adults/families
+Unsheltered adults/families
 
-  Call [510-247-8235](tel:510-247-8235)  
-  Email [HaywardHRC@bayareacs.org](mailto:HaywardHRC@bayareacs.org)
+Call [510-247-8235](tel:+1-510-247-8235)  
+ Email [HaywardHRC@bayareacs.org](mailto:HaywardHRC@bayareacs.org)
 
-  Walk in at 590 B Street, Hayward  
-  Office hours: 1-4pm, Tuesday and Thursday
-
-  </InfoCard>
-
-  </div></section>
-
-  ### East County/Tri-Valley (Livermore, Dublin, Pleasanton)
-
-  <section className="info-cards"><div className="info-cards__grid">
-
-  <InfoCard title="Abode Services" externalHref="https://www.abodeservices.org/">
-
-  Unsheltered adults/families
-
-  Call [510-371-0447](tel:+1-510-371-0447)
-
-  Walk in at 3311 Pacific Ave.  
-  Drop-in hours: 8am-12pm, Wednesday and Thursday
-
-  Livermore
+Walk in at 590 B Street, Hayward  
+ Office hours: 1-4pm, Tuesday and Thursday
 
   </InfoCard>
 
   </div></section>
 
-  ### South County/Tri-City (Fremont, Newark, Union City)
+### East County/Tri-Valley (Livermore, Dublin, Pleasanton)
 
   <section className="info-cards"><div className="info-cards__grid">
 
   <InfoCard title="Abode Services" externalHref="https://www.abodeservices.org/">
 
-  Unsheltered adults
+Unsheltered adults/families
 
-  Call [510-330-5822](tel:+1-510-330-5822)
+Call [510-371-0447](tel:+1-510-371-0447)
 
-  Walk in at 4075 Papazian Way, Fremont  
-  Drop-in hours: 9am-1pm, Monday and Tuesday
+Walk in at 3311 Pacific Ave.  
+ Drop-in hours: 8am-12pm, Wednesday and Thursday
+
+Livermore
+
+  </InfoCard>
+
+  </div></section>
+
+### South County/Tri-City (Fremont, Newark, Union City)
+
+  <section className="info-cards"><div className="info-cards__grid">
+
+  <InfoCard title="Abode Services" externalHref="https://www.abodeservices.org/">
+
+Unsheltered adults
+
+Call [510-330-5822](tel:+1-510-330-5822)
+
+Walk in at 4075 Papazian Way, Fremont  
+ Drop-in hours: 9am-1pm, Monday and Tuesday
 
   </InfoCard>
 
   <InfoCard title="Fremont Family Resource Center" externalHref="https://www.fremont.gov/228/Family-Resource-Center">
 
-  Unsheltered families
+Unsheltered families
 
-  Call [510-574-2000](tel:+1-510-574-2000)
+Call [510-574-2000](tel:+1-510-574-2000)
 
   </InfoCard>
 
@@ -255,31 +274,42 @@
 
 <RenderIf language="es">
 
-  <InfoCardGrid title="Immediate Housing Assistance">
-  <InfoCard title="211 Buscador de recursos del Condado de Alameda" externalHref="https://achousingchoices.org/">
+<InfoCardGrid title="Immediate Housing Assistance" subtitle="Si está huyendo de violencia doméstica, agresión sexual o trata de personas y está en peligro inmediato, llame al 911.
+">
+<InfoCard title="211 Buscador de recursos del Condado de Alameda" externalHref="https://achousingchoices.org/">
 
-  Si necesita asistencia inmediata de emergencia para obtener un refugio o vivienda, sírvase poner en contacto con Eden Information & Referral llamando al [510-537-2552](tel:+1-510-537-2552) o con la Bay Area Helpline llamando al [1-800-273-6222](tel:+1-800-273-6222) o visitando https://achousingchoices.org/.
+Si necesita un refugio de emergencia y ayuda para encontrar vivienda de inmediato, comuníquese con Información y Derivaciones de Eden al [211](tel:+1-510-537-2552) o la línea de ayuda del Área de la Bahía al [1-800-273-6222](tel:+1-800-273-6222).
+
+También puede visitar el [sitio web que lo acompaña](https://achousingchoices.org/) para obtener servicios relacionados con la vivienda y servicios generales.
 
   </InfoCard>
 
-  <InfoCard title="Bay Area Community Services" externalHref="https://www.bayareacs.org/">
+  <InfoCard title="Vida independiente" externalHref="https://ilacalifornia.org/alameda-county/directory/">
 
-  Número de contacto del Centro de Recursos de Vivienda de BACS: [510-613-0330](tel:+1-510-613-0330).
-
-  Albany, Berkeley, Emeryville y Oakland
+Busque hogares o complejos de propiedad o administración privada que ofrezcan vivienda para adultos con discapacidades, incluidas enfermedades mentales, y otras personas que se pueden beneficiar con un entorno de vida compartida.
 
   </InfoCard>
 
   <InfoCard title="ECHO Housing" externalHref="https://www.echofairhousing.org/">
 
-  Proporciona ayuda en el alquiler, asistencia de vivienda, asesoría a inquilinos y caseros, búsqueda de vivienda, vivienda compartida y asesoría sobre hipotecas y compra de viviendas.
+Proporciona ayuda en el alquiler, asistencia de vivienda, asesoría a inquilinos y caseros, búsqueda de vivienda, vivienda compartida y asesoría sobre hipotecas y compra de viviendas.
 
+  </InfoCard>
+  <InfoCard title="Centros de Recursos de Vivienda (Housing Resource Centers, HRC)" externalHref="https://drive.google.com/file/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/view">
+El condado de Alameda tiene Centros de Recursos de Vivienda (HRC) en el condado para ayudar a personas que actualmente estén en situación de calle.
+
+Si está en situación de calle en el condado de Alameda, puede comunicarse con un HRC llamando a Información y Derivaciones de Eden al [510-537-2552](tel:+1-510-537-2552) o puede comunicarse con un HRC [buscando directamente un punto de acceso cerca de usted](https://drive.google.com/file/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/view?usp=sharing).
+
+  </InfoCard>
+
+  <InfoCard title="Ayuda para depósitos y alquileres" externalHref="https://achousingchoices.org/deposit-rental-assistance-housing-search-assistance-resources/">
+  Encuentre recursos para ayuda con alquileres y depósitos.
   </InfoCard>
   </InfoCardGrid>
   
   <br />
 
-  <InfoCardGrid title="Programas de Vivienda y de Desarrollo Comunitario y de Vivienda (HCD) del Condado de Alameda">
+  <InfoCardGrid title="Programas de vivienda de Desarrollo Comunitario y de Vivienda (Housing & Community Development, HCD) del Condado de Alameda.">
   <InfoCard title="Departamento de Desarrollo Comunitario y de Vivienda (HCD) del Condado de Alameda" externalHref="https://www.acgov.org/cda/hcd/rhd/index.htm">
     
   Información sobre las políticas y programas del Departamento de Desarrollo Comunitario y de Vivienda (HCD) del Condado de Alameda. 
@@ -288,19 +318,19 @@
 
   <InfoCard title="AC Boost - Programa de asistencia de préstamos para pagos iniciales del Condado de Alameda" externalHref="https://www.acboost.org/">
 
-  Proporciona préstamos de asistencia para pagos iniciales a compradores de casas de ingresos medianos que compren su primera casa y reúnan los requisitos.
+Proporciona préstamos de asistencia para pagos iniciales a compradores de casas de ingresos medianos que compren su primera casa y reúnan los requisitos.
 
   </InfoCard>
 
   <InfoCard title="AC Housing Secure - Programa antidesplazamiento del Condado de Alameda" externalHref="https://www.centrolegal.org/achousingsecure/">
 
-  Proporciona servicios legales gratuitos y asistencia financiera de emergencia a inquilinos y propietarios de viviendas.
+Proporciona servicios legales gratuitos y asistencia financiera de emergencia a inquilinos y propietarios de viviendas.
 
   </InfoCard>
 
   <InfoCard title="Renew AC - Programa de préstamos para la preservación de la vivienda del Condado de Alameda" externalHref="https://www.renewac.org/">
 
-  Proporciona préstamos accesibles de intereses bajos y pagos diferidos para ayudar a los residentes a realizar mejoras en sus hogares que sean necesarias para permanecer, crecer y progresar en sus hogares.
+Proporciona préstamos accesibles de intereses bajos y pagos diferidos para ayudar a los residentes a realizar mejoras en sus hogares que sean necesarias para permanecer, crecer y progresar en sus hogares.
 
   </InfoCard>
   </InfoCardGrid>
@@ -326,162 +356,179 @@
 
   <br />
 
-  <InfoCardGrid title="SERVICIOS RELACIONADOS CON LA CIUDAD Y LA REGIÓN">
-
-  ### Oakland
-
-  </InfoCardGrid>
+  <section className="info-cards">
+  <header className="info-cards__header">
+    <h2 className="info-cards__title">SERVICIOS RELACIONADOS CON LA CIUDAD Y LA REGIÓN</h2>
+    <p className="info-cards__subtitle">Como los datos cambian, puede <a href="https://docs.google.com/document/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/edit">ver la información actualizada en el horario de atención sin turno</a>.</p>
+  </header>
+### Oakland
+</section>
 
   <section className="info-cards"><div className="info-cards__grid">
   <InfoCard title="Servicios de la comunidad del área de la bahía (Bay Area Community Services, BACS), centro de Oakland" externalHref="http://www.bayareacs.org/">
 
-  Adultos sin hogar y sin acceso a refugios
+Adultos sin hogar y sin acceso a refugios
 
-  Llame a la línea de ingreso coordinado de BACS al [510-658-9480](tel:+1-510-658-9480)
+Llame a la línea de ingreso coordinado de BACS al [510-658-9480](tel:+1-510-658-9480)
 
-  Atención sin turno en 629 Oakland Ave.  
-  Horarios de atención: De 1 a 4 p. m. los lunes, martes y miércoles
-
-  </InfoCard>
-
-  <InfoCard title="Organismo de la Vivienda de Berkeley (Berkeley Housing Authority), oeste de Oakland" externalHref="http://www.self-sufficiency.org/">
-
-  Adultos sin hogar y sin acceso a refugios
-
-  Llame a la línea de ingreso coordinado de BOSS al [510-844-8221](tel:+1-510-844-8221)
-
-  Atención sin turno en 2811 Adeline St.  
-  Horarios de atención: De 10 a. m. a 2 p. m. los lunes, martes, jueves y viernes
+Atención sin turno en 629 Oakland Ave.  
+ Horarios de atención: De 1 a 4 p. m. los lunes, martes y miércoles
 
   </InfoCard>
 
+  <InfoCard title="Ingreso coordinado de Construir Oportunidades para la Autosuficiencia (Building Opportunities for Self-Sufficiency, BOSS) de West Oakland" externalHref="http://www.self-sufficiency.org/">
+
+Adultos sin hogar y sin acceso a refugios
+
+Llame a la línea de ingreso coordinado de BOSS al [510-844-8221](tel:+1-510-844-8221)
+
+Atención sin turno en 2811 Adeline St.  
+ Horarios de atención: De 10 a. m. a 2 p. m. los lunes, martes, jueves y viernes
+
+  </InfoCard>
+   <InfoCard title="Ingreso coordinado del Proyecto Comunitario de East Oakland (East Oakland Community Project, EOCP) de East Oakland">
+
+Adultos en situación de calle
+
+Llame al ingreso coordinado del EOCP al [510-463-4601](tel:+1-510463-4601)
+
+Preséntese sin turno en 7515 International Blvd. Horario de atención: de 10 a. m. a 3 p. m., jueves y viernes
+
+</InfoCard>
   <InfoCard title="Family Front Door">
 
-  Familias sin hogar y sin acceso a refugios (con hijos menores de 18 años) 
+Familias sin hogar y sin acceso a refugios (con hijos menores de 18 años)
 
-  Llame al [510-808-7410](tel:+1-510-808-7410) ext. 282 
+Llame al [510-808-7410](tel:+1-510-808-7410) ext. 282
 
-  Si ya recibe servicios y necesita actualizar su información, envíe su nombre completo y su información actualizada o nueva por mensaje de texto al [510-435-2772](sms:+1-510-435-2772).
+Si ya recibe servicios y necesita actualizar su información, envíe su nombre completo y su información actualizada o nueva por mensaje de texto al [510-435-2772](sms:+1-510-435-2772).
 
   </InfoCard>
 
   <InfoCard title="Programa Keep Oakland Housed" externalHref="https://www.keepoaklandhoused.org">
 
-  Todas las familias y personas que todavía tengan hogar, pero enfrenten una crisis como pago en 3 días o deshaucio, o un aviso de desalojo.
+Todas las familias y personas que todavía tengan hogar, pero enfrenten una crisis como pago en 3 días o deshaucio, o un aviso de desalojo.
 
-  Llame al [510-613-0330](tel:+1-510-613-0330) ext. 2
+Llame al [510-613-0330](tel:+1-510-613-0330) ext. 2
 
   </InfoCard>
 
   </div></section>
 
-  ### Condado del norte (Berkeley, Albany, Emeryville)
+### Condado del norte (Berkeley, Albany, Emeryville)
 
   <section className="info-cards"><div className="info-cards__grid">
 
   <InfoCard title="Servicios comunitarios del área de la bahía (Bay Area Community Services)" externalHref="http://www.bayareacs.org/">
 
-  Adultos sin hogar y sin acceso a refugios
+Adultos sin hogar y sin acceso a refugios
 
-  Llame al [510-495-0131](tel:+1-510-495-0131)  
-  Correo electrónico: [housinghub@bayareacs.org](mailto:housinghub@bayareacs.org)
+Llame al [510-495-0131](tel:+1-510-495-0131)  
+ Correo electrónico: [housinghub@bayareacs.org](mailto:housinghub@bayareacs.org)
 
-  Atención sin turno en 2809 Telegraph Ave.  
-  Horarios de atención: De 9 a. m. a 12 p. m. los lunes, miércoles y viernes
+Atención sin turno en 2809 Telegraph Ave.  
+ Horarios de atención: De 9 a. m. a 12 p. m. los lunes, miércoles y viernes
 
   </InfoCard>
 
   <InfoCard title="Family Front Door">
 
-  Familias sin hogar y sin acceso a refugios (con un hijo menor de 18 años) 
+Familias sin hogar y sin acceso a refugios (con un hijo menor de 18 años)
 
-  Llame al [510-808-7410](tel:+1-510-808-7410) ext. 282 
+Llame al [510-808-7410](tel:+1-510-808-7410) ext. 282
 
-  Si ya recibe servicios y necesita actualizar su información, envíe su nombre completo y su información actualizada o nueva por mensaje de texto al [510-435-2772](sms:+1-510-435-2772).
+Si ya recibe servicios y necesita actualizar su información, envíe su nombre completo y su información actualizada o nueva por mensaje de texto al [510-435-2772](sms:+1-510-435-2772).
 
-  Emeryville
+Emeryville
 
   </InfoCard>
 
   <InfoCard title="Centro de Asistencia Diurno para Mujeres (Women’s Daytime Drop-in Center)" externalHref="https://www.womensdropin.org/">
 
-  Familias sin hogar y sin acceso a refugios
+Familias sin hogar y sin acceso a refugios
 
-  Llame al [510-548-2884](tel:+1-510-548-2884)  
-  Correo electrónico: [help@womensdropin.org](mailto:help@womensdropin.org)
+Llame al [510-548-2884](tel:+1-510-548-2884)  
+ Correo electrónico: [help@womensdropin.org](mailto:help@womensdropin.org)
 
-  Atención sin turno en 2218 Acton St.  
-  Horarios de atención: De 8 a. m. a 4 p. m. de lunes a viernes 
+Atención sin turno en 2218 Acton St.  
+ Horarios de atención: De 8 a. m. a 4 p. m. de lunes a viernes
 
   </InfoCard>
 
   </div></section>
 
-  ### Condado medio
+### Condado medio
 
   <section className="info-cards"><div className="info-cards__grid">
 
-  <InfoCard title="Building Futures, oeste (San Leandro y Alameda)" externalHref="https://bfwc.org">
+  <InfoCard title="Building Futures, oeste (San Leandro)" externalHref="https://bfwc.org">
 
-  Adultos y familias sin hogar y sin acceso a refugios
+Adultos y familias sin hogar y sin acceso a refugios
 
-  Llame al [510-357-0205](tel:+1-510-357-0205)
+Llame al [510-357-0205](tel:+1-510-357-0205)
+
+  </InfoCard>
+  <InfoCard title="Building Futures. Oeste (Alameda)" externalHref="https://bfwc.org/">
+
+Adultos y familias en situación de calle
+
+Call [510-201-0203](tel:+1-510-201-0203)
 
   </InfoCard>
 
   <InfoCard title="Servicios comunitarios del área de la bahía (Bay Area Community Services), este (Hayward y no incorporados)" externalHref="http://www.bayareacs.org/">
 
-  Familias y adultos sin hogar y sin acceso a refugios
+Familias y adultos sin hogar y sin acceso a refugios
 
-  Llame al [510-247-8235](tel:510-247-8235)  
-  Correo electrónico [HaywardHRC@bayareacs.org](mailto:HaywardHRC@bayareacs.org)
+Llame al [510-247-8235](tel:510-247-8235)  
+ Correo electrónico [HaywardHRC@bayareacs.org](mailto:HaywardHRC@bayareacs.org)
 
-  Atención sin turno en 590 B Street, Hayward  
-  Horarios de atención: De 1 a 4 p. m. los martes y jueves
-
-  </InfoCard>
-
-  </div></section>
-
-  ### Condado del este/Tri-Valley (Livermore, Dublin, Pleasanton)
-
-  <section className="info-cards"><div className="info-cards__grid">
-
-  <InfoCard title="Abode Services" externalHref="https://www.abodeservices.org/">
-
-  Adultos y familias sin hogar y sin acceso a refugios
-
-  Llame al [510-371-0447](tel:+1-510-371-0447)
-
-  Atención sin turno en 3311 Pacific Ave.  
-  Horarios de atención sin turno: De 8 a. m. a 12 p. m. los miércoles y jueves
-
-  Livermore
+Atención sin turno en 590 B Street, Hayward  
+ Horarios de atención: De 1 a 4 p. m. los martes y jueves
 
   </InfoCard>
 
   </div></section>
 
-  ### Condado del sur/Tri-City (Fremont, Newark, Union City)
+### Condado del este/Tri-Valley (Livermore, Dublin, Pleasanton)
 
   <section className="info-cards"><div className="info-cards__grid">
 
   <InfoCard title="Abode Services" externalHref="https://www.abodeservices.org/">
 
-  Adultos sin hogar y sin acceso a refugios
+Adultos y familias sin hogar y sin acceso a refugios
 
-  Llame al [510-330-5822](tel:+1-510-330-5822)
+Llame al [510-371-0447](tel:+1-510-371-0447)
 
-  Atención sin turno en 4075 Papazian Way, Fremont  
-  Horarios de atención sin turno: De 9 a. m. a 1 p. m. los lunes y martes
+Atención sin turno en 3311 Pacific Ave.  
+ Horarios de atención sin turno: De 8 a. m. a 12 p. m. los miércoles y jueves
+
+Livermore
+
+  </InfoCard>
+
+  </div></section>
+
+### Condado del sur/Tri-City (Fremont, Newark, Union City)
+
+  <section className="info-cards"><div className="info-cards__grid">
+
+  <InfoCard title="Abode Services" externalHref="https://www.abodeservices.org/">
+
+Adultos sin hogar y sin acceso a refugios
+
+Llame al [510-330-5822](tel:+1-510-330-5822)
+
+Atención sin turno en 4075 Papazian Way, Fremont  
+ Horarios de atención sin turno: De 9 a. m. a 1 p. m. los lunes y martes
 
   </InfoCard>
 
   <InfoCard title="Centro de Recursos para Familias de Fremont (Fremont Family Resource Center)" externalHref="https://www.fremont.gov/228/Family-Resource-Center">
 
-  Familias sin hogar y sin acceso a refugios
+Familias sin hogar y sin acceso a refugios
 
-  Llame al [510-574-2000](tel:+1-510-574-2000)
+Llame al [510-574-2000](tel:+1-510-574-2000)
 
   </InfoCard>
 
@@ -494,21 +541,21 @@
   <InfoCardGrid title="Immediate Housing Assistance">
   <InfoCard title="211 阿拉米達縣資源搜尋工具" externalHref="https://achousingchoices.org/">
 
-  如果您需要立即入住緊急收容所和尋求住房協助，請致電 [510-537-2552](tel:+1-510-537-2552) 與 Eden Information & Referral（伊甸資訊和轉介中心）聯絡，或致電 1-800-273-6222 與 Bay Area Helpline（灣區求助熱線）聯絡；或可瀏覽 https://achousingchoices.org/ 。
+如果您需要立即入住緊急收容所和尋求住房協助，請致電 [510-537-2552](tel:+1-510-537-2552) 與 Eden Information & Referral（伊甸資訊和轉介中心）聯絡，或致電 1-800-273-6222 與 Bay Area Helpline（灣區求助熱線）聯絡；或可瀏覽 https://achousingchoices.org/ 。
 
   </InfoCard>
 
   <InfoCard title="Bay Area Community Services" externalHref="https://www.bayareacs.org/">
 
-  BACS 住房資源中心，聯絡電話：[510-613-0330](tel:+1-510-613-0330)。
+BACS 住房資源中心，聯絡電話：[510-613-0330](tel:+1-510-613-0330)。
 
-  Albany、Berkeley、Emeryville 及 Oakland
+Albany、Berkeley、Emeryville 及 Oakland
 
   </InfoCard>
 
   <InfoCard title="ECHO Housing" externalHref="https://www.echofairhousing.org/">
 
-  提供租屋援助、住房援助、租客／房東諮詢、房屋尋找、房屋共享以及抵押和購買房屋諮詢服務。
+提供租屋援助、住房援助、租客／房東諮詢、房屋尋找、房屋共享以及抵押和購買房屋諮詢服務。
 
   </InfoCard>
   </InfoCardGrid>
@@ -524,19 +571,19 @@
 
   <InfoCard title="AC Boost - 阿拉米達縣首期貸款援助計劃" externalHref="https://www.acboost.org/">
 
-  為符合資格、首次置業的中等收入人士提供首期貸款援助。
+為符合資格、首次置業的中等收入人士提供首期貸款援助。
 
   </InfoCard>
 
   <InfoCard title="AC Housing Secure - 阿拉米達縣反被迫遷離計劃" externalHref="https://www.centrolegal.org/achousingsecure/">
 
-  為租戶和業主提供免費法律服務和緊急財務援助。
+為租戶和業主提供免費法律服務和緊急財務援助。
 
   </InfoCard>
 
   <InfoCard title="Renew AC - 阿拉米達縣房屋維護貸款計劃" externalHref="https://www.renewac.org/">
 
-  提供人們負擔得起，並可延期還款的低息貸款，幫助居民為家居進行必要的修繕，讓他們繼續留在家中生活、成長和發展。
+提供人們負擔得起，並可延期還款的低息貸款，幫助居民為家居進行必要的修繕，讓他們繼續留在家中生活、成長和發展。
 
   </InfoCard>
   </InfoCardGrid>
@@ -564,160 +611,160 @@
 
   <InfoCardGrid title="城市及地區相關服務">
 
-  ### Oakland
+### Oakland
 
   </InfoCardGrid>
 
   <section className="info-cards"><div className="info-cards__grid">
   <InfoCard title="灣區社區服務–奧克蘭市中心 (Bay Area Community Services - Downtown Oakland)" externalHref="http://www.bayareacs.org/">
 
-  無居所的成年人
+無居所的成年人
 
-  致電 BACS 協調入口專線 [510-658-9480](tel:+1-510-658-9480)
+致電 BACS 協調入口專線 [510-658-9480](tel:+1-510-658-9480)
 
-  直接前往 629 Oakland Ave.  
-  辦公室服務時間：週一、週二及週三下午 1-4 點
+直接前往 629 Oakland Ave.  
+ 辦公室服務時間：週一、週二及週三下午 1-4 點
 
   </InfoCard>
 
   <InfoCard title="柏克萊住房管理局 – 西奧克蘭 (Berkeley Housing Authority - West Oakland)" externalHref="http://www.self-sufficiency.org/">
 
-  無居所的成年人
+無居所的成年人
 
-  致電 BOSS 協調入口專線 [510-844-8221](tel:+1-510-844-8221)
+致電 BOSS 協調入口專線 [510-844-8221](tel:+1-510-844-8221)
 
-  直接前往 2811 Adeline St.  
-  辦公室服務時間：週一、週二、週四及週五上午 10 點至下午 2 點
+直接前往 2811 Adeline St.  
+ 辦公室服務時間：週一、週二、週四及週五上午 10 點至下午 2 點
 
   </InfoCard>
 
   <InfoCard title="家庭前門">
 
-  無居所家庭（有 18 歲以下孩童） 
+無居所家庭（有 18 歲以下孩童）
 
-  致電 [510-808-7410](tel:+1-510-808-7410) 分機 282 
+致電 [510-808-7410](tel:+1-510-808-7410) 分機 282
 
-  如果您已接受服務並需要更新您的資訊，請將全名及更新後／新資訊傳送至 [510-435-2772](sms:+1-510-435-2772)。
+如果您已接受服務並需要更新您的資訊，請將全名及更新後／新資訊傳送至 [510-435-2772](sms:+1-510-435-2772)。
 
   </InfoCard>
 
   <InfoCard title="保留奧克蘭住屋計劃(Keep Oakland Housed Program)" externalHref="https://www.keepoaklandhoused.org">
 
-  仍居住在庇護所但面臨危機，例如 3 天工資或辭職通知、驅逐通知的家庭或個人。
+仍居住在庇護所但面臨危機，例如 3 天工資或辭職通知、驅逐通知的家庭或個人。
 
-  致電 [510-613-0330](tel:+1-510-613-0330) 分機 2
+致電 [510-613-0330](tel:+1-510-613-0330) 分機 2
 
   </InfoCard>
 
   </div></section>
 
-  ### North County (Berkeley, Albany, Emeryville) 
+### North County (Berkeley, Albany, Emeryville)
 
   <section className="info-cards"><div className="info-cards__grid">
 
   <InfoCard title="灣區社區服務" externalHref="http://www.bayareacs.org/">
 
-  無居所的成年人
+無居所的成年人
 
-  致電 [510-495-0131](tel:+1-510-495-0131)  
-  電子郵件 [housinghub@bayareacs.org](mailto:housinghub@bayareacs.org)
+致電 [510-495-0131](tel:+1-510-495-0131)  
+ 電子郵件 [housinghub@bayareacs.org](mailto:housinghub@bayareacs.org)
 
-  直接前往 2809 Telegraph Ave.  
-  辦公室服務時間：週一、週三及週五上午 9 點至中午 12 點
+直接前往 2809 Telegraph Ave.  
+ 辦公室服務時間：週一、週三及週五上午 9 點至中午 12 點
 
   </InfoCard>
 
   <InfoCard title="家庭前門">
 
-  無居所家庭（有 18 歲以下孩童） 
+無居所家庭（有 18 歲以下孩童）
 
-  致電 [510-808-7410](tel:+1-510-808-7410) 分機 282 
+致電 [510-808-7410](tel:+1-510-808-7410) 分機 282
 
-  如果您已接受服務並需要更新您的資訊，請將全名及更新後／新資訊傳送至 [510-435-2772](sms:+1-510-435-2772)。
+如果您已接受服務並需要更新您的資訊，請將全名及更新後／新資訊傳送至 [510-435-2772](sms:+1-510-435-2772)。
 
-  Emeryville
+Emeryville
 
   </InfoCard>
 
   <InfoCard title="婦女日間服務中心 (Women’s Daytime Drop-in Center)" externalHref="https://www.womensdropin.org/">
 
-  無居所家庭
+無居所家庭
 
-  致電 [510-548-2884](tel:+1-510-548-2884)  
-  電子郵件 [help@womensdropin.org](mailto:help@womensdropin.org)
+致電 [510-548-2884](tel:+1-510-548-2884)  
+ 電子郵件 [help@womensdropin.org](mailto:help@womensdropin.org)
 
-  直接前往 2218 Acton St.。  
-  辦公室服務時間：週一至週五上午 8 點至下午 4 點
+直接前往 2218 Acton St.。  
+ 辦公室服務時間：週一至週五上午 8 點至下午 4 點
 
   </InfoCard>
 
   </div></section>
 
-  ### 中郡
+### 中郡
 
   <section className="info-cards"><div className="info-cards__grid">
 
   <InfoCard title="Building Futures - West (San Leandro 及 Alameda)" externalHref="https://bfwc.org">
 
-  無居所的成年人／家庭
+無居所的成年人／家庭
 
-  致電 [510-357-0205](tel:+1-510-357-0205)
+致電 [510-357-0205](tel:+1-510-357-0205)
 
   </InfoCard>
 
   <InfoCard title="灣區社區服務 - 東部 (Hayward 及 Unincorporated)" externalHref="http://www.bayareacs.org/">
 
-  無居所的成年人／家庭
+無居所的成年人／家庭
 
-  致電 [510-247-8235](tel:510-247-8235)  
-  電子郵件 [HaywardHRC@bayareacs.org](mailto:HaywardHRC@bayareacs.org)
+致電 [510-247-8235](tel:510-247-8235)  
+ 電子郵件 [HaywardHRC@bayareacs.org](mailto:HaywardHRC@bayareacs.org)
 
-  直接前往 590 B Street, Hayward  
-  辦公室服務時間：週二及週四下午 1-4 點
-
-  </InfoCard>
-
-  </div></section>
-
-  ### East County/Tri-Valley (Livermore, Dublin, Pleasanton)
-
-  <section className="info-cards"><div className="info-cards__grid">
-
-  <InfoCard title="住所服務" externalHref="https://www.abodeservices.org/">
-
-  無居所的成年人／家庭
-
-  致電 [510-371-0447](tel:+1-510-371-0447)
-
-  直接前往 3311 Pacific Ave.  
-  服務時間：週三及週四上午 8 點至中午 12 點
-
-  Livermore
+直接前往 590 B Street, Hayward  
+ 辦公室服務時間：週二及週四下午 1-4 點
 
   </InfoCard>
 
   </div></section>
 
-  ### South County/Tri-City (Fremont, Newark, Union City)
+### East County/Tri-Valley (Livermore, Dublin, Pleasanton)
 
   <section className="info-cards"><div className="info-cards__grid">
 
   <InfoCard title="住所服務" externalHref="https://www.abodeservices.org/">
 
-  無居所的成年人
+無居所的成年人／家庭
 
-  致電 [510-330-5822](tel:+1-510-330-5822)
+致電 [510-371-0447](tel:+1-510-371-0447)
 
-  直接前往 4075 Papazian Way, Fremont  
-  服務時間：週一及週二上午 9 點至下午 1 點
+直接前往 3311 Pacific Ave.  
+ 服務時間：週三及週四上午 8 點至中午 12 點
+
+Livermore
+
+  </InfoCard>
+
+  </div></section>
+
+### South County/Tri-City (Fremont, Newark, Union City)
+
+  <section className="info-cards"><div className="info-cards__grid">
+
+  <InfoCard title="住所服務" externalHref="https://www.abodeservices.org/">
+
+無居所的成年人
+
+致電 [510-330-5822](tel:+1-510-330-5822)
+
+直接前往 4075 Papazian Way, Fremont  
+ 服務時間：週一及週二上午 9 點至下午 1 點
 
   </InfoCard>
 
   <InfoCard title="費利蒙家庭資源中心 (Fremont Family Resource Center)" externalHref="https://www.fremont.gov/228/Family-Resource-Center">
 
-  無居所家庭
+無居所家庭
 
-  致電 [510-574-2000](tel:+1-510-574-2000)
+致電 [510-574-2000](tel:+1-510-574-2000)
 
   </InfoCard>
 
@@ -730,21 +777,21 @@
   <InfoCardGrid title="Immediate Housing Assistance">
   <InfoCard title="211 Công cụ Tìm kiếm Nguồn Trợ giúp Quận Alameda" externalHref="https://achousingchoices.org/">
 
-  Nếu quý vị cần nơi trú ẩn khẩn cấp và hỗ trợ về nhà ở ngay lập tức, vui lòng liên lạc ban Thông tin & Giới thiệu Eden theo số [510-537-2552](tel:+1-510-537-2552) hoặc Đường dây Trợ giúp Bay Area theo số [1-800-273-6222](tel:+1-800-273-6222), hoặc truy cập https://achousingchoices.org/.
+Nếu quý vị cần nơi trú ẩn khẩn cấp và hỗ trợ về nhà ở ngay lập tức, vui lòng liên lạc ban Thông tin & Giới thiệu Eden theo số [510-537-2552](tel:+1-510-537-2552) hoặc Đường dây Trợ giúp Bay Area theo số [1-800-273-6222](tel:+1-800-273-6222), hoặc truy cập https://achousingchoices.org/.
 
   </InfoCard>
 
   <InfoCard title="Bay Area Community Services" externalHref="https://www.bayareacs.org/">
 
-  Trung tâm Nguồn Thông Tin Trợ giúp Gia cư BACS, số điện thoại liên lạc: [510-613-0330](tel:+1-510-613-0330).
+Trung tâm Nguồn Thông Tin Trợ giúp Gia cư BACS, số điện thoại liên lạc: [510-613-0330](tel:+1-510-613-0330).
 
-  Albany, Berkeley, Emeryville, và Oakland
+Albany, Berkeley, Emeryville, và Oakland
 
   </InfoCard>
 
   <InfoCard title="ECHO Housing" externalHref="https://www.echofairhousing.org/">
 
-  Cung cấp hỗ trợ tiền thuê nhà, hỗ trợ nhà ở, cố vấn cho người thuê nhà/chủ nhà, tìm kiếm nhà, chia sẻ nhà, và cố vấn về tiền mua nhà trả góp và mua nhà.
+Cung cấp hỗ trợ tiền thuê nhà, hỗ trợ nhà ở, cố vấn cho người thuê nhà/chủ nhà, tìm kiếm nhà, chia sẻ nhà, và cố vấn về tiền mua nhà trả góp và mua nhà.
 
   </InfoCard>
   </InfoCardGrid>
@@ -760,19 +807,19 @@
 
   <InfoCard title="AC Boost - Chương trình Hỗ trợ Vay Tiền Trả trước của Quận Alameda" externalHref="https://www.acboost.org/">
 
-  Cung cấp hỗ trợ cho vay tiền trả trước để mua nhà cho những người lần đầu tiên mua nhà hội đủ điều kiện, có thu nhập trung bình.
+Cung cấp hỗ trợ cho vay tiền trả trước để mua nhà cho những người lần đầu tiên mua nhà hội đủ điều kiện, có thu nhập trung bình.
 
   </InfoCard>
 
   <InfoCard title="AC Housing Secure - Chương trình Ngăn Chuyển chỗ ở Bắt buộc của Quận Alameda" externalHref="https://www.centrolegal.org/achousingsecure/">
 
-  Cung cấp dịch vụ pháp lý miễn phí và hỗ trợ tài chính khẩn cấp cho người thuê nhà và chủ nhà.
+Cung cấp dịch vụ pháp lý miễn phí và hỗ trợ tài chính khẩn cấp cho người thuê nhà và chủ nhà.
 
   </InfoCard>
 
   <InfoCard title="Renew AC - Chương trình Cho vay để Giữ Nhà ở của Quận Alameda" externalHref="https://www.renewac.org/">
 
-  Cung cấp các khoản vay trả chậm lãi suất thấp để hỗ trợ các cư dân nâng cấp nhà cần thiết để ở, phát triển, và thịnh vượng trong nhà mình.
+Cung cấp các khoản vay trả chậm lãi suất thấp để hỗ trợ các cư dân nâng cấp nhà cần thiết để ở, phát triển, và thịnh vượng trong nhà mình.
 
   </InfoCard>
   </InfoCardGrid>
@@ -800,160 +847,160 @@
 
   <InfoCardGrid title="CÁC DỊCH VỤ LIÊN QUAN ĐẾN THÀNH PHỐ VÀ VÙNG MIỀN">
 
-  ### Oakland
+### Oakland
 
   </InfoCardGrid>
 
   <section className="info-cards"><div className="info-cards__grid">
   <InfoCard title="Cơ Quan Dịch Vụ Cộng Đồng Vùng Vịnh (BACS) - Trung Tâm Thành Phố Oakland" externalHref="http://www.bayareacs.org/">
 
-  Người trưởng thành không nơi trú ẩn
+Người trưởng thành không nơi trú ẩn
 
-  Gọi tới đường dây Tiếp Nhận Được Điều Phối của BACS theo số [510-658-9480](tel:+1-510-658-9480)
+Gọi tới đường dây Tiếp Nhận Được Điều Phối của BACS theo số [510-658-9480](tel:+1-510-658-9480)
 
-  Đến tận nơi không cần hẹn trước tại 629 Oakland Ave.  
-  Giờ làm việc: 1-4 giờ chiều, Thứ Hai, Thứ Ba và Thứ Tư
+Đến tận nơi không cần hẹn trước tại 629 Oakland Ave.  
+ Giờ làm việc: 1-4 giờ chiều, Thứ Hai, Thứ Ba và Thứ Tư
 
   </InfoCard>
 
   <InfoCard title="Cơ Quan Gia Cư Berkeley - Tây Oakland" externalHref="http://www.self-sufficiency.org/">
 
-  Người trưởng thành không nơi trú ẩn
+Người trưởng thành không nơi trú ẩn
 
-  Gọi tới đường dây Tiếp Nhận Được Điều Phối của BOSS theo số [510-844-8221](tel:+1-510-844-8221)
+Gọi tới đường dây Tiếp Nhận Được Điều Phối của BOSS theo số [510-844-8221](tel:+1-510-844-8221)
 
-  Đến tận nơi không cần hẹn trước tại 2811 Adeline St.  
-  Giờ làm việc: 10 giờ sáng-2 giờ chiều, Thứ Hai, Thứ Ba, Thứ Năm và Thứ Sáu
+Đến tận nơi không cần hẹn trước tại 2811 Adeline St.  
+ Giờ làm việc: 10 giờ sáng-2 giờ chiều, Thứ Hai, Thứ Ba, Thứ Năm và Thứ Sáu
 
   </InfoCard>
 
   <InfoCard title="Chương trình Family Front Door">
 
-  Những gia đình không có nơi trú ẩn (có con dưới 18 tuổi) 
+Những gia đình không có nơi trú ẩn (có con dưới 18 tuổi)
 
-  Gọi [510-808-7410](tel:+1-510-808-7410), số máy lẻ 282 
+Gọi [510-808-7410](tel:+1-510-808-7410), số máy lẻ 282
 
-  Nếu quý vị đã nhận được dịch vụ và cần cập nhật thông tin của mình, vui lòng nhắn đầy đủ họ tên và thông tin mới/đã cập nhật của quý vị tới số   [510-435-2772](sms:+1-510-435-2772).
+Nếu quý vị đã nhận được dịch vụ và cần cập nhật thông tin của mình, vui lòng nhắn đầy đủ họ tên và thông tin mới/đã cập nhật của quý vị tới số [510-435-2772](sms:+1-510-435-2772).
 
   </InfoCard>
 
   <InfoCard title="Chương Trình Keep Oakland Housed" externalHref="https://www.keepoaklandhoused.org">
 
-  Những gia đình và cá nhân có nơi trú ẩn nhưng đang gặp khủng hoảng, ví dụ như thông báo phải trả tiền thuê trong vòng 3 ngày nếu không phải ra khỏi nơi trú ẩn, thông báo trục xuất.
+Những gia đình và cá nhân có nơi trú ẩn nhưng đang gặp khủng hoảng, ví dụ như thông báo phải trả tiền thuê trong vòng 3 ngày nếu không phải ra khỏi nơi trú ẩn, thông báo trục xuất.
 
-  Gọi [510-613-0330](tel:+1-510-613-0330), số máy lẻ 2
+Gọi [510-613-0330](tel:+1-510-613-0330), số máy lẻ 2
 
   </InfoCard>
 
   </div></section>
 
-  ### Quận North (Berkeley, Albany, Emeryville) 
+### Quận North (Berkeley, Albany, Emeryville)
 
   <section className="info-cards"><div className="info-cards__grid">
 
   <InfoCard title="Cơ Quan Dịch Vụ Cộng Đồng Vùng Vịnh" externalHref="http://www.bayareacs.org/">
 
-  Người trưởng thành không nơi trú ẩn
+Người trưởng thành không nơi trú ẩn
 
-  Gọi số [510-495-0131](tel:+1-510-495-0131)  
-  Email [housinghub@bayareacs.org](mailto:housinghub@bayareacs.org)
+Gọi số [510-495-0131](tel:+1-510-495-0131)  
+ Email [housinghub@bayareacs.org](mailto:housinghub@bayareacs.org)
 
-  Đến tận nơi không cần hẹn trước tại 2809 Telegraph Ave.  
-  Giờ làm việc: 9 giờ sáng-12 giờ trưa, Thứ Hai, Thứ Yư và Thứ Sáu
+Đến tận nơi không cần hẹn trước tại 2809 Telegraph Ave.  
+ Giờ làm việc: 9 giờ sáng-12 giờ trưa, Thứ Hai, Thứ Yư và Thứ Sáu
 
   </InfoCard>
 
   <InfoCard title="Chương trình Family Front Door">
 
-  Những gia đình không có nơi trú ẩn (có con dưới 18 tuổi) 
+Những gia đình không có nơi trú ẩn (có con dưới 18 tuổi)
 
-  Gọi [510-808-7410](tel:+1-510-808-7410), số máy lẻ 282 
+Gọi [510-808-7410](tel:+1-510-808-7410), số máy lẻ 282
 
-  Nếu quý vị đã nhận được dịch vụ và cần cập nhật thông tin của mình, vui lòng nhắn đầy đủ họ tên và thông tin mới/đã cập nhật của quý vị tới số [510-435-2772](sms:+1-510-435-2772).
+Nếu quý vị đã nhận được dịch vụ và cần cập nhật thông tin của mình, vui lòng nhắn đầy đủ họ tên và thông tin mới/đã cập nhật của quý vị tới số [510-435-2772](sms:+1-510-435-2772).
 
-  Emeryville
+Emeryville
 
   </InfoCard>
 
   <InfoCard title="Trung Tâm Women’s Daytime Drop-in" externalHref="https://www.womensdropin.org/">
 
-  Những gia đình không có nơi trú ẩn
+Những gia đình không có nơi trú ẩn
 
-  Gọi số [510-548-2884](tel:+1-510-548-2884)  
-  Email [help@womensdropin.org](mailto:help@womensdropin.org)
+Gọi số [510-548-2884](tel:+1-510-548-2884)  
+ Email [help@womensdropin.org](mailto:help@womensdropin.org)
 
-  Đến tận nơi không cần hẹn trước tại 2218 Acton St.  
-  Giờ làm việc: 8 giờ sáng-4 giờ chiều, Thứ Hai-Thứ Sáu
+Đến tận nơi không cần hẹn trước tại 2218 Acton St.  
+ Giờ làm việc: 8 giờ sáng-4 giờ chiều, Thứ Hai-Thứ Sáu
 
   </InfoCard>
 
   </div></section>
 
-  ### Mid-County
+### Mid-County
 
   <section className="info-cards"><div className="info-cards__grid">
 
   <InfoCard title="Tổ chức Building Futures - Phía tây (San Leandro và Alameda)" externalHref="https://bfwc.org">
 
-  Người trưởng thành/những gia đình không có nơi trú ẩn
+Người trưởng thành/những gia đình không có nơi trú ẩn
 
-  Gọi số [510-357-0205](tel:+1-510-357-0205)
+Gọi số [510-357-0205](tel:+1-510-357-0205)
 
   </InfoCard>
 
   <InfoCard title="Cơ Quan Dịch Vụ Cộng Đồng Vùng Vịnh - Phía đông (Hayward và Unincorporated)" externalHref="http://www.bayareacs.org/">
 
-  Người trưởng thành/những gia đình không có nơi trú ẩn
+Người trưởng thành/những gia đình không có nơi trú ẩn
 
-  Gọi số [510-247-8235](tel:510-247-8235)  
-  Email [HaywardHRC@bayareacs.org](mailto:HaywardHRC@bayareacs.org)
+Gọi số [510-247-8235](tel:510-247-8235)  
+ Email [HaywardHRC@bayareacs.org](mailto:HaywardHRC@bayareacs.org)
 
-  Đến tận nơi không cần hẹn trước tại 590 B Street, Hayward  
-  Giờ làm việc: 1-4 giờ chiều, Thứ Ba và Thứ Năm
-
-  </InfoCard>
-
-  </div></section>
-
-  ### Quận East/Tri-Valley (Livermore, Dublin, Pleasanton)
-
-  <section className="info-cards"><div className="info-cards__grid">
-
-  <InfoCard title="Tổ chức Abode Services" externalHref="https://www.abodeservices.org/">
-
-  Người trưởng thành/những gia đình không có nơi trú ẩn
-
-  Gọi số [510-371-0447](tel:+1-510-371-0447)
-
-  Đến tận nơi không cần hẹn trước tại 3311 Pacific Ave.  
-  Giờ ghé qua: 8 giờ sáng-12 giờ trưa, Thứ Tư và Thứ Năm
-
-  Livermore
+Đến tận nơi không cần hẹn trước tại 590 B Street, Hayward  
+ Giờ làm việc: 1-4 giờ chiều, Thứ Ba và Thứ Năm
 
   </InfoCard>
 
   </div></section>
 
-  ### Quận South/Tri-City (Fremont, Newark, Union City)
+### Quận East/Tri-Valley (Livermore, Dublin, Pleasanton)
 
   <section className="info-cards"><div className="info-cards__grid">
 
   <InfoCard title="Tổ chức Abode Services" externalHref="https://www.abodeservices.org/">
 
-  Người trưởng thành không nơi trú ẩn
+Người trưởng thành/những gia đình không có nơi trú ẩn
 
-  Gọi số [510-330-5822](tel:+1-510-330-5822)
+Gọi số [510-371-0447](tel:+1-510-371-0447)
 
-  Đến tận nơi không cần hẹn trước tại 4075 Papazian Way, Fremont  
-  Giờ ghé qua: 9 giờ sáng-1 giờ chiều, Thứ Hai và Thứ Ba
+Đến tận nơi không cần hẹn trước tại 3311 Pacific Ave.  
+ Giờ ghé qua: 8 giờ sáng-12 giờ trưa, Thứ Tư và Thứ Năm
+
+Livermore
+
+  </InfoCard>
+
+  </div></section>
+
+### Quận South/Tri-City (Fremont, Newark, Union City)
+
+  <section className="info-cards"><div className="info-cards__grid">
+
+  <InfoCard title="Tổ chức Abode Services" externalHref="https://www.abodeservices.org/">
+
+Người trưởng thành không nơi trú ẩn
+
+Gọi số [510-330-5822](tel:+1-510-330-5822)
+
+Đến tận nơi không cần hẹn trước tại 4075 Papazian Way, Fremont  
+ Giờ ghé qua: 9 giờ sáng-1 giờ chiều, Thứ Hai và Thứ Ba
 
   </InfoCard>
 
   <InfoCard title="Trung Tâm Nguồn Hỗ Trợ Gia Đình Fremont" externalHref="https://www.fremont.gov/228/Family-Resource-Center">
 
-  Những gia đình không có nơi trú ẩn
+Những gia đình không có nơi trú ẩn
 
-  Gọi số [510-574-2000](tel:+1-510-574-2000)
+Gọi số [510-574-2000](tel:+1-510-574-2000)
 
   </InfoCard>
 

--- a/sites/public/page_content/AdditionalResources.md
+++ b/sites/public/page_content/AdditionalResources.md
@@ -800,18 +800,18 @@ Livermore
 
 <RenderIf language="vi">
 
-  <InfoCardGrid title="Immediate Housing Assistance">
+  <InfoCardGrid title="Hỗ trợ nhà ở ngay lập tức">
   <InfoCard title="211 Công cụ Tìm kiếm Nguồn Trợ giúp Quận Alameda" externalHref="https://achousingchoices.org/">
 
-Nếu quý vị cần nơi trú ẩn khẩn cấp và hỗ trợ về nhà ở ngay lập tức, vui lòng liên lạc ban Thông tin & Giới thiệu Eden theo số [510-537-2552](tel:+1-510-537-2552) hoặc Đường dây Trợ giúp Bay Area theo số [1-800-273-6222](tel:+1-800-273-6222), hoặc truy cập https://achousingchoices.org/.
+Nếu quý vị cần chỗ trú ẩn khẩn cấp tức thì và hỗ trợ về nhà ở, vui lòng liên hệ Trung tâm Thông tin và Giới thiệu Eden theo số [211](tel:+1-510-537-2552) hoặc Đường dây trợ giúp Vùng Vịnh theo số [1-800-273-6222](tel:+1-800-273-6222.
+
+Quý vị cũng có thể truy cập trang web hướng dẫn để biết các dịch vụ liên quan đến nhà ở và dịch vụ tổng hợp
 
   </InfoCard>
 
-  <InfoCard title="Bay Area Community Services" externalHref="https://www.bayareacs.org/">
+  <InfoCard title="Sống Độc lập" externalHref="https://ilacalifornia.org/alameda-county/directory/">
 
-Trung tâm Nguồn Thông Tin Trợ giúp Gia cư BACS, số điện thoại liên lạc: [510-613-0330](tel:+1-510-613-0330).
-
-Albany, Berkeley, Emeryville, và Oakland
+Tìm kiếm nhà ở hoặc chung cư do tư nhân sở hữu hoặc điều hành, cung cấp nhà ở chung cho người trưởng thành khuyết tật, bao gồm cả bệnh tâm thần, cùng những người khác có thể hưởng lợi từ môi trường sống chung.
 
   </InfoCard>
 
@@ -820,11 +820,25 @@ Albany, Berkeley, Emeryville, và Oakland
 Cung cấp hỗ trợ tiền thuê nhà, hỗ trợ nhà ở, cố vấn cho người thuê nhà/chủ nhà, tìm kiếm nhà, chia sẻ nhà, và cố vấn về tiền mua nhà trả góp và mua nhà.
 
   </InfoCard>
-  </InfoCardGrid>
-  
+    
+  <InfoCard title="Trung tâm Nguồn thông tin Nhà ở (HRC)" externalHref="https://drive.google.com/file/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/view?usp=sharing">
+
+Quận Alameda có các Trung tâm Nguồn thông tin Nhà ở (HRC) trên toàn Quận để hỗ trợ những người hiện đang trong tình trạng vô gia cư.
+
+Nếu đang trong tình trạng vô gia cư tại Quận Alameda, quý vị có thể liên hệ với HRC khi gọi cho Trung tâm Thông tin và Giới thiệu Eden theo số [510-537-2552](tel:+1-510-537-2552) hoặc quý vị có thể liên hệ trực tiếp với HRC [bằng cách tìm điểm truy cập gần quý vị](https://drive.google.com/file/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/view?usp=sharing).
+
+  </InfoCard>
+
+  <InfoCard title="Hỗ trợ Tiền đặt cọc và Tiền thuê nhà" externalHref="https://achousingchoices.org/deposit-rental-assistance-housing-search-assistance-resources/">
+
+Tìm các nguồn thông tin về hỗ trợ tiền thuê nhà và tiền đặt cọc.
+
+  </InfoCard>
+</InfoCardGrid>
+
   <br />
 
-  <InfoCardGrid title="Sở Gia cư và Phát triển Cộng đồng (HCD) Quận Alameda">
+  <InfoCardGrid title="Chương trình Nhà ở của Sở Gia cư và Phát triển Cộng đồng (HCD) Quận Alameda">
   <InfoCard title="Sở Gia cư & Phát triển Cộng đồng (HCD) Quận Alameda " externalHref="https://www.acgov.org/cda/hcd/rhd/index.htm">
     
   Thông tin về các chính sách và chương trình của Sở Gia cư và Phát triển Cộng đồng (HCD) Quận Alameda. 
@@ -871,11 +885,18 @@ Cung cấp các khoản vay trả chậm lãi suất thấp để hỗ trợ cá
 
   <br />
 
-  <InfoCardGrid title="CÁC DỊCH VỤ LIÊN QUAN ĐẾN THÀNH PHỐ VÀ VÙNG MIỀN">
+  <InfoCardGrid title="">
 
 ### Oakland
 
   </InfoCardGrid>
+<section className="info-cards">
+  <header className="info-cards__header">
+    <h2 className="info-cards__title">CÁC DỊCH VỤ LIÊN QUAN ĐẾN THÀNH PHỐ VÀ VÙNG MIỀN</h2>
+    <p className="info-cards__subtitle">Khi thông tin chi tiết thay đổi, quý vị có thể <a href="https://docs.google.com/document/d/1U6d4KIXAFMMF8E2H-VAi3gpLy71L3Tvm/edit?usp=sharing&ouid=104857760863458372387&rtpof=true&sd=true">xem thông tin mới nhất về giờ làm việc không cần hẹn trước</a>.</p>
+  </header>
+### Oakland
+</section>
 
   <section className="info-cards"><div className="info-cards__grid">
   <InfoCard title="Cơ Quan Dịch Vụ Cộng Đồng Vùng Vịnh (BACS) - Trung Tâm Thành Phố Oakland" externalHref="http://www.bayareacs.org/">
@@ -889,7 +910,7 @@ Gọi tới đường dây Tiếp Nhận Được Điều Phối của BACS theo
 
   </InfoCard>
 
-  <InfoCard title="Cơ Quan Gia Cư Berkeley - Tây Oakland" externalHref="http://www.self-sufficiency.org/">
+  <InfoCard title="Tiếp nhận Phối hợp BOSS - Tây Oakland" externalHref="http://www.self-sufficiency.org/">
 
 Người trưởng thành không nơi trú ẩn
 
@@ -897,6 +918,15 @@ Gọi tới đường dây Tiếp Nhận Được Điều Phối của BOSS theo
 
 Đến tận nơi không cần hẹn trước tại 2811 Adeline St.  
  Giờ làm việc: 10 giờ sáng-2 giờ chiều, Thứ Hai, Thứ Ba, Thứ Năm và Thứ Sáu
+
+  </InfoCard>
+  <InfoCard title="Tiếp nhận Phối hợp EOCP - Đông Oakland">
+
+Người trưởng thành Không có nơi trú ẩn
+
+Hãy gọi cho hệ thống Tiếp nhận Phối hợp EOCP theo số [510-844-8221](tel:+1-510-844-8221)
+
+Quý vị có thể đến 7515 International Blvd. mà không cần hẹn trước Giờ làm việc: 10 giờ sáng - 3 giờ chiều, thứ Năm và thứ Sáu
 
   </InfoCard>
 
@@ -966,14 +996,20 @@ Gọi số [510-548-2884](tel:+1-510-548-2884)
 
   <section className="info-cards"><div className="info-cards__grid">
 
-  <InfoCard title="Tổ chức Building Futures - Phía tây (San Leandro và Alameda)" externalHref="https://bfwc.org">
+  <InfoCard title="Tổ chức Building Futures - Phía tây (San Leandro)" externalHref="https://bfwc.org">
 
 Người trưởng thành/những gia đình không có nơi trú ẩn
 
 Gọi số [510-357-0205](tel:+1-510-357-0205)
 
   </InfoCard>
+  <InfoCard title="Building Futures - Tây (Alameda)" externalHref="https://bfwc.org/">
 
+Người trưởng thành/gia đình không có nơi trú ẩn
+
+Hãy gọi số [510-201-0203](tel:+1-510-201-0203)
+
+  </InfoCard>
   <InfoCard title="Cơ Quan Dịch Vụ Cộng Đồng Vùng Vịnh - Phía đông (Hayward và Unincorporated)" externalHref="http://www.bayareacs.org/">
 
 Người trưởng thành/những gia đình không có nơi trú ẩn

--- a/sites/public/page_content/AdditionalResourcesSidebar.md
+++ b/sites/public/page_content/AdditionalResourcesSidebar.md
@@ -1,47 +1,47 @@
 <RenderIf language="default">
 
-  #### Contact
+#### Contact
 
-  For listing and application questions, please contact the Property Agent displayed on the listing.
+For listing and application questions, please contact the Property Agent displayed on the listing.
 
-  **Alameda County's Housing & Development Department (HCD)**
+**Alameda County's Housing & Development Department (HCD)**
 
-  **[achousingportal@acgov.org](mailto:achousingportal@acgov.org)**
+**[achousingportal@acgov.org](mailto:achousingportal@acgov.org)**
 
 </RenderIf>
 
 <RenderIf language="es">
 
-  #### Contact
+#### Contacto
 
-  Si tiene alguna pregunta sobre los listados y la solicitud, sírvase poner en contacto con el Agente de la Propiedad que aparece indicado en el listado.
+Si tiene alguna pregunta sobre los listados y la solicitud, sírvase poner en contacto con el Agente de la Propiedad que aparece indicado en el listado.
 
-  **Departamento de Desarrollo Comunitario y de Vivienda (HCD) del Condado de Alameda**
+**Departamento de Desarrollo Comunitario y de Vivienda (HCD) del Condado de Alameda**
 
-  **[achousingportal@acgov.org](mailto:achousingportal@acgov.org)**
+**[achousingportal@acgov.org](mailto:achousingportal@acgov.org)**
 
 </RenderIf>
 
 <RenderIf language="zh">
 
-  #### Contact
+#### 接觸
 
-  若有上市名單和申請方面的疑問，請聯絡上市名單上顯示的物業經紀人。
+若有上市名單和申請方面的疑問，請聯絡上市名單上顯示的物業經紀人。
 
-  **阿拉米達縣房屋及社區發展部 (HCD)**
+**阿拉米達縣房屋及社區發展部 (HCD)**
 
-  **[achousingportal@acgov.org](mailto:achousingportal@acgov.org)**
+**[achousingportal@acgov.org](mailto:achousingportal@acgov.org)**
 
 </RenderIf>
 
 <RenderIf language="vi">
 
-  #### Contact
+#### Tiếp xúc
 
-  Đối với các thắc mắc về danh sách nhà và đơn ghi danh, vui lòng liên lạc với Nhân viên Đại diện Bất động sản có trên danh sách.
+Đối với các thắc mắc về danh sách nhà và đơn ghi danh, vui lòng liên lạc với Nhân viên Đại diện Bất động sản có trên danh sách.
 
-  **Sở Gia cư và Phát triển Cộng đồng (HCD) Quận Alameda**
+**Sở Gia cư và Phát triển Cộng đồng (HCD) Quận Alameda**
 
-  **[achousingportal@acgov.org](mailto:achousingportal@acgov.org)**
-  
+**[achousingportal@acgov.org](mailto:achousingportal@acgov.org)**
+
 </RenderIf>


### PR DESCRIPTION
This PR addresses the content updates and Spanish translations described in #403.

This can be tested by navigating to the additional resource page on the Alameda public site.

Assumptions Made/Questions:
1) In the figma, "211" was shown as linked in the description so I kept the same number linked under the "211 Alameda County Resource Finder."

2)With the addition of the new section, "Building Futures - West (Alameda)", I removed Alameda from the pre-existing Building Futures - West (San Leandro and Alameda). This was shown in the Figma but not anyway else so just wanted to verify it should be removed.

3)Is there a reason that the "Immediate Housing Assistance" and "Contact" isn't translated?
