### PR TITLE
feat: creating new ami charts & script

### DIFF
--- a/backend/core/scripts/ami-chart-import-script.sh
+++ b/backend/core/scripts/ami-chart-import-script.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  cat << EOF
+Usage: ami-chart-import-script path/to/FILE
+
+WARNING: overwrites the file path/to/FILE.ts
+
+This script takes a formatted text file and writes a .ts file containing the JSON representation
+of the AMI chart data. It is expecting 9 columns, the first one being the AMI percentage and then
+8 columns representing the income for a household with 1..8 people corresponding to that AMI. Ex:
+20% 10,000 11,000 12,000 13,000 14,000 15,000 16,000 17,000
+30% 15,000 16,000 17,000 18,000 19,000 20,000 21,000 22,000
+
+This format is based on the PDF format for published MSHDA charts. Output note: there must be a newline
+at the end of the file or the last row will not be read in.
+
+Once you have the generated ts file, you can create a migration that uses that ts file to create the new ami chart
+EOF
+  exit
+fi
+
+# Get the file name and the path separately.
+DIRECTORY=$(dirname "$1")
+FILE=$(basename "$1")
+FILENAME=${FILE%.*}
+OUTPUT_FILE="$DIRECTORY/$FILENAME.ts"
+
+
+echo "Generating $OUTPUT_FILE"
+
+cat << EOF > $OUTPUT_FILE
+import { AmiChartCreateDto } from "../../../ami-charts/dto/ami-chart.dto"
+import { BaseEntity } from "typeorm"
+
+// THIS FILE WAS AUTOMATICALLY GENERATED FROM $FILE.
+export const $FILENAME: Omit<AmiChartCreateDto, keyof BaseEntity | "jurisdiction"> = {
+  name: "$FILENAME",
+  items: [
+EOF
+
+# For each line, generate a set of JSON values
+sed -e "s/%//g" -e "s/,//g" $1 |
+  while read -ra INCOME; do
+    # AMI is the first column
+    AMI=${INCOME[0]}
+    for i in $(seq 8); do
+      # print this AMI table value to the OUTPUT
+      cat << EOF >> $OUTPUT_FILE
+    {
+      percentOfAmi: $AMI,
+      householdSize: $i,
+      income: ${INCOME[$i]},
+    },
+EOF
+    done
+  done
+
+# Finish the JSON
+cat << EOF >> $OUTPUT_FILE
+  ],
+}
+EOF

--- a/backend/core/src/migration/1654636407033-alameda-2022-amicharts.ts
+++ b/backend/core/src/migration/1654636407033-alameda-2022-amicharts.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+import { alamedaTCAC2022 } from "../seeder/seeds/ami-charts/alameda-tcac-2022"
+import { alamedaHUD2022 } from "../seeder/seeds/ami-charts/alameda-hud-2022"
+
+export class alameda2022Amicharts1654636407033 implements MigrationInterface {
+  name = "alameda2022Amicharts1654636407033"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const [{ id }] = await queryRunner.query(`SELECT id FROM jurisdictions WHERE name = 'Alameda'`)
+    await queryRunner.query(
+      `INSERT INTO ami_chart
+            (name, items, jurisdiction_id)
+            VALUES ('${alamedaTCAC2022.name}', '${JSON.stringify(alamedaTCAC2022.items)}', '${id}')
+          `
+    )
+
+    await queryRunner.query(
+      `INSERT INTO ami_chart
+            (name, items, jurisdiction_id)
+            VALUES ('${alamedaHUD2022.name}', '${JSON.stringify(alamedaHUD2022.items)}', '${id}')
+          `
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/backend/core/src/seeder/seeds/ami-charts/alameda-hud-2022.ts
+++ b/backend/core/src/seeder/seeds/ami-charts/alameda-hud-2022.ts
@@ -1,0 +1,129 @@
+import { AmiChartCreateDto } from "../../../ami-charts/dto/ami-chart.dto"
+import { BaseEntity } from "typeorm"
+
+// THIS FILE WAS AUTOMATICALLY GENERATED FROM a2.txt.
+export const alamedaHUD2022: Omit<AmiChartCreateDto, keyof BaseEntity | "jurisdiction"> = {
+  name: "Alameda County HUD 2022",
+  items: [
+    {
+      percentOfAmi: 30,
+      householdSize: 1,
+      income: 30000,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 2,
+      income: 34300,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 3,
+      income: 38600,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 4,
+      income: 42850,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 5,
+      income: 46300,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 6,
+      income: 49750,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 7,
+      income: 53150,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 8,
+      income: 56600,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 1,
+      income: 50000,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 2,
+      income: 57150,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 3,
+      income: 64300,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 4,
+      income: 71400,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 5,
+      income: 77150,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 6,
+      income: 82850,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 7,
+      income: 88550,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 8,
+      income: 94250,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 1,
+      income: 74200,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 2,
+      income: 84800,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 3,
+      income: 95400,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 4,
+      income: 106000,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 5,
+      income: 114500,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 6,
+      income: 123000,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 7,
+      income: 131450,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 8,
+      income: 139950,
+    },
+  ],
+}

--- a/backend/core/src/seeder/seeds/ami-charts/alameda-tcac-2022.ts
+++ b/backend/core/src/seeder/seeds/ami-charts/alameda-tcac-2022.ts
@@ -1,0 +1,449 @@
+import { AmiChartCreateDto } from "../../../ami-charts/dto/ami-chart.dto"
+import { BaseEntity } from "typeorm"
+
+// THIS FILE WAS AUTOMATICALLY GENERATED FROM a1.txt.
+export const alamedaTCAC2022: Omit<AmiChartCreateDto, keyof BaseEntity | "jurisdiction"> = {
+  name: "Alameda County TCAC 2022",
+  items: [
+    {
+      percentOfAmi: 20,
+      householdSize: 1,
+      income: 20000,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 2,
+      income: 22860,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 3,
+      income: 25720,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 4,
+      income: 28560,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 5,
+      income: 30860,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 6,
+      income: 33140,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 7,
+      income: 35420,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 8,
+      income: 37700,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 1,
+      income: 30000,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 2,
+      income: 34290,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 3,
+      income: 38580,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 4,
+      income: 42840,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 5,
+      income: 46290,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 6,
+      income: 49710,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 7,
+      income: 53130,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 8,
+      income: 56550,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 1,
+      income: 35000,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 2,
+      income: 40005,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 3,
+      income: 45010,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 4,
+      income: 49980,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 5,
+      income: 54005,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 6,
+      income: 57995,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 7,
+      income: 61985,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 8,
+      income: 65975,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 1,
+      income: 40000,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 2,
+      income: 45720,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 3,
+      income: 51440,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 4,
+      income: 57120,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 5,
+      income: 61720,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 6,
+      income: 66280,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 7,
+      income: 70840,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 8,
+      income: 75400,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 1,
+      income: 45000,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 2,
+      income: 51435,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 3,
+      income: 57870,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 4,
+      income: 64260,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 5,
+      income: 69435,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 6,
+      income: 74565,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 7,
+      income: 79695,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 8,
+      income: 84825,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 1,
+      income: 50000,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 2,
+      income: 57150,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 3,
+      income: 64300,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 4,
+      income: 71400,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 5,
+      income: 77150,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 6,
+      income: 82850,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 7,
+      income: 88550,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 8,
+      income: 94250,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 1,
+      income: 55000,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 2,
+      income: 62865,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 3,
+      income: 70730,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 4,
+      income: 78540,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 5,
+      income: 84865,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 6,
+      income: 91135,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 7,
+      income: 97405,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 8,
+      income: 103675,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 1,
+      income: 60000,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 2,
+      income: 68580,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 3,
+      income: 77160,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 4,
+      income: 85680,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 5,
+      income: 92580,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 6,
+      income: 99420,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 7,
+      income: 106260,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 8,
+      income: 113100,
+    },
+    {
+      percentOfAmi: 70,
+      householdSize: 1,
+      income: 70000,
+    },
+    {
+      percentOfAmi: 70,
+      householdSize: 2,
+      income: 80010,
+    },
+    {
+      percentOfAmi: 70,
+      householdSize: 3,
+      income: 90020,
+    },
+    {
+      percentOfAmi: 70,
+      householdSize: 4,
+      income: 99960,
+    },
+    {
+      percentOfAmi: 70,
+      householdSize: 5,
+      income: 108010,
+    },
+    {
+      percentOfAmi: 70,
+      householdSize: 6,
+      income: 115990,
+    },
+    {
+      percentOfAmi: 70,
+      householdSize: 7,
+      income: 123970,
+    },
+    {
+      percentOfAmi: 70,
+      householdSize: 8,
+      income: 131950,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 1,
+      income: 80000,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 2,
+      income: 91440,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 3,
+      income: 102880,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 4,
+      income: 114240,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 5,
+      income: 123440,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 6,
+      income: 132560,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 7,
+      income: 141680,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 8,
+      income: 150800,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 1,
+      income: 100000,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 2,
+      income: 114300,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 3,
+      income: 128600,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 4,
+      income: 142800,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 5,
+      income: 154200,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 6,
+      income: 165650,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 7,
+      income: 177050,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 8,
+      income: 188500,
+    },
+  ],
+}


### PR DESCRIPTION
This resolves: https://github.com/housingbayarea/bloom/issues/427

in order to test:
head to the partner site https://hba-partners-dev.netlify.app/
go to create/edit a listing
add a unit
notice that the new ami charts are present, and the values match up with the expected values from the spreadsheets in the ticketo

verify that the listing can save properly
verify the listing detail page displays the correct ami info 

head to the public site https://hba-public-dev.netlify.app/
verify the public preview displays the correct info as well