### PR TITLE
fix: updated email address

### DIFF
--- a/sites/public/layouts/application.tsx
+++ b/sites/public/layouts/application.tsx
@@ -142,7 +142,7 @@ const Layout = (props) => {
           <a href="https://www.surveymonkey.com/r/2QLBYML" target="_blank">
             {t("footer.giveFeedback")}
           </a>
-          <a href="mailto:housing@smchousing.org">{t("footer.contact")}</a>
+          <a href="mailto:doorway@smchousing.org">{t("footer.contact")}</a>
           <a href="https://smc.housingbayarea.org/disclaimer" target="_blank">
             {t("footer.disclaimer")}
           </a>


### PR DESCRIPTION
This PR addresses #454 by changing the email address linked to the contact button in the footer to [doorway@smchousing.org](mailto:doorway@smchousing.org), per our SMC stakeholders.

Steps to Review:
1. Go to SMC homepage
2. Click contact button and ensure it opens up with the correct address.