### PR TITLE
feat: adds new san jose ami charts

### DIFF
--- a/backend/core/src/migration/1661352526487-sanJoseAmi.ts
+++ b/backend/core/src/migration/1661352526487-sanJoseAmi.ts
@@ -1,0 +1,26 @@
+import {MigrationInterface, QueryRunner} from "typeorm"
+import { sanJoseHcdIncomeLimits2022 } from "../seeder/seeds/ami-charts/san-jose-hcd-income-limits-2022"
+import { sanJoseHudHome2022 } from "../seeder/seeds/ami-charts/san-jose-hud-home-2022"
+
+export class sanJoseAmi1661352526487 implements MigrationInterface {
+    name = "sanJoseAmi1661352526487"
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const [{ id }] = await queryRunner.query(`SELECT id FROM jurisdictions WHERE name = 'San Jose'`)
+
+        await queryRunner.query(
+        `INSERT INTO ami_chart
+                (name, items, jurisdiction_id)
+                VALUES ('${sanJoseHcdIncomeLimits2022.name}', '${JSON.stringify(sanJoseHcdIncomeLimits2022.items)}', '${id}')
+            `
+        )
+
+        await queryRunner.query(
+        `INSERT INTO ami_chart
+                (name, items, jurisdiction_id)
+                VALUES ('${sanJoseHudHome2022.name}', '${JSON.stringify(sanJoseHudHome2022.items)}', '${id}')
+                `
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/backend/core/src/migration/1661352526487-sanJoseAmi.ts
+++ b/backend/core/src/migration/1661352526487-sanJoseAmi.ts
@@ -1,26 +1,30 @@
-import {MigrationInterface, QueryRunner} from "typeorm"
+import { MigrationInterface, QueryRunner } from "typeorm"
 import { sanJoseHcdIncomeLimits2022 } from "../seeder/seeds/ami-charts/san-jose-hcd-income-limits-2022"
 import { sanJoseHudHome2022 } from "../seeder/seeds/ami-charts/san-jose-hud-home-2022"
 
 export class sanJoseAmi1661352526487 implements MigrationInterface {
-    name = "sanJoseAmi1661352526487"
-    public async up(queryRunner: QueryRunner): Promise<void> {
-        const [{ id }] = await queryRunner.query(`SELECT id FROM jurisdictions WHERE name = 'San Jose'`)
+  name = "sanJoseAmi1661352526487"
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const [{ id }] = await queryRunner.query(`SELECT id FROM jurisdictions WHERE name = 'San Jose'`)
 
-        await queryRunner.query(
-        `INSERT INTO ami_chart
+    await queryRunner.query(
+      `INSERT INTO ami_chart
                 (name, items, jurisdiction_id)
-                VALUES ('${sanJoseHcdIncomeLimits2022.name}', '${JSON.stringify(sanJoseHcdIncomeLimits2022.items)}', '${id}')
+                VALUES ('${sanJoseHcdIncomeLimits2022.name}', '${JSON.stringify(
+        sanJoseHcdIncomeLimits2022.items
+      )}', '${id}')
             `
-        )
+    )
 
-        await queryRunner.query(
-        `INSERT INTO ami_chart
+    await queryRunner.query(
+      `INSERT INTO ami_chart
                 (name, items, jurisdiction_id)
-                VALUES ('${sanJoseHudHome2022.name}', '${JSON.stringify(sanJoseHudHome2022.items)}', '${id}')
+                VALUES ('${sanJoseHudHome2022.name}', '${JSON.stringify(
+        sanJoseHudHome2022.items
+      )}', '${id}')
                 `
-        )
-    }
+    )
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {}
+  public async down(queryRunner: QueryRunner): Promise<void> {}
 }

--- a/backend/core/src/seeder/seeds/ami-charts/san-jose-hcd-income-limits-2022.ts
+++ b/backend/core/src/seeder/seeds/ami-charts/san-jose-hcd-income-limits-2022.ts
@@ -1,0 +1,572 @@
+import { AmiChartCreateDto } from "../../../ami-charts/dto/ami-chart.dto"
+import { BaseEntity } from "typeorm"
+
+// THIS FILE WAS AUTOMATICALLY GENERATED FROM san-jose-hcd-income-limits-2022.txt.
+export const sanJoseHcdIncomeLimits2022: Omit<
+  AmiChartCreateDto,
+  keyof BaseEntity | "jurisdiction"
+> = {
+  name: "San Jose HCD Income Limits 2022",
+  items: [
+    {
+      percentOfAmi: 15,
+      householdSize: 1,
+      income: 17685,
+    },
+    {
+      percentOfAmi: 15,
+      householdSize: 2,
+      income: 20220,
+    },
+    {
+      percentOfAmi: 15,
+      householdSize: 3,
+      income: 22755,
+    },
+    {
+      percentOfAmi: 15,
+      householdSize: 4,
+      income: 25275,
+    },
+    {
+      percentOfAmi: 15,
+      householdSize: 5,
+      income: 27300,
+    },
+    {
+      percentOfAmi: 15,
+      householdSize: 6,
+      income: 29325,
+    },
+    {
+      percentOfAmi: 15,
+      householdSize: 7,
+      income: 31355,
+    },
+    {
+      percentOfAmi: 15,
+      householdSize: 8,
+      income: 33360,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 1,
+      income: 23580,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 2,
+      income: 26960,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 3,
+      income: 30340,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 4,
+      income: 33700,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 5,
+      income: 36400,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 6,
+      income: 39100,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 7,
+      income: 41780,
+    },
+    {
+      percentOfAmi: 20,
+      householdSize: 8,
+      income: 44480,
+    },
+    {
+      percentOfAmi: 25,
+      householdSize: 1,
+      income: 29475,
+    },
+    {
+      percentOfAmi: 25,
+      householdSize: 2,
+      income: 33700,
+    },
+    {
+      percentOfAmi: 25,
+      householdSize: 3,
+      income: 37925,
+    },
+    {
+      percentOfAmi: 25,
+      householdSize: 4,
+      income: 41125,
+    },
+    {
+      percentOfAmi: 25,
+      householdSize: 5,
+      income: 45500,
+    },
+    {
+      percentOfAmi: 25,
+      householdSize: 6,
+      income: 48875,
+    },
+    {
+      percentOfAmi: 25,
+      householdSize: 7,
+      income: 52225,
+    },
+    {
+      percentOfAmi: 25,
+      householdSize: 8,
+      income: 55600,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 1,
+      income: 35370,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 2,
+      income: 40440,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 3,
+      income: 45510,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 4,
+      income: 50550,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 5,
+      income: 54600,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 6,
+      income: 58650,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 7,
+      income: 62670,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 8,
+      income: 66720,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 1,
+      income: 41265,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 2,
+      income: 47180,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 3,
+      income: 53095,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 4,
+      income: 58975,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 5,
+      income: 63700,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 6,
+      income: 68425,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 7,
+      income: 73115,
+    },
+    {
+      percentOfAmi: 35,
+      householdSize: 8,
+      income: 77840,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 1,
+      income: 47160,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 2,
+      income: 53920,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 3,
+      income: 60680,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 4,
+      income: 67400,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 5,
+      income: 72800,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 6,
+      income: 78200,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 7,
+      income: 83560,
+    },
+    {
+      percentOfAmi: 40,
+      householdSize: 8,
+      income: 88960,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 1,
+      income: 53055,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 2,
+      income: 60660,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 3,
+      income: 68265,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 4,
+      income: 75825,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 5,
+      income: 81900,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 6,
+      income: 87975,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 7,
+      income: 94005,
+    },
+    {
+      percentOfAmi: 45,
+      householdSize: 8,
+      income: 100080,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 1,
+      income: 58950,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 2,
+      income: 67400,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 3,
+      income: 75850,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 4,
+      income: 84250,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 5,
+      income: 9100,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 6,
+      income: 97750,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 7,
+      income: 104450,
+    },
+    {
+      percentOfAmi: 50,
+      householdSize: 8,
+      income: 111200,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 1,
+      income: 58950,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 2,
+      income: 67400,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 3,
+      income: 75850,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 4,
+      income: 84250,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 5,
+      income: 91000,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 6,
+      income: 97750,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 7,
+      income: 104450,
+    },
+    {
+      percentOfAmi: 55,
+      householdSize: 8,
+      income: 111200,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 1,
+      income: 70740,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 2,
+      income: 80880,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 3,
+      income: 91020,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 4,
+      income: 101100,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 5,
+      income: 109200,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 6,
+      income: 117300,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 7,
+      income: 125340,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 8,
+      income: 133440,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 1,
+      income: 94320,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 2,
+      income: 107840,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 3,
+      income: 121360,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 4,
+      income: 134800,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 5,
+      income: 145600,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 6,
+      income: 156400,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 7,
+      income: 167120,
+    },
+    {
+      percentOfAmi: 80,
+      householdSize: 8,
+      income: 177920,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 1,
+      income: 117900,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 2,
+      income: 134800,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 3,
+      income: 151700,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 4,
+      income: 168500,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 5,
+      income: 182000,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 6,
+      income: 195500,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 7,
+      income: 208900,
+    },
+    {
+      percentOfAmi: 100,
+      householdSize: 8,
+      income: 222400,
+    },
+    {
+      percentOfAmi: 110,
+      householdSize: 1,
+      income: 129690,
+    },
+    {
+      percentOfAmi: 110,
+      householdSize: 2,
+      income: 148280,
+    },
+    {
+      percentOfAmi: 110,
+      householdSize: 3,
+      income: 166870,
+    },
+    {
+      percentOfAmi: 110,
+      householdSize: 4,
+      income: 185350,
+    },
+    {
+      percentOfAmi: 110,
+      householdSize: 5,
+      income: 200200,
+    },
+    {
+      percentOfAmi: 110,
+      householdSize: 6,
+      income: 215050,
+    },
+    {
+      percentOfAmi: 110,
+      householdSize: 7,
+      income: 229790,
+    },
+    {
+      percentOfAmi: 110,
+      householdSize: 8,
+      income: 244640,
+    },
+    {
+      percentOfAmi: 120,
+      householdSize: 1,
+      income: 141480,
+    },
+    {
+      percentOfAmi: 120,
+      householdSize: 2,
+      income: 161760,
+    },
+    {
+      percentOfAmi: 120,
+      householdSize: 3,
+      income: 182040,
+    },
+    {
+      percentOfAmi: 120,
+      householdSize: 4,
+      income: 202200,
+    },
+    {
+      percentOfAmi: 120,
+      householdSize: 5,
+      income: 218400,
+    },
+    {
+      percentOfAmi: 120,
+      householdSize: 6,
+      income: 234600,
+    },
+    {
+      percentOfAmi: 120,
+      householdSize: 7,
+      income: 250680,
+    },
+    {
+      percentOfAmi: 120,
+      householdSize: 8,
+      income: 266880,
+    },
+  ],
+}

--- a/backend/core/src/seeder/seeds/ami-charts/san-jose-hud-home-2022.ts
+++ b/backend/core/src/seeder/seeds/ami-charts/san-jose-hud-home-2022.ts
@@ -1,0 +1,89 @@
+import { AmiChartCreateDto } from "../../../ami-charts/dto/ami-chart.dto"
+import { BaseEntity } from "typeorm"
+
+// THIS FILE WAS AUTOMATICALLY GENERATED FROM san-jose-hud-home-2022.txt.
+export const sanJoseHudHome2022: Omit<AmiChartCreateDto, keyof BaseEntity | "jurisdiction"> = {
+  name: "San Jose HUD/HOME 2022",
+  items: [
+    {
+      percentOfAmi: 30,
+      householdSize: 1,
+      income: 35400,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 2,
+      income: 40450,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 3,
+      income: 45500,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 4,
+      income: 50550,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 5,
+      income: 54600,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 6,
+      income: 58650,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 7,
+      income: 62700,
+    },
+    {
+      percentOfAmi: 30,
+      householdSize: 8,
+      income: 66750,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 1,
+      income: 70800,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 2,
+      income: 80880,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 3,
+      income: 91020,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 4,
+      income: 101100,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 5,
+      income: 109200,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 6,
+      income: 117300,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 7,
+      income: 125400,
+    },
+    {
+      percentOfAmi: 60,
+      householdSize: 8,
+      income: 133500,
+    },
+  ],
+}


### PR DESCRIPTION
This adds new AMI charts from #446 . You can test this by reseeding locally and seeing that the migration file inserts the new chars.