### PR TITLE
fix: disable applicationFlaggedSets call and add banner

### DIFF
--- a/sites/partners/lib/hooks.ts
+++ b/sites/partners/lib/hooks.ts
@@ -151,7 +151,8 @@ export function useFlaggedApplicationsList({
 
   const fetcher = () => applicationFlaggedSetsService.list(params)
 
-  const { data, error } = useSWR(endpoint, fetcher)
+  // only make the call if duplicates should be shown
+  const { data, error } = useSWR(process.env.showDuplicates ? endpoint : null, fetcher)
 
   return {
     data,

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -100,6 +100,7 @@
   "flags.markedAsDuplicate": "%{quantity} applications marked as duplicate",
   "flags.resolveFlag": "Resolve Flag",
   "flags.ruleName": "Rule Name",
+  "flags.underConstruction": "Under Construction: New updates to the feature coming soon.",
   "leasingAgent.name": "Leasing Agent Name",
   "leasingAgent.namePlaceholder": "Full Name",
   "leasingAgent.officeHoursPlaceholder": "ex: 9:00am - 5:00pm, Monday to Friday",

--- a/sites/partners/pages/listings/[id]/flags/index.tsx
+++ b/sites/partners/pages/listings/[id]/flags/index.tsx
@@ -12,6 +12,7 @@ import {
   Breadcrumbs,
   BreadcrumbLink,
   NavigationHeader,
+  AlertBox,
 } from "@bloom-housing/ui-components"
 import { getFlagSetCols } from "../../../../src/flags/flagSetCols"
 
@@ -45,8 +46,6 @@ const FlagsPage = () => {
 
   const columns = useMemo(() => getFlagSetCols(), [])
 
-  if (!data) return null
-
   return (
     <Layout>
       <Head>
@@ -77,28 +76,32 @@ const FlagsPage = () => {
       <ListingStatusBar status={listingDto?.status} />
 
       <article className="flex-row flex-wrap relative max-w-screen-xl mx-auto mt-2 pb-8 px-4 w-full">
-        <div className="ag-theme-alpine ag-theme-bloom">
-          <div className="applications-table">
-            <AgGridReact
-              columnDefs={columns}
-              rowData={data?.items}
-              domLayout="autoHeight"
-              headerHeight={83}
-              rowHeight={58}
-              defaultColDef={defaultColDef}
-            ></AgGridReact>
+        {process.env.showDuplicates ? (
+          <div className="ag-theme-alpine ag-theme-bloom">
+            <div className="applications-table">
+              <AgGridReact
+                columnDefs={columns}
+                rowData={data?.items}
+                domLayout="autoHeight"
+                headerHeight={83}
+                rowHeight={58}
+                defaultColDef={defaultColDef}
+              ></AgGridReact>
 
-            <AgPagination
-              totalItems={data?.meta.totalItems}
-              totalPages={data?.meta.totalPages}
-              currentPage={currentPage}
-              itemsPerPage={itemsPerPage}
-              quantityLabel={t("applications.totalSets")}
-              setCurrentPage={setCurrentPage}
-              setItemsPerPage={setItemsPerPage}
-            />
+              <AgPagination
+                totalItems={data?.meta.totalItems}
+                totalPages={data?.meta.totalPages}
+                currentPage={currentPage}
+                itemsPerPage={itemsPerPage}
+                quantityLabel={t("applications.totalSets")}
+                setCurrentPage={setCurrentPage}
+                setItemsPerPage={setItemsPerPage}
+              />
+            </div>
           </div>
-        </div>
+        ) : (
+          <AlertBox type="warn">{t("flags.underConstruction")}</AlertBox>
+        )}
       </article>
     </Layout>
   )

--- a/ui-components/src/page_components/NavigationHeader.tsx
+++ b/ui-components/src/page_components/NavigationHeader.tsx
@@ -49,15 +49,12 @@ const NavigationHeader = ({
         path: `/listings/${listingId}/applications`,
         content: undefined,
       },
-    ]
-
-    if (process.env.showDuplicates && typeof tabs?.flagsQty === "number") {
-      elements.push({
-        label: tabs.flagsLabel,
+      {
+        label: tabs?.flagsLabel || "",
         path: `/listings/${listingId}/flags`,
-        content: <>{tabs.flagsQty}</>,
-      })
-    }
+        content: tabs?.flagsQty ? <>{tabs?.flagsQty}</> : undefined,
+      },
+    ]
 
     return elements
   }, [tabs, listingId])


### PR DESCRIPTION
There is a bug in production where if a user opens up the `One Hundred Grand` property on the partners site the backend runs out of memory. This causes the backend to crash. The culprit is the `applicationFlaggedSets` endpoint. And although the flags tab is currently disabled, the API call is still being done on the other two tabs to get the flagged count.

This PR removes all calls to the applicationFlaggedSets and also adds a warning banner that it is under construction when the environment variable `SHOW_DUPLICATES` is equal to false.
![image](https://user-images.githubusercontent.com/42942267/191997684-3ce62d19-2bc3-4e06-a1dd-ff79bd5ef6c7.png)

Two options for testing (both require setting the partners .env variable of `SHOW_DUPLICATES` to FALSE:
1. Open up any closed listing and the applicationFlaggedSets call should not be happening. Should also see under construction banner instead of table on the Flags tab
2. Copy the prod HBA DB locally and go to the property One Hundred Grand. The backend should not crash and the flags tab should work.

