### PR TITLE
fix: remove lottery date from confirmation email

### DIFF
--- a/backend/core/src/email/email.service.spec.ts
+++ b/backend/core/src/email/email.service.spec.ts
@@ -279,7 +279,7 @@ describe("EmailService", () => {
 
       const emailMock = sendMock.mock.calls[0][0]
       expect(emailMock.html).toMatch(
-        /The lottery will be held on December 31, 2019. Eligible applicants will be placed in order <strong>based on preference and lottery rank<\/strong>./
+        /Eligible applicants will be placed in order <strong>based on preference and lottery rank<\/strong>./
       )
     })
 

--- a/backend/core/src/email/email.service.ts
+++ b/backend/core/src/email/email.service.ts
@@ -6,7 +6,6 @@ import Handlebars from "handlebars"
 import path from "path"
 import Polyglot from "node-polyglot"
 import fs from "fs"
-import dayjs from "dayjs"
 import { ConfigService } from "@nestjs/config"
 import { TranslationsService } from "../translations/services/translations.service"
 import { JurisdictionResolverService } from "../jurisdictions/services/jurisdiction-resolver.service"
@@ -144,16 +143,9 @@ export class EmailService {
     }
 
     if (listing.reviewOrderType === ListingReviewOrder.lottery) {
-      const lotteryText = []
-      if (listing.applicationDueDate) {
-        lotteryText.push(
-          this.polyglot.t("confirmation.eligibleApplicants.lotteryDate", {
-            lotteryDate: dayjs(listing.applicationDueDate).format("MMMM D, YYYY"),
-          })
-        )
-      }
-      lotteryText.push(this.polyglot.t("confirmation.eligibleApplicants.lottery"))
-      eligibleApplicantsText = new Handlebars.SafeString(lotteryText.join(" "))
+      eligibleApplicantsText = new Handlebars.SafeString(
+        this.polyglot.t("confirmation.eligibleApplicants.lottery")
+      )
     } else {
       // for when listing.reviewOrderType === ListingReviewOrder.firstComeFirstServe
       eligibleApplicantsText = new Handlebars.SafeString(


### PR DESCRIPTION
There is currently a bug in production where the confirmation email for lottery properties are showing the application due date instead of the lottery start date.

This fixes the issue by just removing the sentence where the date is listed in the email. It is a temporary fix until the new "What to expect" changes go out.

Email with date:
![image](https://user-images.githubusercontent.com/42942267/194593541-07c6d5e7-4409-4b2b-a270-c9a553eb0f81.png)

Email without date:
<img width="433" alt="image" src="https://user-images.githubusercontent.com/42942267/194593360-0ccdd535-81bc-45fd-8d6a-58bfcbdc9dce.png">
