### PR TITLE
fix: update fremont family resources link

### DIFF
--- a/sites/public/page_content/resources/fremontFamily.md
+++ b/sites/public/page_content/resources/fremontFamily.md
@@ -1,6 +1,6 @@
 <RenderIf language="en,tl">
 
-### [Fremont Family Resource Center](https://www.fremont.gov/228/Family-Resource-Center)
+### [Fremont Family Resource Center](https://www.fremont.gov/government/departments/human-services/fremont-family-resource-center)
 
 Unsheltered families
 
@@ -9,7 +9,7 @@ Call [510-574-2000](tel:+1-510-574-2000)
 </RenderIf>
 <RenderIf language="es">
  
- ### [Centro de Recursos para Familias de Fremont (Fremont Family Resource Center)](https://www.fremont.gov/228/Family-Resource-Center)
+ ### [Centro de Recursos para Familias de Fremont (Fremont Family Resource Center)](https://www.fremont.gov/government/departments/human-services/fremont-family-resource-center)
 
 Familias sin hogar y sin acceso a refugios
 
@@ -18,7 +18,7 @@ Llame al [510-574-2000](tel:+1-510-574-2000)
 </RenderIf>
 <RenderIf language="zh">
 
-### [費利蒙家庭資源中心 (Fremont Family Resource Center)](https://www.fremont.gov/228/Family-Resource-Center)
+### [費利蒙家庭資源中心 (Fremont Family Resource Center)](https://www.fremont.gov/government/departments/human-services/fremont-family-resource-center)
 
 無居所家庭
 
@@ -27,7 +27,7 @@ Llame al [510-574-2000](tel:+1-510-574-2000)
 </RenderIf>
 <RenderIf language="vi">
 
-### [Trung Tâm Nguồn Hỗ Trợ Gia Đình Fremont](https://www.fremont.gov/228/Family-Resource-Center)
+### [Trung Tâm Nguồn Hỗ Trợ Gia Đình Fremont](https://www.fremont.gov/government/departments/human-services/fremont-family-resource-center)
 
 Những gia đình không có nơi trú ẩn
 


### PR DESCRIPTION
The link to the Fremont family resources is a 404 page. This is the updated url