### PR TITLE
fix: add listing id to bad request

### DIFF
--- a/backend/core/src/applications/services/applications.service.ts
+++ b/backend/core/src/applications/services/applications.service.ts
@@ -142,7 +142,9 @@ export class ApplicationsService {
       listing.applicationDueDate &&
       applicationCreateDto.submissionDate > listing.applicationDueDate
     ) {
-      throw new BadRequestException("Listing is not open for application submission.")
+      throw new BadRequestException(
+        `Listing ${applicationCreateDto?.listing?.id} is not open for application submission.`
+      )
     }
 
     await this.authorizeUserAction(

--- a/backend/core/test/applications/applications.e2e-spec.ts
+++ b/backend/core/test/applications/applications.e2e-spec.ts
@@ -615,7 +615,7 @@ describe("Applications", () => {
       .send(body)
       .set(...setAuthorization(user1AccessToken))
       .expect(400)
-    expect(res.body.message).toBe("Listing is not open for application submission.")
+    expect(res.body.message).toBe(`Listing ${listing1Id} is not open for application submission.`)
 
     listing.applicationDueDate = oldApplicationDueDate
     await supertest(app.getHttpServer())


### PR DESCRIPTION
This adds the listing id to the error message when a user applies to a listing that is not open. This is due to the increase in instances of this happening so we can better identify the cause