### PR TITLE
fix: add check in afs for null email

### DIFF
--- a/backend/core/src/application-flagged-sets/application-flagged-sets-cronjob.service.ts
+++ b/backend/core/src/application-flagged-sets/application-flagged-sets-cronjob.service.ts
@@ -227,6 +227,10 @@ export class ApplicationFlaggedSetsCronjobService implements OnModuleInit {
   }
 
   private async fetchDuplicatesMatchingEmailRule(newApplication: Application) {
+    const emailAddress = newApplication.applicant.emailAddress
+    if (!emailAddress) {
+      return []
+    }
     const whereClause: FindOptionsWhere<Application> = {
       id: Not(newApplication.id),
       status: ApplicationStatus.submitted,
@@ -234,7 +238,7 @@ export class ApplicationFlaggedSetsCronjobService implements OnModuleInit {
         id: newApplication.listingId,
       },
       applicant: {
-        emailAddress: newApplication.applicant.emailAddress,
+        emailAddress: emailAddress,
       },
     }
     return await this.applicationRepository.find({


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3517

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

There is an issue where on at least 7 listings in production there is a application flagged set group that has an unusually high number of "pending review". Some of them in the thousands. This is due to a change that went in last week, the upgrade of TypeORM. Although the logic is the same, under the covers it appears that a different behavior is happening when calculating if there is a conflicting Email. Specifically if there is an application that does not have an email (email is null and `no_email` is true) it will conflict with all other applications that also don't have an email listed.

This is the first step of two to address the issue. When running the afs cron job this PR updates the calculation on email conflict by only running it if the applicant has an email.

There will need to be an additional step of cleaning up the already run afs flagged sets. We can do this by deleting all of the application_flagged_sets rows where the rule is "Email" and the ruleKey ends in null. It would also be useful to update the afs_last_run_timestamp on all 7 of those listings to a date before the 15th as well. 

## How Can This Be Tested/Reviewed?

This is fairly tricky to test as it all happens under the hood of the afs cron job and tables. I tested it by taking a copy of the production db locally and making sure that no application flagged sets were set with a ruleKey containing null. It requires you to do the second step outlined above and also changing your local `AFS_PROCESSING_CRON_STRING` env variable to sometime in the very near future in order to trigger the job (or if you are smarter than me you could also hit the `/applicationFlaggedSets/process` endpoint manually).

Another way of testing this locally is to make two listings with different names and dob but both have no email. Then run the cron job and make sure it didn't flag those applications 

Long term it would be nice if we had tests for this service, but as this is a bug fix I think that would be a good follow up as to not block this ticket

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
