### PR TITLE
fix: 07-14-2023 hot fixes

### DIFF
--- a/backend/core/src/auth/services/user.service.ts
+++ b/backend/core/src/auth/services/user.service.ts
@@ -230,7 +230,9 @@ export class UserService {
     }
 
     if (user.confirmationToken !== dto.token) {
-      console.error(`Confirmation token mismatch for user ${token.id}.`)
+      console.error(
+        `Confirmation token mismatch for user ${token.id}. Stored confirmation token: ${user.confirmationToken} incoming token: ${dto.token}`
+      )
       throw new HttpException(USER_ERRORS.TOKEN_MISSING.message, USER_ERRORS.TOKEN_MISSING.status)
     }
 

--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -368,6 +368,7 @@
   "authentication.createAccount.resendTheEmail": "Volver a enviar el email",
   "authentication.forgotPassword.changePassword": "Cambia la contraseña",
   "authentication.forgotPassword.errors.emailNotFound": "El correo electrónico no fue encontrado. Por favor_ revise que si ha creado una cuenta con nosotros con ese correo electrónico y haya sido confirmado confirmado.",
+  "authentication.forgotPassword.errors.passwordTooWeak": "La contraseña es demasiado débil. Debe tener al menos 8 caracteres y deberá incluir por lo menos 1 letra y 1 número.",
   "authentication.forgotPassword.errors.tokenExpired": "El token de restablecimiento de contraseña caducó. Por favor_ solicite uno nuevo.",
   "authentication.forgotPassword.errors.tokenMissing": "El token no fue encontrado. Por favor_ solicite uno nuevo.",
   "authentication.forgotPassword.sendEmail": "Enviar correo electrónico",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -502,6 +502,7 @@
   "authentication.forgotPassword.enterNewLoginPassword": "Please enter new login password",
   "authentication.forgotPassword.changePassword": "Change Password",
   "authentication.forgotPassword.errors.emailNotFound": "Email not found. Please make sure your email has an account with us and is confirmed.",
+  "authentication.forgotPassword.errors.passwordTooWeak": "Password is too weak. Must be at least 8 characters and include at least 1 letter and at least one number.",
   "authentication.forgotPassword.errors.tokenExpired": "Reset password token expired. Please request for a new one.",
   "authentication.forgotPassword.errors.tokenMissing": "Token not found. Please request for a new one.",
   "authentication.forgotPassword.sendEmail": "Send email",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -321,6 +321,7 @@
   "authentication.createAccount.resendTheEmail": "Ipadalang muli ang email",
   "authentication.forgotPassword.changePassword": "Palitan ang Password",
   "authentication.forgotPassword.errors.emailNotFound": "Hindi nahanap ang email. Pakitiyak na ang iyong email ay may account sa amin at nakumpirma.",
+  "authentication.forgotPassword.errors.passwordTooWeak": "Masyadong mahina ang password. Dapat ay hindi bababa sa 8 mga character at may kasamang hindi bababa sa 1 titik at hindi bababa sa isang numero.",
   "authentication.forgotPassword.errors.tokenExpired": "Nag-expire na ang token ng pag-reset ng password. Humiling ng bago.",
   "authentication.forgotPassword.errors.tokenMissing": "Hindi nahanap ang token. Humiling ng bago.",
   "authentication.forgotPassword.sendEmail": "Magpadala ng email",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -368,6 +368,7 @@
   "authentication.createAccount.resendTheEmail": "Gửi lại Email",
   "authentication.forgotPassword.changePassword": "Đổi mật khẩu",
   "authentication.forgotPassword.errors.emailNotFound": "Không tìm thấy email. Vui lòng đảm bảo email của quý vị có tài khoản với chúng tôi và đã được xác nhận.",
+  "authentication.forgotPassword.errors.passwordTooWeak": "Mật khẩu quá yếu. Phải có ít nhất 8 ký tự và bao gồm ít nhất 1 chữ cái và ít nhất một số.",
   "authentication.forgotPassword.errors.tokenExpired": "Mã thông báo đặt lại mật khẩu đã hết hạn. Vui lòng yêu cầu mã mới.",
   "authentication.forgotPassword.errors.tokenMissing": "Không tìm thấy mã thông báo. Vui lòng yêu cầu mã mới.",
   "authentication.forgotPassword.sendEmail": "Gửi email",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -368,6 +368,7 @@
   "authentication.createAccount.resendTheEmail": "重新發送電子郵件",
   "authentication.forgotPassword.changePassword": "變更密碼",
   "authentication.forgotPassword.errors.emailNotFound": "找不到電子郵件。請確保您以此電子郵件向我們註冊帳戶並確認完畢。",
+  "authentication.forgotPassword.errors.passwordTooWeak": "密碼強度太弱。至少必須為 8 個字元，並至少包含 1 個字母及 1 個數字。",
   "authentication.forgotPassword.errors.tokenExpired": "重設密碼權杖已到期。請要求新的權杖。",
   "authentication.forgotPassword.errors.tokenMissing": "找不到權杖。請要求新的權杖。",
   "authentication.forgotPassword.sendEmail": "傳送電子郵件",


### PR DESCRIPTION
This is a patch to release:
Some missing translations (https://github.com/bloom-housing/bloom/issues/3544)
Adding some additional logging to help track down an user confirm() error (https://github.com/bloom-housing/bloom/issues/3537)


Testing: 

the logging error isn't something we've been able to replicate so looking to see in the deployed state to help track down how this is happening. No testing on our end needed

missing translations: 
```
create a public user (or use an existing user)
go through the reset password work flow
enter a password that would be too weak abcdef for example, you should now get a translated error message
```