### PR TITLE
fix: foreign language in export

### DIFF
--- a/shared-helpers/__tests__/views/multiselectQuestions.test.ts
+++ b/shared-helpers/__tests__/views/multiselectQuestions.test.ts
@@ -1,0 +1,14 @@
+import { cleanup } from "@testing-library/react"
+import { cleanMultiselectString } from "../../src/views/multiselectQuestions"
+
+afterEach(cleanup)
+
+describe("multiselectQuestions", () => {
+  describe("cleanMultiselectString", () => {
+    it("should remove expected characters", () => {
+      expect(
+        cleanMultiselectString("I'm a string, and I have a comma, period, and apostrophe.")
+      ).toBe("Im a string and I have a comma period and apostrophe")
+    })
+  })
+})

--- a/shared-helpers/src/views/multiselectQuestions.tsx
+++ b/shared-helpers/src/views/multiselectQuestions.tsx
@@ -21,6 +21,7 @@ import { stateKeys } from "../utilities/formKeys"
 import { AddressHolder } from "../utilities/constants"
 import { FormAddressAlternate } from "./address/FormAddressAlternate"
 
+// Removes periods, commas, and apostrophes
 export const cleanMultiselectString = (name: string | undefined) => {
   return name?.replace(/\.|,|'/g, "")
 }

--- a/shared-helpers/src/views/multiselectQuestions.tsx
+++ b/shared-helpers/src/views/multiselectQuestions.tsx
@@ -21,6 +21,10 @@ import { stateKeys } from "../utilities/formKeys"
 import { AddressHolder } from "../utilities/constants"
 import { FormAddressAlternate } from "./address/FormAddressAlternate"
 
+export const cleanMultiselectString = (name: string | undefined) => {
+  return name?.replace(/\.|,|'/g, "")
+}
+
 export const listingSectionQuestions = (
   listing: Listing,
   applicationSection: ApplicationSection
@@ -37,8 +41,8 @@ export const fieldName = (
   applicationSection: ApplicationSection,
   optionName?: string
 ) => {
-  return `application.${applicationSection}.${questionName?.replace(/\.|,|'/g, "")}${
-    optionName ? `.${optionName?.replace(/\.|,|'/g, "")}` : ""
+  return `application.${applicationSection}.${cleanMultiselectString(questionName)}${
+    optionName ? `.${cleanMultiselectString(optionName)}` : ""
   }`
 }
 
@@ -343,7 +347,8 @@ export const mapCheckboxesToApi = (
   question: MultiselectQuestion,
   applicationSection: ApplicationSection
 ): ApplicationMultiselectQuestion => {
-  const data = formData["application"][applicationSection][question.text.replace(/\.|,|'/g, "")]
+  const data =
+    formData["application"][applicationSection][cleanMultiselectString(question.text) || ""]
   const claimed = !!Object.keys(data).filter((key) => data[key] === true).length
 
   const addressFields = Object.keys(data).filter((option) => Object.keys(data[option]))
@@ -380,9 +385,9 @@ export const mapCheckboxesToApi = (
 
       const getFinalKey = () => {
         const optionKey = question?.options?.find(
-          (elem) => elem.text.replace(/\.|,|'/g, "") === key
+          (elem) => cleanMultiselectString(elem.text) === key
         )?.text
-        const cleanOptOutKey = question?.optOutText?.replace(/\.|,|'/g, "")
+        const cleanOptOutKey = cleanMultiselectString(question?.optOutText)
         if (cleanOptOutKey === key) return question?.optOutText || key
         return optionKey || key
       }
@@ -442,7 +447,7 @@ export const mapApiToMultiselectForm = (
     if (appQuestion.inputType === "checkbox") {
       options = question.options.reduce((acc, curr) => {
         const claimed = curr.checked
-        const cleanKey = curr.key.replace(/\.|,|'/g, "")
+        const cleanKey = cleanMultiselectString(curr.key) || ""
         if (appQuestion.inputType === "checkbox") {
           acc[cleanKey] = claimed
           if (curr.extraData?.length) {

--- a/shared-helpers/src/views/multiselectQuestions.tsx
+++ b/shared-helpers/src/views/multiselectQuestions.tsx
@@ -433,26 +433,27 @@ export const mapApiToMultiselectForm = (
     if (appQuestion.inputType === "checkbox") {
       options = question.options.reduce((acc, curr) => {
         const claimed = curr.checked
+        const cleanKey = curr.key.replace(/\.|,|'/g, "")
         if (appQuestion.inputType === "checkbox") {
-          acc[curr.key] = claimed
+          acc[cleanKey] = claimed
           if (curr.extraData?.length) {
-            acc[`${curr.key}-address`] = curr.extraData[0].value
+            acc[`${cleanKey}-address`] = curr.extraData[0].value
 
             const addressHolderName = curr.extraData?.find(
               (field) => field.key === AddressHolder.Name
             )
             if (addressHolderName) {
-              acc[`${curr.key}-${AddressHolder.Name}`] = addressHolderName.value
+              acc[`${cleanKey}-${AddressHolder.Name}`] = addressHolderName.value
             }
 
             const addressHolderRelationship = curr.extraData?.find(
               (field) => field.key === AddressHolder.Relationship
             )
             if (addressHolderRelationship) {
-              acc[`${curr.key}-${AddressHolder.Relationship}`] = addressHolderRelationship.value
+              acc[`${cleanKey}-${AddressHolder.Relationship}`] = addressHolderRelationship.value
             }
             if (curr?.mapPinPosition) {
-              acc[`${curr.key}-mapPinPosition`] = curr.mapPinPosition
+              acc[`${cleanKey}-mapPinPosition`] = curr.mapPinPosition
             }
           }
         }

--- a/shared-helpers/src/views/multiselectQuestions.tsx
+++ b/shared-helpers/src/views/multiselectQuestions.tsx
@@ -37,8 +37,8 @@ export const fieldName = (
   applicationSection: ApplicationSection,
   optionName?: string
 ) => {
-  return `application.${applicationSection}.${questionName?.replace(/'/g, "")}${
-    optionName ? `.${optionName?.replace(/'/g, "")}` : ""
+  return `application.${applicationSection}.${questionName?.replace(/\.|,|'/g, "")}${
+    optionName ? `.${optionName?.replace(/\.|,|'/g, "")}` : ""
   }`
 }
 
@@ -343,7 +343,7 @@ export const mapCheckboxesToApi = (
   question: MultiselectQuestion,
   applicationSection: ApplicationSection
 ): ApplicationMultiselectQuestion => {
-  const data = formData["application"][applicationSection][question.text.replace(/'/g, "")]
+  const data = formData["application"][applicationSection][question.text.replace(/\.|,|'/g, "")]
   const claimed = !!Object.keys(data).filter((key) => data[key] === true).length
 
   const addressFields = Object.keys(data).filter((option) => Object.keys(data[option]))
@@ -378,8 +378,17 @@ export const mapCheckboxesToApi = (
         }
       }
 
+      const getFinalKey = () => {
+        const optionKey = question?.options?.find(
+          (elem) => elem.text.replace(/\.|,|'/g, "") === key
+        )?.text
+        const cleanOptOutKey = question?.optOutText?.replace(/\.|,|'/g, "")
+        if (cleanOptOutKey === key) return question?.optOutText || key
+        return optionKey || key
+      }
+
       return {
-        key,
+        key: getFinalKey(),
         mapPinPosition: data?.[`${key}-mapPinPosition`],
         checked: data[key] === true,
         extraData: extraData,

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
@@ -41,7 +41,11 @@ const FormMultiselectQuestions = ({
     questions?.forEach((listingQuestion) =>
       listingQuestion?.multiselectQuestion.options.forEach((option) =>
         keys.push(
-          fieldName(listingQuestion?.multiselectQuestion.text, applicationSection, option.text)
+          fieldName(
+            listingQuestion?.multiselectQuestion.text,
+            applicationSection,
+            option.text.replace(/\.|,|'/g, "")
+          )
         )
       )
     )
@@ -68,7 +72,11 @@ const FormMultiselectQuestions = ({
   const watchQuestions = watch(allOptionFieldNames)
 
   const getCheckboxOption = (option: MultiselectOption, question: MultiselectQuestion) => {
-    const optionFieldName = fieldName(question.text, applicationSection, option.text)
+    const optionFieldName = fieldName(
+      question.text,
+      applicationSection,
+      option.text.replace(/\.|,|'/g, "")
+    )
     return (
       <React.Fragment key={option.text}>
         <Field

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
@@ -2,7 +2,13 @@ import React, { useEffect, useMemo, useState } from "react"
 import { Field, t, FieldGroup, resolveObject } from "@bloom-housing/ui-components"
 import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
 import { useFormContext } from "react-hook-form"
-import { stateKeys, getInputType, fieldName, AddressHolder } from "@bloom-housing/shared-helpers"
+import {
+  stateKeys,
+  getInputType,
+  fieldName,
+  AddressHolder,
+  cleanMultiselectString,
+} from "@bloom-housing/shared-helpers"
 import {
   ApplicationSection,
   ListingMultiselectQuestion,
@@ -44,7 +50,7 @@ const FormMultiselectQuestions = ({
           fieldName(
             listingQuestion?.multiselectQuestion.text,
             applicationSection,
-            option.text.replace(/\.|,|'/g, "")
+            cleanMultiselectString(option.text)
           )
         )
       )
@@ -75,7 +81,7 @@ const FormMultiselectQuestions = ({
     const optionFieldName = fieldName(
       question.text,
       applicationSection,
-      option.text.replace(/\.|,|'/g, "")
+      cleanMultiselectString(option.text)
     )
     return (
       <React.Fragment key={option.text}>

--- a/sites/public/src/components/shared/FormSummaryDetails.tsx
+++ b/sites/public/src/components/shared/FormSummaryDetails.tsx
@@ -1,7 +1,11 @@
 import React, { Fragment, useEffect, useState } from "react"
 import { LocalizedLink, MultiLineAddress, t } from "@bloom-housing/ui-components"
 import { FieldValue } from "@bloom-housing/ui-seeds"
-import { getUniqueUnitTypes, AddressHolder } from "@bloom-housing/shared-helpers"
+import {
+  getUniqueUnitTypes,
+  AddressHolder,
+  cleanMultiselectString,
+} from "@bloom-housing/shared-helpers"
 import {
   Address,
   AllExtraDataTypes,
@@ -113,17 +117,18 @@ const FormSummaryDetails = ({
   ) => {
     const initialMultiselectQuestion = listing.listingMultiselectQuestions.find(
       (elem) =>
-        elem.multiselectQuestion.text.replace(/\.|,|'/g, "") === question.key.replace(/\.|,|'/g, "")
+        cleanMultiselectString(elem.multiselectQuestion.text) ===
+        cleanMultiselectString(question.key)
     )
 
     const initialOption = initialMultiselectQuestion?.multiselectQuestion.options.find(
-      (elem) => elem.text.replace(/\.|,|'/g, "") === option.key
+      (elem) => cleanMultiselectString(elem.text) === option.key
     )
 
     const initialOptOut = initialMultiselectQuestion?.multiselectQuestion.optOutText
 
     const optOutOption =
-      option.key === initialOptOut?.replace(/\.|,|'/g, "") ? initialOptOut : undefined
+      option.key === cleanMultiselectString(initialOptOut) ? initialOptOut : undefined
 
     return initialOption?.text || optOutOption || option.key
   }

--- a/sites/public/src/components/shared/FormSummaryDetails.tsx
+++ b/sites/public/src/components/shared/FormSummaryDetails.tsx
@@ -107,6 +107,27 @@ const FormSummaryDetails = ({
     return `${name ? `${name}\n` : ""}${relationship ? `${relationship}\n` : ""}${helperText}`
   }
 
+  const getOptionText = (
+    question: ApplicationMultiselectQuestion,
+    option: ApplicationMultiselectQuestionOption
+  ) => {
+    const initialMultiselectQuestion = listing.listingMultiselectQuestions.find(
+      (elem) =>
+        elem.multiselectQuestion.text.replace(/\.|,|'/g, "") === question.key.replace(/\.|,|'/g, "")
+    )
+
+    const initialOption = initialMultiselectQuestion?.multiselectQuestion.options.find(
+      (elem) => elem.text.replace(/\.|,|'/g, "") === option.key
+    )
+
+    const initialOptOut = initialMultiselectQuestion?.multiselectQuestion.optOutText
+
+    const optOutOption =
+      option.key === initialOptOut?.replace(/\.|,|'/g, "") ? initialOptOut : undefined
+
+    return initialOption?.text || optOutOption || option.key
+  }
+
   const multiselectQuestionSection = (
     applicationSection: ApplicationSection,
     appLink: string,
@@ -141,7 +162,7 @@ const FormSummaryDetails = ({
                         testId={"app-summary-preference"}
                         className={"pb-6 whitespace-pre-wrap"}
                       >
-                        {option.key}
+                        {getOptionText(question, option)}
                       </FieldValue>
                     ))
                 )}

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -195,11 +195,13 @@ export const untranslateMultiselectQuestion = (
       if (datum.options) {
         datum.options.forEach((option) => {
           const selectedOption = question.options.find((elem) => {
-            return elem.text.replace(/\.|,|'/g, "") === option.key
+            return elem.text.replace(/\.|,|'/g, "") === option.key.replace(/\.|,|'/g, "")
           })
           if (selectedOption) {
             option.key = selectedOption.untranslatedText ?? selectedOption.text
-          } else if (question?.optOutText?.replace(/\.|,|'/g, "") === option.key) {
+          } else if (
+            question?.optOutText?.replace(/\.|,|'/g, "") === option.key.replace(/\.|,|'/g, "")
+          ) {
             option.key = question.untranslatedOptOutText ?? question.optOutText
           }
 

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -184,7 +184,9 @@ export const untranslateMultiselectQuestion = (
 
   data.forEach((datum) => {
     const question = multiselectQuestions.find(
-      (elem) => elem.multiselectQuestion.text === datum.key
+      (elem) =>
+        elem.multiselectQuestion.text === datum.key ||
+        elem.multiselectQuestion.untranslatedText === datum.key
     )?.multiselectQuestion
 
     if (question) {
@@ -192,11 +194,12 @@ export const untranslateMultiselectQuestion = (
 
       if (datum.options) {
         datum.options.forEach((option) => {
-          const selectedOption = question.options.find((elem) => elem.text === option.key)
-
+          const selectedOption = question.options.find((elem) => {
+            return elem.text.replace(/\.|,|'/g, "") === option.key
+          })
           if (selectedOption) {
             option.key = selectedOption.untranslatedText ?? selectedOption.text
-          } else if (question.optOutText === option.key) {
+          } else if (question?.optOutText?.replace(/\.|,|'/g, "") === option.key) {
             option.key = question.untranslatedOptOutText ?? question.optOutText
           }
 

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -19,6 +19,7 @@ import {
   imageUrlFromListing,
   getSummariesTable,
   IMAGE_FALLBACK_URL,
+  cleanMultiselectString,
 } from "@bloom-housing/shared-helpers"
 
 export const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
@@ -195,12 +196,12 @@ export const untranslateMultiselectQuestion = (
       if (datum.options) {
         datum.options.forEach((option) => {
           const selectedOption = question.options.find((elem) => {
-            return elem.text.replace(/\.|,|'/g, "") === option.key.replace(/\.|,|'/g, "")
+            return cleanMultiselectString(elem.text) === cleanMultiselectString(option.key)
           })
           if (selectedOption) {
             option.key = selectedOption.untranslatedText ?? selectedOption.text
           } else if (
-            question?.optOutText?.replace(/\.|,|'/g, "") === option.key.replace(/\.|,|'/g, "")
+            cleanMultiselectString(question?.optOutText) === cleanMultiselectString(option.key)
           ) {
             option.key = question.untranslatedOptOutText ?? question.optOutText
           }


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses:
https://github.com/bloom-housing/bloom/issues/3856
https://github.com/bloom-housing/bloom/issues/3857

## Description

Support Slack thread: https://exygy.slack.com/archives/C02G1S19QA2/p1707140129651329
Some applications with a specific preference were coming through as non-English, and sometimes they had periods at the end / other times they did not.

## How Can This Be Tested/Reviewed?

Create a new preference with the following options:
* `I'm an option, and I have a comma, period, and apostrophe.`
* `I'm a custom opt out option, and I also have all three.`

The comma, period, and apostrophe are "characters" that react-hook-form removes from object keys. The issue was failing comparisons between the two versions of these strings, so everywhere we are comparing options, I'm stripping the characters. We honestly need a full overhaul of how we are mapping form data to the preference API - we should not be sending the key strings themselves, ideally the option IDs.

Both flows need to be tested in terms of either selecting the first option or the custom opt-out option.

A few additional issues surfaced in testing. The following should be true filling out an application in a foreign language (ideally Spanish):
* As you are filling out an application, once you select either option and move forward then backward, the appropriate answer should still be selected.
* When you are on the application summary page before submission, the selected option should include all of the characters.
* On the partners side, the selected options should come through in English. You should test this first on the individual application form pages. On the view page, the selected option should include all of the characters. On the edit page, the right option should be selected. When changing an option and saving, the right data should be saved on the view page and again when re-opening in edit should be appropriately selected.
* This data is the same as in the export, but you can also export the data and ensure the responses are all (1) in English and (2) include all characters.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
