### PR TITLE
fix: Application perm hotfix

### DIFF
--- a/api/src/services/application-flagged-set.service.ts
+++ b/api/src/services/application-flagged-set.service.ts
@@ -24,7 +24,11 @@ import { AfsQueryParams } from '../dtos/application-flagged-sets/afs-query-param
 import { AfsMeta } from '../dtos/application-flagged-sets/afs-meta.dto';
 import { OrderByEnum } from '../enums/shared/order-by-enum';
 import { View } from '../enums/application-flagged-sets/view';
-import { buildPaginationMetaInfo } from '../utilities/pagination-helpers';
+import {
+  buildPaginationMetaInfo,
+  calculateSkip,
+  calculateTake,
+} from '../utilities/pagination-helpers';
 import { AfsResolve } from '../dtos/application-flagged-sets/afs-resolve.dto';
 import { User } from '../dtos/users/user.dto';
 import { Application } from '../dtos/applications/application.dto';
@@ -67,6 +71,15 @@ export class ApplicationFlaggedSetService implements OnModuleInit {
       where: whereClause,
     });
 
+    // if passed in page and limit would result in no results because there aren't that many listings
+    // revert back to the first page
+    let page = params.page;
+    if (count && params.limit && params.limit !== 'all' && params.page > 1) {
+      if (Math.ceil(count / params.limit) < params.page) {
+        page = 1;
+      }
+    }
+
     const rawAfs = await this.prisma.applicationFlaggedSet.findMany({
       include: {
         listings: true,
@@ -80,6 +93,8 @@ export class ApplicationFlaggedSetService implements OnModuleInit {
       orderBy: {
         id: OrderByEnum.DESC,
       },
+      skip: calculateSkip(params.limit, page),
+      take: calculateTake(params.limit),
     });
 
     const totalFlagged = await this.prisma.applicationFlaggedSet.count({

--- a/api/src/services/application.service.ts
+++ b/api/src/services/application.service.ts
@@ -47,6 +47,11 @@ export const view: Partial<
         address: true,
       },
     },
+    listings: {
+      select: {
+        id: true,
+      },
+    },
   },
 };
 

--- a/api/test/unit/services/application-flagged-set.service.spec.ts
+++ b/api/test/unit/services/application-flagged-set.service.spec.ts
@@ -409,6 +409,7 @@ describe('Testing application flagged set service', () => {
       orderBy: {
         id: OrderByEnum.DESC,
       },
+      skip: 0,
     });
 
     expect(prisma.applicationFlaggedSet.count).toHaveBeenNthCalledWith(1, {


### PR DESCRIPTION
## Description
fixes a problem where on the partner site we weren't selecting listing id when getting applications, so we were getting errors

## How Can This Be Tested/Reviewed?
log in as juris admin, try to get a listing -> application tab you should now be able to
