### PR TITLE
fix: partner and public matching (#4090)

### DIFF
--- a/api/.env.template
+++ b/api/.env.template
@@ -31,7 +31,7 @@ TWILIO_ACCOUNT_SID=
 # account auth token for twilio
 TWILIO_AUTH_TOKEN=
 # url for the partner front end
-PARTNERS_PORTAL_URL=http://localhost:3001/
+PARTNERS_PORTAL_URL=http://localhost:3001
 # sendgrid email api key
 EMAIL_API_KEY=SG.ExampleApiKey
 # controls the repetition of the afs cron job

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -401,6 +401,17 @@ export class UserService {
       UserViews.full,
     );
 
+    const isPartnerPortalUser =
+      storedUser.userRoles?.isAdmin ||
+      storedUser.userRoles?.isJurisdictionalAdmin ||
+      storedUser.userRoles?.isPartner;
+    const isUserSiteMatch =
+      (isPartnerPortalUser && dto.appUrl === process.env.PARTNERS_PORTAL_URL) ||
+      (!isPartnerPortalUser &&
+        dto.appUrl === storedUser.jurisdictions?.[0]?.publicUrl);
+    // user on wrong site, return neutral message and don't send email
+    if (!isUserSiteMatch) return { success: true };
+
     const payload = {
       id: storedUser.id,
       exp: Number.parseInt(dayjs().add(1, 'hour').format('X')),

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -405,12 +405,24 @@ export class UserService {
       storedUser.userRoles?.isAdmin ||
       storedUser.userRoles?.isJurisdictionalAdmin ||
       storedUser.userRoles?.isPartner;
-    const isUserSiteMatch =
-      (isPartnerPortalUser && dto.appUrl === process.env.PARTNERS_PORTAL_URL) ||
-      (!isPartnerPortalUser &&
-        dto.appUrl === storedUser.jurisdictions?.[0]?.publicUrl);
+    const isUserSiteMatch = async () => {
+      if (isPartnerPortalUser) {
+        return dto.appUrl === process.env.PARTNERS_PORTAL_URL;
+      } else {
+        //temporary solution since users can currently log into other jurisdictions' public site
+        const juris = await this.prisma.jurisdictions.findFirst({
+          select: {
+            id: true,
+          },
+          where: {
+            publicUrl: dto.appUrl,
+          },
+        });
+        return !!juris;
+      }
+    };
     // user on wrong site, return neutral message and don't send email
-    if (!isUserSiteMatch) return { success: true };
+    if (!(await isUserSiteMatch())) return { success: true };
 
     const payload = {
       id: storedUser.id,

--- a/api/test/integration/user.e2e-spec.ts
+++ b/api/test/integration/user.e2e-spec.ts
@@ -533,9 +533,13 @@ describe('User Controller Tests', () => {
     expect(userPostResend.hitConfirmationUrl).toBeNull();
   });
 
-  it('should set resetToken when forgot-password is called', async () => {
+  it('should set resetToken when forgot-password is called by public user on the public site', async () => {
+    const juris = await prisma.jurisdictions.create({
+      data: jurisdictionFactory(),
+    });
+
     const userA = await prisma.userAccounts.create({
-      data: await userFactory(),
+      data: await userFactory({ jurisdictionIds: [juris.id] }),
     });
 
     const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
@@ -544,6 +548,7 @@ describe('User Controller Tests', () => {
       .set({ passkey: process.env.API_PASS_KEY || '' })
       .send({
         email: userA.email,
+        appUrl: juris.publicUrl,
       } as EmailAndAppUrl)
       .expect(200);
 
@@ -557,6 +562,105 @@ describe('User Controller Tests', () => {
 
     expect(userPostResend.resetToken).not.toBeNull();
     expect(mockforgotPassword.mock.calls.length).toBe(1);
+  });
+
+  it('should not set resetToken when forgot-password is called by public user on the partners site', async () => {
+    const juris = await prisma.jurisdictions.create({
+      data: jurisdictionFactory(),
+    });
+
+    const userA = await prisma.userAccounts.create({
+      data: await userFactory({ jurisdictionIds: [juris.id] }),
+    });
+
+    const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
+    const res = await request(app.getHttpServer())
+      .put(`/user/forgot-password/`)
+      .set({ passkey: process.env.API_PASS_KEY || '' })
+      .send({
+        email: userA.email,
+        appUrl: process.env.PARTNERS_PORTAL_URL,
+      } as EmailAndAppUrl)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+
+    const userPostResend = await prisma.userAccounts.findUnique({
+      where: {
+        id: userA.id,
+      },
+    });
+
+    expect(userPostResend.resetToken).toBeNull();
+    expect(mockforgotPassword.mock.calls.length).toBe(0);
+  });
+
+  it('should set resetToken when forgot-password is called by partner user on the partners site', async () => {
+    const juris = await prisma.jurisdictions.create({
+      data: jurisdictionFactory(),
+    });
+
+    const userA = await prisma.userAccounts.create({
+      data: await userFactory({
+        roles: { isAdmin: true },
+        jurisdictionIds: [juris.id],
+      }),
+    });
+
+    const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
+    const res = await request(app.getHttpServer())
+      .put(`/user/forgot-password/`)
+      .set({ passkey: process.env.API_PASS_KEY || '' })
+      .send({
+        email: userA.email,
+        appUrl: process.env.PARTNERS_PORTAL_URL,
+      } as EmailAndAppUrl)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+
+    const userPostResend = await prisma.userAccounts.findUnique({
+      where: {
+        id: userA.id,
+      },
+    });
+
+    expect(userPostResend.resetToken).not.toBeNull();
+    expect(mockforgotPassword.mock.calls.length).toBe(1);
+  });
+
+  it('should not set resetToken when forgot-password is called by partner user on the public site', async () => {
+    const juris = await prisma.jurisdictions.create({
+      data: jurisdictionFactory(),
+    });
+
+    const userA = await prisma.userAccounts.create({
+      data: await userFactory({
+        roles: { isAdmin: true },
+        jurisdictionIds: [juris.id],
+      }),
+    });
+
+    const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
+    const res = await request(app.getHttpServer())
+      .put(`/user/forgot-password/`)
+      .set({ passkey: process.env.API_PASS_KEY || '' })
+      .send({
+        email: userA.email,
+        appUrl: juris.publicUrl,
+      } as EmailAndAppUrl)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+
+    const userPostResend = await prisma.userAccounts.findUnique({
+      where: {
+        id: userA.id,
+      },
+    });
+
+    expect(userPostResend.resetToken).toBeNull();
+    expect(mockforgotPassword.mock.calls.length).toBe(0);
   });
 
   it('should create public user', async () => {

--- a/api/test/unit/services/user.service.spec.ts
+++ b/api/test/unit/services/user.service.spec.ts
@@ -664,12 +664,13 @@ describe('Testing user service', () => {
   });
 
   describe('forgotPassword', () => {
-    it('should set resetToken', async () => {
+    it('should set resetToken when public user on public site', async () => {
       const id = randomUUID();
       const email = 'email@example.com';
 
       prisma.userAccounts.findUnique = jest.fn().mockResolvedValue({
         id,
+        jurisdictions: [{ publicUrl: 'http://localhost:3000' }],
       });
       prisma.userAccounts.update = jest.fn().mockResolvedValue({
         id,
@@ -697,6 +698,109 @@ describe('Testing user service', () => {
           id,
         },
       });
+    });
+
+    it('should not set resetToken when public user on partner site', async () => {
+      const id = randomUUID();
+      const email = 'email@example.com';
+
+      prisma.userAccounts.findUnique = jest.fn().mockResolvedValue({
+        id,
+        jurisdictions: [{ publicUrl: 'http://localhost:3000' }],
+      });
+      prisma.userAccounts.update = jest.fn().mockResolvedValue({
+        id,
+        resetToken: 'example reset token',
+      });
+      emailService.forgotPassword = jest.fn();
+
+      await service.forgotPassword({
+        email,
+        appUrl: process.env.PARTNERS_PORTAL_URL,
+      });
+      expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
+        include: {
+          jurisdictions: true,
+          listings: true,
+          userRoles: true,
+        },
+        where: {
+          email,
+          id: undefined,
+        },
+      });
+      expect(prisma.userAccounts.update).not.toHaveBeenCalled();
+    });
+
+    it('should set resetToken when partner user on partner site', async () => {
+      const id = randomUUID();
+      const email = 'email@example.com';
+
+      prisma.userAccounts.findUnique = jest.fn().mockResolvedValue({
+        id,
+        userRoles: { isAdmin: true },
+      });
+      prisma.userAccounts.update = jest.fn().mockResolvedValue({
+        id,
+        resetToken: 'example reset token',
+      });
+      emailService.forgotPassword = jest.fn();
+
+      await service.forgotPassword({
+        email,
+        appUrl: process.env.PARTNERS_PORTAL_URL,
+      });
+      expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
+        include: {
+          jurisdictions: true,
+          listings: true,
+          userRoles: true,
+        },
+        where: {
+          email,
+          id: undefined,
+        },
+      });
+      expect(prisma.userAccounts.update).toHaveBeenCalledWith({
+        data: {
+          resetToken: expect.anything(),
+        },
+        where: {
+          id,
+        },
+      });
+    });
+
+    it('should not set resetToken when partner user on public site', async () => {
+      const id = randomUUID();
+      const email = 'email@example.com';
+
+      prisma.userAccounts.findUnique = jest.fn().mockResolvedValue({
+        id,
+        userRoles: { isAdmin: true },
+      });
+      prisma.userAccounts.update = jest.fn().mockResolvedValue({
+        id,
+        resetToken: 'example reset token',
+      });
+      emailService.forgotPassword = jest.fn();
+
+      await service.forgotPassword({
+        email,
+        appUrl: 'http://localhost:3000',
+      });
+      expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
+        include: {
+          jurisdictions: true,
+          listings: true,
+          userRoles: true,
+        },
+        where: {
+          email,
+          id: undefined,
+        },
+      });
+      expect(prisma.userAccounts.update).not.toHaveBeenCalled();
     });
 
     it('should error when trying to set resetToken on nonexistent user', async () => {

--- a/api/test/unit/services/user.service.spec.ts
+++ b/api/test/unit/services/user.service.spec.ts
@@ -676,6 +676,9 @@ describe('Testing user service', () => {
         id,
         resetToken: 'example reset token',
       });
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
+        id,
+      });
       emailService.forgotPassword = jest.fn();
 
       await service.forgotPassword({ email, appUrl: 'http://localhost:3000' });
@@ -712,6 +715,7 @@ describe('Testing user service', () => {
         id,
         resetToken: 'example reset token',
       });
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue(null);
       emailService.forgotPassword = jest.fn();
 
       await service.forgotPassword({


### PR DESCRIPTION
# Pulls fix from core

## Issue Overview

This PR addresses #4089. 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This PR now incorporates some points that @mcgarrye came up in discussing the previous https://github.com/bloom-housing/bloom/pull/4090 addressing this issue. Specifically in HBA, an alameda public user is able to log in to the san jose site and see applications from alameda in the san jose portal. Matching fully on the public url from the users jurisdiction would mean the forgot password experience is incorporating security that users aren't experiencing on the sign in page itself leading to a confusing experience. This issue is captured here https://github.com/bloom-housing/bloom/issues/4119

As a result of this, this PR just checks that a public user is not using the partners portal. Additionally, this PR updates the env and env template to just include http://localhost:3001/ to actually match the window.location.origin checks along with our staging and production sites who's urls do not include this trailing slash.

How Can This Be Tested/Reviewed?
Update your env to match the template

This can be tested by making a public user and partner user and with each account following the forgot password flow on the public and partners account. The flow should work as expected on the matching site but should not send an email for the mismatch.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
