### PR TITLE
fix: add language to headers (#4148)

### DIFF
--- a/sites/public/src/pages/preview/listings/[id].tsx
+++ b/sites/public/src/pages/preview/listings/[id].tsx
@@ -45,12 +45,17 @@ export default function ListingPage(props: ListingProps) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function getServerSideProps(context: { params: Record<string, string>; req: any }) {
+export async function getServerSideProps(context: {
+  params: Record<string, string>
+  locale: string
+  req: any
+}) {
   let response
 
   try {
     response = await axios.get(`${process.env.backendApiBase}/listings/${context.params.id}`, {
       headers: {
+        language: context.locale,
         passkey: process.env.API_PASS_KEY,
         "x-forwarded-for":
           context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,


### PR DESCRIPTION
PULLED FROM CORE: 
This PR addresses #4147 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR adds in language to the headers of the listings call on the preview page so that it matches the [slug.tsx] headers. This way the translation service is called within the listingService.findOne() call.

## How Can This Be Tested/Reviewed?

This can be tested by pulling this down locally, previewing a listing from the partner's side and see that most if not all strings are translating with the exception of a few particular fields such as "or one month's rent may be higher for lower credit scores" which are known by Sarah. If you wish you can uncomment the new line to see the difference.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
