### PR TITLE
fix: add missing listing translations

### DIFF
--- a/api/src/services/translation.service.ts
+++ b/api/src/services/translation.service.ts
@@ -93,25 +93,37 @@ export class TranslationService {
     }
 
     const pathsToFilter = {
+      accessibility: listing.accessibility,
+      amenities: listing.amenities,
+      applicationDropOffAddressOfficeHours:
+        listing.applicationDropOffAddressOfficeHours,
       applicationPickUpAddressOfficeHours:
         listing.applicationPickUpAddressOfficeHours,
       costsNotIncluded: listing.costsNotIncluded,
       creditHistory: listing.creditHistory,
       criminalBackground: listing.criminalBackground,
+      depositHelperText: listing.depositHelperText,
+      depositMax: listing.depositMax,
+      depositMin: listing.depositMin,
+      leasingAgentOfficeHours: listing.leasingAgentOfficeHours,
+      neighborhood: listing.neighborhood,
+      petPolicy: listing.petPolicy,
       programRules: listing.programRules,
       rentalAssistance: listing.rentalAssistance,
       rentalHistory: listing.rentalHistory,
       requiredDocuments: listing.requiredDocuments,
-      specialNotes: listing.specialNotes,
-      whatToExpect: listing.whatToExpect,
-      accessibility: listing.accessibility,
-      amenities: listing.amenities,
-      neighborhood: listing.neighborhood,
-      petPolicy: listing.petPolicy,
+      reservedCommunityDescription: listing.reservedCommunityDescription,
       servicesOffered: listing.servicesOffered,
       smokingPolicy: listing.smokingPolicy,
+      specialNotes: listing.specialNotes,
       unitAmenities: listing.unitAmenities,
+      whatToExpect: listing.whatToExpect,
     };
+
+    if (listing.referralApplication?.externalReference) {
+      pathsToFilter[`referralApplication.externalReference`] =
+        listing.referralApplication?.externalReference;
+    }
 
     listing.listingEvents?.forEach((_, index) => {
       pathsToFilter[`listingEvents[${index}].note`] =

--- a/api/test/unit/services/translation.service.spec.ts
+++ b/api/test/unit/services/translation.service.spec.ts
@@ -53,24 +53,38 @@ const mockListing = (): Listing => {
   };
   return {
     ...basicListing,
+    whatToExpect: 'untranslated what to expect',
     unitAmenities: 'untranslated unit amenities',
+    specialNotes: 'untranslated special notes',
     smokingPolicy: 'untranslated smoking policy',
     servicesOffered: 'untranslated services offered',
-    petPolicy: 'untranslated pet policy',
-    neighborhood: 'untranslated neighborhood',
-    amenities: 'untranslated amenities',
-    accessibility: 'untranslated accessibility',
-    whatToExpect: 'untranslated what to expect',
-    specialNotes: 'untranslated special notes',
+    reservedCommunityDescription: 'untranslated reserved community description',
     requiredDocuments: 'untranslated required documents',
     rentalHistory: 'untranslated rental history',
     rentalAssistance: 'untranslated rental assistance',
     programRules: 'untranslated program rules',
+    petPolicy: 'untranslated pet policy',
+    neighborhood: 'untranslated neighborhood',
+    leasingAgentOfficeHours: 'untranslated leasing agent office hours',
+    depositMin: 'untranslated deposit minimum',
+    depositMax: 'untranslated deposit maximum',
+    depositHelperText: 'untranslated deposit helper text',
     criminalBackground: 'untranslated criminal background',
     creditHistory: 'untranslated credit history',
     costsNotIncluded: 'untranslated costs not included',
     applicationPickUpAddressOfficeHours:
       'untranslated application pick up address office hours',
+    applicationDropOffAddressOfficeHours:
+      'untranslated application drop off address office hours',
+    amenities: 'untranslated amenities',
+    accessibility: 'untranslated accessibility',
+    referralApplication: {
+      externalReference: 'untranslated external reference',
+      type: 'Referral',
+      id: 'referral application',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
     listingMultiselectQuestions: [
       {
         multiselectQuestions: {
@@ -91,23 +105,30 @@ const mockListing = (): Listing => {
 };
 
 const translatedStrings = [
+  'translated accessibility',
+  'translated amenities',
+  'translated application drop off address office hours',
   'translated application pick up address office hours',
   'translated costs not included',
   'translated credit history',
   'translated criminal background',
+  'translated deposit helper text',
+  'translated deposit maximum',
+  'translated deposit minimum',
+  'translated leasing agent office hours',
+  'translated neighborhood',
+  'translated pet policy',
   'translated program rules',
   'translated rental assistance',
   'translated rental history',
   'translated required documents',
-  'translated special notes',
-  'translated what to expect',
-  'translated accessibility',
-  'translated amenities',
-  'translated neighborhood',
-  'translated pet policy',
+  'translated reserved community description',
   'translated services offered',
   'translated smoking policy',
+  'translated special notes',
   'translated unit amenities',
+  'translated what to expect',
+  'translated external reference',
   'translated multiselect text',
   'translated multiselect description',
   'translated multiselect subtext',
@@ -319,25 +340,42 @@ describe('Testing translations service', () => {
 });
 
 const validateTranslatedFields = (listing: Listing) => {
+  expect(listing.accessibility).toEqual('translated accessibility');
+  expect(listing.amenities).toEqual('translated amenities');
   expect(listing.applicationPickUpAddressOfficeHours).toEqual(
     'translated application pick up address office hours',
+  );
+  expect(listing.applicationDropOffAddressOfficeHours).toEqual(
+    'translated application drop off address office hours',
   );
   expect(listing.costsNotIncluded).toEqual('translated costs not included');
   expect(listing.creditHistory).toEqual('translated credit history');
   expect(listing.criminalBackground).toEqual('translated criminal background');
+  expect(listing.depositHelperText).toEqual('translated deposit helper text');
+  expect(listing.depositMax).toEqual('translated deposit maximum');
+  expect(listing.depositMin).toEqual('translated deposit minimum');
+  expect(listing.leasingAgentOfficeHours).toEqual(
+    'translated leasing agent office hours',
+  );
+  expect(listing.neighborhood).toEqual('translated neighborhood');
+  expect(listing.petPolicy).toEqual('translated pet policy');
   expect(listing.programRules).toEqual('translated program rules');
   expect(listing.rentalAssistance).toEqual('translated rental assistance');
   expect(listing.rentalHistory).toEqual('translated rental history');
   expect(listing.requiredDocuments).toEqual('translated required documents');
-  expect(listing.specialNotes).toEqual('translated special notes');
-  expect(listing.whatToExpect).toEqual('translated what to expect');
-  expect(listing.accessibility).toEqual('translated accessibility');
-  expect(listing.amenities).toEqual('translated amenities');
-  expect(listing.neighborhood).toEqual('translated neighborhood');
-  expect(listing.petPolicy).toEqual('translated pet policy');
+  expect(listing.reservedCommunityDescription).toEqual(
+    'translated reserved community description',
+  );
   expect(listing.servicesOffered).toEqual('translated services offered');
   expect(listing.smokingPolicy).toEqual('translated smoking policy');
+  expect(listing.specialNotes).toEqual('translated special notes');
   expect(listing.unitAmenities).toEqual('translated unit amenities');
+  expect(listing.whatToExpect).toEqual('translated what to expect');
+
+  expect(listing.referralApplication.externalReference).toEqual(
+    'translated external reference',
+  );
+
   expect(
     listing.listingMultiselectQuestions[0].multiselectQuestions.text,
   ).toEqual('translated multiselect text');


### PR DESCRIPTION
This PR addresses [#(672)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/metrotranscom/doorway/672)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Pulling over from core https://github.com/bloom-housing/bloom/pull/4155

## How Can This Be Tested/Reviewed?

Login to the partners portal. Create or update a listing and fill out every single free text field. Publish listing. Find listing on public site. Click through the languages and confirm all text is translated with the exception of proper nouns (names, titles, company names, urls).
## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
