### PR TITLE
fix: improve application submission logic (#4179)

### DIFF
--- a/api/prisma/seed-helpers/listing-factory.ts
+++ b/api/prisma/seed-helpers/listing-factory.ts
@@ -57,9 +57,7 @@ export const listingFactory = async (
     jurisdictionId,
   );
 
-  const digitalApp = !!optionalParams?.digitalApp
-    ? optionalParams.digitalApp
-    : Math.random() < 0.5;
+  const digitalApp = optionalParams?.digitalApp ?? Math.random() < 0.5;
 
   return {
     createdAt: new Date(),

--- a/api/src/services/application.service.ts
+++ b/api/src/services/application.service.ts
@@ -519,10 +519,11 @@ export class ApplicationService {
     if (forPublic) {
       // SubmissionDate is time the application was created for public
       dto.submissionDate = new Date();
-      // if the submission is after the application due date
+      // if there is no common app or submission is after the application due date
       if (
-        listing?.applicationDueDate &&
-        dto.submissionDate > listing.applicationDueDate
+        !(listing.digitalApplication && listing.commonDigitalApplication) ||
+        (listing?.applicationDueDate &&
+          dto.submissionDate > listing.applicationDueDate)
       ) {
         throw new BadRequestException(
           `Listing is not open for application submission`,

--- a/api/test/integration/application.e2e-spec.ts
+++ b/api/test/integration/application.e2e-spec.ts
@@ -349,7 +349,9 @@ describe('Application Controller Tests', () => {
         data: jurisdictionFactory(),
       });
       await reservedCommunityTypeFactoryAll(jurisdiction.id, prisma);
-      const listing1 = await listingFactory(jurisdiction.id, prisma);
+      const listing1 = await listingFactory(jurisdiction.id, prisma, {
+        digitalApp: true,
+      });
       const listing1Created = await prisma.listings.create({
         data: listing1,
       });
@@ -503,6 +505,171 @@ describe('Application Controller Tests', () => {
       expect(mockApplicationConfirmation).toBeCalledTimes(1);
     });
 
+    it('should throw an error when submitting an application from the public site on a listing with no common app', async () => {
+      const unitTypeA = await unitTypeFactorySingle(
+        prisma,
+        UnitTypeEnum.oneBdrm,
+      );
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdiction.id, prisma);
+      const listing1 = await listingFactory(jurisdiction.id, prisma, {
+        digitalApp: false,
+      });
+      const listing1Created = await prisma.listings.create({
+        data: listing1,
+      });
+
+      const multiselectQuestionProgram = await createMultiselectQuestion(
+        jurisdiction.id,
+        listing1Created.id,
+        MultiselectQuestionsApplicationSectionEnum.programs,
+      );
+      const multiselectQuestionPreference = await createMultiselectQuestion(
+        jurisdiction.id,
+        listing1Created.id,
+        MultiselectQuestionsApplicationSectionEnum.preferences,
+      );
+
+      const submissionDate = new Date();
+      const exampleAddress = addressFactory() as AddressCreate;
+      const dto: ApplicationCreate = {
+        contactPreferences: ['example contact preference'],
+        preferences: [
+          {
+            multiselectQuestionId: multiselectQuestionPreference,
+            key: 'example key',
+            claimed: true,
+            options: [
+              {
+                key: 'example key',
+                checked: true,
+                extraData: [
+                  {
+                    type: InputType.boolean,
+                    key: 'example key',
+                    value: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        status: ApplicationStatusEnum.submitted,
+        submissionType: ApplicationSubmissionTypeEnum.electronical,
+        applicant: {
+          firstName: 'applicant first name',
+          middleName: 'applicant middle name',
+          lastName: 'applicant last name',
+          birthMonth: '12',
+          birthDay: '17',
+          birthYear: '1993',
+          emailAddress: 'example@email.com',
+          noEmail: false,
+          phoneNumber: '111-111-1111',
+          phoneNumberType: 'Cell',
+          noPhone: false,
+          workInRegion: YesNoEnum.yes,
+          applicantWorkAddress: exampleAddress,
+          applicantAddress: exampleAddress,
+        },
+        accessibility: {
+          mobility: false,
+          vision: false,
+          hearing: false,
+        },
+        alternateContact: {
+          type: AlternateContactRelationship.friend,
+          otherType: 'example other type',
+          firstName: 'example first name',
+          lastName: 'example last name',
+          agency: 'example agency',
+          phoneNumber: '111-111-1111',
+          emailAddress: 'example@email.com',
+          address: exampleAddress,
+        },
+        applicationsAlternateAddress: exampleAddress,
+        applicationsMailingAddress: exampleAddress,
+        listings: {
+          id: listing1Created.id,
+        },
+        demographics: {
+          ethnicity: 'example ethnicity',
+          gender: 'example gender',
+          sexualOrientation: 'example sexual orientation',
+          howDidYouHear: ['example how did you hear'],
+          race: ['example race'],
+        },
+        preferredUnitTypes: [
+          {
+            id: unitTypeA.id,
+          },
+        ],
+        householdMember: [
+          {
+            orderId: 0,
+            firstName: 'example first name',
+            middleName: 'example middle name',
+            lastName: 'example last name',
+            birthMonth: '12',
+            birthDay: '17',
+            birthYear: '1993',
+            sameAddress: YesNoEnum.yes,
+            relationship: HouseholdMemberRelationship.friend,
+            workInRegion: YesNoEnum.yes,
+            householdMemberWorkAddress: exampleAddress,
+            householdMemberAddress: exampleAddress,
+          },
+        ],
+        appUrl: 'http://www.example.com',
+        additionalPhone: true,
+        additionalPhoneNumber: '111-111-1111',
+        additionalPhoneNumberType: 'example type',
+        householdSize: 2,
+        housingStatus: 'example status',
+        sendMailToMailingAddress: true,
+        householdExpectingChanges: false,
+        householdStudent: false,
+        incomeVouchers: false,
+        income: '36000',
+        incomePeriod: IncomePeriodEnum.perYear,
+        language: LanguagesEnum.en,
+        acceptedTerms: true,
+        submissionDate: submissionDate,
+        reviewStatus: ApplicationReviewStatusEnum.valid,
+        programs: [
+          {
+            multiselectQuestionId: multiselectQuestionProgram,
+            key: 'example key',
+            claimed: true,
+            options: [
+              {
+                key: 'example key',
+                checked: true,
+                extraData: [
+                  {
+                    type: InputType.boolean,
+                    key: 'example key',
+                    value: true,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const res = await request(app.getHttpServer())
+        .post(`/applications/submit`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(dto)
+        .set('Cookie', cookies)
+        .expect(400);
+      expect(res.body.message).toEqual(
+        `Listing is not open for application submission`,
+      );
+    });
+
     it('should calculate geocoding on application', async () => {
       const unitTypeA = await unitTypeFactorySingle(
         prisma,
@@ -514,6 +681,7 @@ describe('Application Controller Tests', () => {
       await reservedCommunityTypeFactoryAll(jurisdiction.id, prisma);
       const exampleAddress = addressFactory() as AddressCreate;
       const listing1 = await listingFactory(jurisdiction.id, prisma, {
+        digitalApp: true,
         listing: {
           listingsBuildingAddress: { create: exampleAddress },
         } as unknown as Prisma.ListingsCreateInput,

--- a/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
@@ -297,7 +297,9 @@ describe('Testing Permissioning of endpoints as Admin User', () => {
         'permission juris 3',
       );
       await reservedCommunityTypeFactoryAll(jurisdiction, prisma);
-      const listing1 = await listingFactory(jurisdiction, prisma);
+      const listing1 = await listingFactory(jurisdiction, prisma, {
+        digitalApp: true,
+      });
       const listing1Created = await prisma.listings.create({
         data: listing1,
       });
@@ -328,7 +330,9 @@ describe('Testing Permissioning of endpoints as Admin User', () => {
         'permission juris 4',
       );
       await reservedCommunityTypeFactoryAll(jurisdiction, prisma);
-      const listing1 = await listingFactory(jurisdiction, prisma);
+      const listing1 = await listingFactory(jurisdiction, prisma, {
+        digitalApp: true,
+      });
       const listing1Created = await prisma.listings.create({
         data: listing1,
       });

--- a/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
@@ -296,7 +296,9 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
         UnitTypeEnum.oneBdrm,
       );
 
-      const listing1 = await listingFactory(jurisId, prisma);
+      const listing1 = await listingFactory(jurisId, prisma, {
+        digitalApp: true,
+      });
       const listing1Created = await prisma.listings.create({
         data: listing1,
       });
@@ -323,7 +325,9 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
         UnitTypeEnum.oneBdrm,
       );
 
-      const listing1 = await listingFactory(jurisId, prisma);
+      const listing1 = await listingFactory(jurisId, prisma, {
+        digitalApp: true,
+      });
       const listing1Created = await prisma.listings.create({
         data: listing1,
       });

--- a/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
@@ -289,7 +289,9 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the wron
         UnitTypeEnum.oneBdrm,
       );
 
-      const listing1 = await listingFactory(jurisId, prisma);
+      const listing1 = await listingFactory(jurisId, prisma, {
+        digitalApp: true,
+      });
       const listing1Created = await prisma.listings.create({
         data: listing1,
       });
@@ -316,7 +318,9 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the wron
         UnitTypeEnum.oneBdrm,
       );
 
-      const listing1 = await listingFactory(jurisId, prisma);
+      const listing1 = await listingFactory(jurisId, prisma, {
+        digitalApp: true,
+      });
       const listing1Created = await prisma.listings.create({
         data: listing1,
       });

--- a/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
@@ -262,7 +262,9 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
         'permission juris 60',
       );
       await reservedCommunityTypeFactoryAll(jurisdiction, prisma);
-      const listing1 = await listingFactory(jurisdiction, prisma);
+      const listing1 = await listingFactory(jurisdiction, prisma, {
+        digitalApp: true,
+      });
       const listing1Created = await prisma.listings.create({
         data: listing1,
       });
@@ -293,7 +295,9 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
         'permission juris 61',
       );
       await reservedCommunityTypeFactoryAll(jurisdiction, prisma);
-      const listing1 = await listingFactory(jurisdiction, prisma);
+      const listing1 = await listingFactory(jurisdiction, prisma, {
+        digitalApp: true,
+      });
       const listing1Created = await prisma.listings.create({
         data: listing1,
       });

--- a/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
@@ -125,6 +125,7 @@ describe('Testing Permissioning of endpoints as partner with correct listing', (
 
     const listingData = await listingFactory(jurisId, prisma, {
       multiselectQuestions: [msq],
+      digitalApp: true,
     });
     const listing = await prisma.listings.create({
       data: listingData,

--- a/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
@@ -125,6 +125,7 @@ describe('Testing Permissioning of endpoints as partner with wrong listing', () 
 
     const listingData = await listingFactory(jurisId, prisma, {
       multiselectQuestions: [msq],
+      digitalApp: true,
     });
     const listing = await prisma.listings.create({
       data: listingData,

--- a/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
@@ -306,7 +306,9 @@ describe('Testing Permissioning of endpoints as public user', () => {
         'permission juris 42',
       );
       await reservedCommunityTypeFactoryAll(jurisdiction, prisma);
-      const listing1 = await listingFactory(jurisdiction, prisma);
+      const listing1 = await listingFactory(jurisdiction, prisma, {
+        digitalApp: true,
+      });
       const listing1Created = await prisma.listings.create({
         data: listing1,
       });
@@ -337,7 +339,9 @@ describe('Testing Permissioning of endpoints as public user', () => {
         'permission juris 43',
       );
       await reservedCommunityTypeFactoryAll(jurisdiction, prisma);
-      const listing1 = await listingFactory(jurisdiction, prisma);
+      const listing1 = await listingFactory(jurisdiction, prisma, {
+        digitalApp: true,
+      });
       const listing1Created = await prisma.listings.create({
         data: listing1,
       });

--- a/sites/public/src/pages/applications/review/summary.tsx
+++ b/sites/public/src/pages/applications/review/summary.tsx
@@ -24,6 +24,7 @@ import { useFormConductor } from "../../../lib/hooks"
 import { UserStatus } from "../../../lib/constants"
 import ApplicationFormLayout from "../../../layouts/application-form"
 import styles from "../../../layouts/application-form.module.scss"
+import dayjs from "dayjs"
 
 const ApplicationSummary = () => {
   const router = useRouter()
@@ -51,8 +52,13 @@ const ApplicationSummary = () => {
 
   useEffect(() => {
     if (listing && router.isReady) {
-      if (listing?.status !== ListingsStatusEnum.active) {
-        addToast(t("listings.applicationsClosedRedirect"), { variant: "alert" })
+      const currentDate = dayjs()
+      if (
+        !(listing.digitalApplication && listing.commonDigitalApplication) ||
+        listing?.status !== ListingsStatusEnum.active ||
+        (listing?.applicationDueDate && currentDate > dayjs(listing.applicationDueDate))
+      ) {
+        // addToast(t("listings.applicationsClosedRedirect"), { variant: "alert" })
         void router.push(`/${router.locale}/listing/${listing?.id}/${listing.urlSlug}`)
       }
     }

--- a/sites/public/src/pages/applications/start/choose-language.tsx
+++ b/sites/public/src/pages/applications/start/choose-language.tsx
@@ -26,6 +26,7 @@ import { useGetApplicationStatusProps } from "../../../lib/hooks"
 import { UserStatus } from "../../../lib/constants"
 import ApplicationFormLayout from "../../../layouts/application-form"
 import styles from "../../../layouts/application-form.module.scss"
+import dayjs from "dayjs"
 
 const loadListing = async (
   listingId,
@@ -86,8 +87,13 @@ const ApplicationChooseLanguage = () => {
 
   useEffect(() => {
     if (listing && router.isReady) {
-      if (listing?.status !== ListingsStatusEnum.active && router.query.preview !== "true") {
-        addToast(t("listings.applicationsClosedRedirect"), { variant: "alert" })
+      const currentDate = dayjs()
+      if (
+        !(listing.digitalApplication && listing.commonDigitalApplication) ||
+        (router?.query?.preview !== "true" && listing?.status !== ListingsStatusEnum.active) ||
+        (listing?.applicationDueDate && currentDate > dayjs(listing.applicationDueDate))
+      ) {
+        // addToast(t("listings.applicationsClosedRedirect"), { variant: "alert" })
         void router.push(`/${router.locale}/listing/${listing?.id}/${listing?.urlSlug}`)
       }
     }


### PR DESCRIPTION
# Pulled over from core
This PR addresses https://github.com/metrotranscom/doorway/issues/698

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the logic on the FE and BE to block application submissions from past due applications and listings that do not have the common application.

Note that these changes collides with a few existing bugs:
1) You'll notice the addToast line is commented out. I discovered a bug while testing this PR that results in infinite re-renders and subsequently, endless toasts. #4181 
![image](https://github.com/bloom-housing/bloom/assets/53269332/956a1f3b-55ee-4228-91af-2073febf9f6e)
2) If you change a listing that had a commonApp and answer no to digitalApp, the commonDigitalApp field remains true. The logic checks for both but I wrote up a ticket here: #4182 
3) application.e2e-spec.ts has significant amounts of duplicate (copy-pasta) code. Particularly in the creation of dtos. Instead, a base dto should be created and the needed unique fields should override that base dto as opposed from creating it from scratch each time. Captured here (#4183) but for now... I am complicit 😞 

## How Can This Be Tested/Reviewed?

This can be tested in the following ways.
1) Start on the choose-language page of a listing that is open for common app
2) Go to the partners portal and edit the listing to have a past due date
3) Go back to the public choose-language page and refresh
4) Notice the redirect
5) Fix the listing to be open again and repeat steps 1-4 but this time setting common app to no in the partners portal
6) Fix the listing to be open again and repeat steps 1-4 but this time setting digital app to no in the partners portal

7) Fix the listing and set the due date to be 2 minutes in the future
8) Fill out the application but wait until the due date is past before hitting the summary page
9) You should be redirected
10) Fix the listing to be open again 
11) Fill out the application until the summary page
12) Before submitting change the listing to have common app or digital app set to no
13) Try submitting and you should get a something went wrong error (matching the pattern of the past due FE behavior

Note that the commonApp/digitalApp redirect on the summary page is hard to test since the listing is saved in sessionStorage from the choose-language screen on but I am keeping it in place to protect against any malicious or unexpected behavior 

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
