### PR TITLE
feat: add Live In Aid as household member relationship

### DIFF
--- a/api/src/enums/applications/household-member-relationship-enum.ts
+++ b/api/src/enums/applications/household-member-relationship-enum.ts
@@ -13,6 +13,6 @@ export enum HouseholdMemberRelationship {
   greatGrandparent = 'greatGrandparent',
   inLaw = 'inLaw',
   friend = 'friend',
-  liveInAid = 'liveInAid',
+  liveInAide = 'liveInAide',
   other = 'other',
 }

--- a/api/src/enums/applications/household-member-relationship-enum.ts
+++ b/api/src/enums/applications/household-member-relationship-enum.ts
@@ -13,5 +13,6 @@ export enum HouseholdMemberRelationship {
   greatGrandparent = 'greatGrandparent',
   inLaw = 'inLaw',
   friend = 'friend',
+  liveInAid = 'liveInAid',
   other = 'other',
 }

--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -171,6 +171,7 @@
   "application.form.options.relationship.grandparent": "Abuelo(a)",
   "application.form.options.relationship.greatGrandparent": "Bisabuelo(a)",
   "application.form.options.relationship.inLaw": "Pariente político",
+  "application.form.options.relationship.liveInAide": "Asistente residente",
   "application.form.options.relationship.nephew": "Sobrino",
   "application.form.options.relationship.niece": "Sobrina",
   "application.form.options.relationship.other": "Otro",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -172,6 +172,7 @@
   "application.form.options.relationship.grandparent": "Grandparent",
   "application.form.options.relationship.greatGrandparent": "Great Grandparent",
   "application.form.options.relationship.inLaw": "In Law",
+  "application.form.options.relationship.liveInAid": "Live in Aid",
   "application.form.options.relationship.nephew": "Nephew",
   "application.form.options.relationship.niece": "Niece",
   "application.form.options.relationship.other": "Other",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -172,7 +172,7 @@
   "application.form.options.relationship.grandparent": "Grandparent",
   "application.form.options.relationship.greatGrandparent": "Great Grandparent",
   "application.form.options.relationship.inLaw": "In Law",
-  "application.form.options.relationship.liveInAid": "Live in Aid",
+  "application.form.options.relationship.liveInAide": "Live-in Aide",
   "application.form.options.relationship.nephew": "Nephew",
   "application.form.options.relationship.niece": "Niece",
   "application.form.options.relationship.other": "Other",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -171,6 +171,7 @@
   "application.form.options.relationship.grandparent": "Lolo o Lola",
   "application.form.options.relationship.greatGrandparent": "Lolo o Lola sa Tuhod",
   "application.form.options.relationship.inLaw": "Biyenan",
+  "application.form.options.relationship.liveInAide": "Live-in Aide",
   "application.form.options.relationship.nephew": "Pamangking Lalaki",
   "application.form.options.relationship.niece": "Pamangking Babae",
   "application.form.options.relationship.other": "Iba pa",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -171,6 +171,7 @@
   "application.form.options.relationship.grandparent": "Ông/bà",
   "application.form.options.relationship.greatGrandparent": "Cụ ông/cụ bà",
   "application.form.options.relationship.inLaw": "Bố/mẹ chồng/vợ",
+  "application.form.options.relationship.liveInAide": "Trợ lý nội trú",
   "application.form.options.relationship.nephew": "Cháu trai",
   "application.form.options.relationship.niece": "Cháu gái",
   "application.form.options.relationship.other": "Khác",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -171,6 +171,7 @@
   "application.form.options.relationship.grandparent": "祖父母／外祖父母",
   "application.form.options.relationship.greatGrandparent": "曾祖父母／外曾祖父母",
   "application.form.options.relationship.inLaw": "姻親",
+  "application.form.options.relationship.liveInAide": "住家助理",
   "application.form.options.relationship.nephew": "侄子／外甥",
   "application.form.options.relationship.niece": "侄女／外甥女",
   "application.form.options.relationship.other": "其他",

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -5698,7 +5698,7 @@ export enum HouseholdMemberRelationship {
   "greatGrandparent" = "greatGrandparent",
   "inLaw" = "inLaw",
   "friend" = "friend",
-  "liveInAid" = "liveInAid",
+  "liveInAide" = "liveInAide",
   "other" = "other",
 }
 export type AllExtraDataTypes = BooleanInput | TextInput | AddressInput

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -5698,6 +5698,7 @@ export enum HouseholdMemberRelationship {
   "greatGrandparent" = "greatGrandparent",
   "inLaw" = "inLaw",
   "friend" = "friend",
+  "liveInAid" = "liveInAid",
   "other" = "other",
 }
 export type AllExtraDataTypes = BooleanInput | TextInput | AddressInput


### PR DESCRIPTION
This PR addresses https://github.com/bloom-housing/bloom/issues/4266

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds a "Live-in Aide" option for household members (note that we decided it should be "Live-in Aide" rather than "Live in Aid").

Also note Google Translate for Filipino just gave "Live-in Aide" so maybe there's not a native term for it (or it doesn't know about one).

## How Can This Be Tested/Reviewed?

Fill out an online application and verify you can submit Live-in Aide as an option for a household member.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
