### PR TITLE
fix: change "begin" to language name

### DIFF
--- a/sites/public/src/pages/applications/start/choose-language.tsx
+++ b/sites/public/src/pages/applications/start/choose-language.tsx
@@ -165,7 +165,7 @@ const ApplicationChooseLanguage = () => {
                   key={index}
                   id={"app-choose-language-button"}
                 >
-                  {t(`applications.begin.${lang}`)}
+                  {t(`languages.${lang}`)}
                 </Button>
               ))}
             </>


### PR DESCRIPTION
This PR addresses #(insert-number-here)
https://github.com/bloom-housing/bloom/issues/4257

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Changes begin word to language name. 
I left unused "begin" translations, not sure if that's correct.

## How Can This Be Tested/Reviewed?

go to application 1st step, now it will show languages

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
