### PR TITLE
release: listing duplication endpoint

### DIFF
--- a/api/.env.template
+++ b/api/.env.template
@@ -44,6 +44,8 @@ LOTTERY_PUBLISH_PROCESSING_CRON_STRING=58 23 * * *
 LOTTERY_PROCESSING_CRON_STRING=0 * * * *
 # how many days till lottery data expires
 LOTTERY_DAYS_TILL_EXPIRY=45
+# allow partners and jadmins to create duplicate listings
+ALLOW_PARTNERS_TO_DUPLICATE_LISTINGS=FALSE
 # the list of allowed urls that can make requests to the api (strings must be exact matches)
 CORS_ORIGINS=["http://localhost:3000", "http://localhost:3001"]
 # spill over list of allowed urls that can make requests to the api (strings are turned into regex)

--- a/api/src/controllers/listing.controller.ts
+++ b/api/src/controllers/listing.controller.ts
@@ -32,6 +32,7 @@ import { PermissionAction } from '../decorators/permission-action.decorator';
 import { PermissionTypeDecorator } from '../decorators/permission-type.decorator';
 import Listing from '../dtos/listings/listing.dto';
 import { ListingCreate } from '../dtos/listings/listing-create.dto';
+import { ListingDuplicate } from '../dtos/listings/listing-duplicate.dto';
 import { ListingCsvQueryParams } from '../dtos/listings/listing-csv-query-params.dto';
 import { ListingFilterParams } from '../dtos/listings/listings-filter-params.dto';
 import { ListingsQueryParams } from '../dtos/listings/listings-query-params.dto';
@@ -154,6 +155,19 @@ export class ListingController {
       listingDto,
       mapTo(User, req['user']),
     );
+  }
+
+  @Post('duplicate')
+  @ApiOperation({ summary: 'Duplicate listing', operationId: 'duplicate' })
+  @UseInterceptors(ClassSerializerInterceptor)
+  @UsePipes(new ListingCreateUpdateValidationPipe(defaultValidationPipeOptions))
+  @ApiOkResponse({ type: Listing })
+  @UseGuards(ApiKeyGuard)
+  async duplicate(
+    @Request() req: ExpressRequest,
+    @Body() dto: ListingDuplicate,
+  ): Promise<Listing> {
+    return await this.listingService.duplicate(dto, mapTo(User, req['user']));
   }
 
   @Delete()

--- a/api/src/dtos/listings/listing-duplicate.dto.ts
+++ b/api/src/dtos/listings/listing-duplicate.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose, Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsDefined,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+import { IdDTO } from '../shared/id.dto';
+
+export class ListingDuplicate {
+  @Expose()
+  @ApiProperty()
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  name: string;
+
+  @Expose()
+  @ApiProperty()
+  @IsBoolean({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  includeUnits: boolean;
+
+  @Expose()
+  @ApiProperty()
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => IdDTO)
+  storedListing: IdDTO;
+}

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -1,6 +1,5 @@
 import {
   BadRequestException,
-  ForbiddenException,
   HttpException,
   Inject,
   Injectable,

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -13,6 +13,7 @@ import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import {
   LanguagesEnum,
+  ListingEventsTypeEnum,
   ListingsStatusEnum,
   LotteryStatusEnum,
   Prisma,
@@ -28,6 +29,7 @@ import { TranslationService } from './translation.service';
 import { AmiChart } from '../dtos/ami-charts/ami-chart.dto';
 import { Listing } from '../dtos/listings/listing.dto';
 import { ListingCreate } from '../dtos/listings/listing-create.dto';
+import { ListingDuplicate } from '../dtos/listings/listing-duplicate.dto';
 import { ListingFilterParams } from '../dtos/listings/listings-filter-params.dto';
 import { ListingLotteryStatus } from '../dtos/listings/listing-lottery-status.dto';
 import { ListingsQueryParams } from '../dtos/listings/listings-query-params.dto';
@@ -963,6 +965,104 @@ export class ListingService implements OnModuleInit {
     }
     await this.cachePurge(undefined, dto.status, rawListing.id);
     return mapTo(Listing, rawListing);
+  }
+
+  async duplicate(
+    dto: ListingDuplicate,
+    requestingUser: User,
+  ): Promise<Listing> {
+    const storedListing = await this.findOrThrow(
+      dto.storedListing.id,
+      ListingViews.details,
+    );
+    if (dto.name.trim() === storedListing.name) {
+      throw new BadRequestException('New listing name must be unique');
+    }
+
+    const userRoles =
+      process.env.ALLOW_PARTNERS_TO_DUPLICATE_LISTINGS === 'TRUE' &&
+      (requestingUser?.userRoles?.isJurisdictionalAdmin ||
+        requestingUser?.userRoles?.isPartner)
+        ? {
+            ...requestingUser.userRoles,
+            isAdmin: true,
+          }
+        : requestingUser?.userRoles;
+
+    await this.permissionService.canOrThrow(
+      { ...requestingUser, userRoles: userRoles },
+      'listing',
+      permissionActions.create,
+      {
+        jurisdictionId: storedListing.jurisdictions.id,
+      },
+    );
+
+    const mappedListing = mapTo(ListingCreate, storedListing);
+
+    const listingEvents = mappedListing.listingEvents?.filter(
+      (event) => event.type !== ListingEventsTypeEnum.lotteryResults,
+    );
+
+    const listingImages = mappedListing.listingImages?.map((unsavedImage) => ({
+      assets: {
+        fileId: unsavedImage.assets.fileId,
+        label: unsavedImage.assets.label,
+      },
+      ordinal: unsavedImage.ordinal,
+    }));
+
+    if (!dto.includeUnits) {
+      delete mappedListing['units'];
+    }
+
+    const newListingData: ListingCreate = {
+      ...mappedListing,
+      name: dto.name,
+      status: ListingsStatusEnum.pending,
+      listingEvents: listingEvents,
+      listingMultiselectQuestions:
+        storedListing.listingMultiselectQuestions?.map((question) => ({
+          id: question.multiselectQuestionId,
+          ordinal: question.ordinal,
+        })),
+      listingImages: listingImages,
+      lotteryLastRunAt: undefined,
+      lotteryLastPublishedAt: undefined,
+      lotteryStatus: undefined,
+    };
+
+    const res = await this.create(newListingData, {
+      ...requestingUser,
+      userRoles: userRoles,
+    });
+
+    if (
+      process.env.ALLOW_PARTNERS_TO_DUPLICATE_LISTINGS === 'TRUE' &&
+      requestingUser.userRoles?.isPartner
+    ) {
+      await this.prisma.userAccounts.update({
+        data: {
+          listings: {
+            connect: { id: res.id },
+          },
+        },
+        where: {
+          id: requestingUser.id,
+        },
+      });
+
+      await this.prisma.activityLog.create({
+        data: {
+          module: 'user',
+          recordId: requestingUser.id,
+          action: 'update',
+          userAccounts: { connect: { id: requestingUser.id } },
+        },
+      });
+    }
+
+    return res;
   }
 
   /*

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -95,7 +95,7 @@ export class LotteryService {
       this.prisma,
       LOTTERY_PUBLISH_CRON_JOB_NAME,
       process.env.LOTTERY_PUBLISH_PROCESSING_CRON_STRING,
-      this.expireLotteries.bind(this),
+      this.autoPublishResults.bind(this),
       this.logger,
       this.schedulerRegistry,
     );

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -661,6 +661,75 @@ describe('Listing Controller Tests', () => {
     });
   });
 
+  describe('duplicate endpoint', () => {
+    it('should duplicate listing, include units', async () => {
+      const jurisdictionA = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdictionA.id, prisma);
+      const listingData = await listingFactory(jurisdictionA.id, prisma, {
+        numberOfUnits: 2,
+      });
+      const listing = await prisma.listings.create({
+        data: listingData,
+        include: {
+          units: true,
+        },
+      });
+
+      const newName = 'duplicate name 1';
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/duplicate')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          includeUnits: true,
+          name: newName,
+          storedListing: {
+            id: listing.id,
+          },
+        })
+        .set('Cookie', adminAccessToken)
+        .expect(201);
+
+      expect(res.body.name).toEqual(newName);
+      expect(res.body.units.length).toBe(listing.units.length);
+    });
+
+    it('should duplicate listing, exclude units', async () => {
+      const jurisdictionA = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdictionA.id, prisma);
+      const listingData = await listingFactory(jurisdictionA.id, prisma, {
+        numberOfUnits: 2,
+      });
+      const listing = await prisma.listings.create({
+        data: listingData,
+        include: {
+          units: true,
+        },
+      });
+      const newName = 'duplicate name 2';
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/duplicate')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          includeUnits: false,
+          name: newName,
+          storedListing: {
+            id: listing.id,
+          },
+        })
+        .set('Cookie', adminAccessToken)
+        .expect(201);
+
+      expect(res.body.name).toEqual(newName);
+      expect(res.body.units).toEqual([]);
+    });
+  });
+
   describe('process endpoint', () => {
     it('should successfully process listings that are past due', async () => {
       const jurisdictionA = await prisma.jurisdictions.create({

--- a/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
@@ -1272,6 +1272,42 @@ describe('Testing Permissioning of endpoints as Admin User', () => {
       expect(activityLogResult).not.toBeNull();
     });
 
+    it('should succeed for duplicate endpoint & create an activity log entry', async () => {
+      const jurisdictionA = await generateJurisdiction(
+        prisma,
+        'permission juris 180',
+      );
+      await reservedCommunityTypeFactoryAll(jurisdictionA, prisma);
+
+      const listingData = await listingFactory(jurisdictionA, prisma);
+      const listing = await prisma.listings.create({
+        data: listingData,
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/duplicate')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          includeUnits: true,
+          name: 'name',
+          storedListing: {
+            id: listing.id,
+          },
+        })
+        .set('Cookie', cookies)
+        .expect(201);
+
+      const activityLogResult = await prisma.activityLog.findFirst({
+        where: {
+          module: 'listing',
+          action: permissionActions.create,
+          recordId: res.body.id,
+        },
+      });
+
+      expect(activityLogResult).not.toBeNull();
+    });
+
     it('should succeed for process endpoint', async () => {
       await request(app.getHttpServer())
         .put(`/listings/closeListings`)

--- a/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
@@ -1161,6 +1161,32 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
       expect(activityLogResult).not.toBeNull();
     });
 
+    it('should error as forbidden for duplicate endpoint', async () => {
+      const jurisdictionA = await generateJurisdiction(
+        prisma,
+        'permission juris 181',
+      );
+      await reservedCommunityTypeFactoryAll(jurisdictionA, prisma);
+
+      const listingData = await listingFactory(jurisdictionA, prisma);
+      const listing = await prisma.listings.create({
+        data: listingData,
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/duplicate')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          includeUnits: true,
+          name: 'name',
+          storedListing: {
+            id: listing.id,
+          },
+        })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
     it('should succeed for process endpoint', async () => {
       await request(app.getHttpServer())
         .put(`/listings/closeListings`)

--- a/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
@@ -1095,6 +1095,32 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the wron
         .expect(403);
     });
 
+    it('should error as forbidden for duplicate endpoint', async () => {
+      const jurisdictionA = await generateJurisdiction(
+        prisma,
+        'permission juris 182',
+      );
+      await reservedCommunityTypeFactoryAll(jurisdictionA, prisma);
+
+      const listingData = await listingFactory(jurisdictionA, prisma);
+      const listing = await prisma.listings.create({
+        data: listingData,
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/duplicate')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          includeUnits: true,
+          name: 'name',
+          storedListing: {
+            id: listing.id,
+          },
+        })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
     it('should succeed for process endpoint', async () => {
       await request(app.getHttpServer())
         .put(`/listings/closeListings`)

--- a/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
@@ -1118,6 +1118,32 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
         .expect(403);
     });
 
+    it('should error as forbidden for duplicate endpoint', async () => {
+      const jurisdictionA = await generateJurisdiction(
+        prisma,
+        'permission juris 183',
+      );
+      await reservedCommunityTypeFactoryAll(jurisdictionA, prisma);
+
+      const listingData = await listingFactory(jurisdictionA, prisma);
+      const listing = await prisma.listings.create({
+        data: listingData,
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/duplicate')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          includeUnits: true,
+          name: 'name',
+          storedListing: {
+            id: listing.id,
+          },
+        })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
     it('should error as forbidden for process endpoint', async () => {
       await request(app.getHttpServer())
         .put(`/listings/closeListings`)

--- a/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
@@ -1100,6 +1100,32 @@ describe('Testing Permissioning of endpoints as partner with correct listing', (
         .expect(403);
     });
 
+    it('should error as forbidden for duplicate endpoint', async () => {
+      const jurisdictionA = await generateJurisdiction(
+        prisma,
+        'permission juris 184',
+      );
+      await reservedCommunityTypeFactoryAll(jurisdictionA, prisma);
+
+      const listingData = await listingFactory(jurisdictionA, prisma);
+      const listing = await prisma.listings.create({
+        data: listingData,
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/duplicate')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          includeUnits: true,
+          name: 'name',
+          storedListing: {
+            id: listing.id,
+          },
+        })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
     it('should error as forbidden for process endpoint', async () => {
       await request(app.getHttpServer())
         .put(`/listings/closeListings`)

--- a/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
@@ -1056,6 +1056,32 @@ describe('Testing Permissioning of endpoints as partner with wrong listing', () 
         .expect(403);
     });
 
+    it('should error as forbidden for duplicate endpoint', async () => {
+      const jurisdictionA = await generateJurisdiction(
+        prisma,
+        'permission juris 185',
+      );
+      await reservedCommunityTypeFactoryAll(jurisdictionA, prisma);
+
+      const listingData = await listingFactory(jurisdictionA, prisma);
+      const listing = await prisma.listings.create({
+        data: listingData,
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/duplicate')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          includeUnits: true,
+          name: 'name',
+          storedListing: {
+            id: listing.id,
+          },
+        })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
     it('should error as forbidden for process endpoint', async () => {
       await request(app.getHttpServer())
         .put(`/listings/closeListings`)

--- a/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
@@ -1171,6 +1171,32 @@ describe('Testing Permissioning of endpoints as public user', () => {
         .expect(403);
     });
 
+    it('should error as forbidden for duplicate endpoint', async () => {
+      const jurisdictionA = await generateJurisdiction(
+        prisma,
+        'permission juris 186',
+      );
+      await reservedCommunityTypeFactoryAll(jurisdictionA, prisma);
+
+      const listingData = await listingFactory(jurisdictionA, prisma);
+      const listing = await prisma.listings.create({
+        data: listingData,
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/duplicate')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          includeUnits: true,
+          name: 'name',
+          storedListing: {
+            id: listing.id,
+          },
+        })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
     it('should error as forbidden for process endpoint', async () => {
       await request(app.getHttpServer())
         .put(`/listings/closeListings`)

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -2134,6 +2134,274 @@ describe('Testing listing service', () => {
     });
   });
 
+  describe('Test duplicate endpoint', () => {
+    it('should duplicate a listing, including units', async () => {
+      const listing = mockListing(1, { numberToMake: 2, date: new Date() });
+
+      const newName = 'duplicate name';
+
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        ...listing,
+        jurisdictions: {
+          id: randomUUID(),
+        },
+      });
+
+      prisma.listings.create = jest.fn().mockResolvedValue({
+        ...listing,
+        id: 'duplicate id',
+        name: newName,
+      });
+
+      const newListing = await service.duplicate(
+        {
+          includeUnits: true,
+          name: newName,
+          storedListing: {
+            id: listing.id.toString(),
+          },
+        },
+        user,
+      );
+
+      expect(newListing.name).toBe(newName);
+      expect(newListing.units).toEqual(listing.units);
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: listing.id.toString(),
+        },
+        include: {
+          applicationMethods: {
+            include: {
+              paperApplications: {
+                include: {
+                  assets: true,
+                },
+              },
+            },
+          },
+          jurisdictions: true,
+          listingEvents: {
+            include: {
+              assets: true,
+            },
+          },
+          listingFeatures: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingUtilities: true,
+          listingsApplicationDropOffAddress: true,
+          listingsApplicationPickUpAddress: true,
+          listingsBuildingAddress: true,
+          listingsBuildingSelectionCriteriaFile: true,
+          listingsApplicationMailingAddress: true,
+          listingsLeasingAgentAddress: true,
+          listingsResult: true,
+          requestedChangesUser: true,
+          reservedCommunityTypes: true,
+          units: {
+            include: {
+              amiChart: {
+                include: {
+                  jurisdictions: true,
+                  unitGroupAmiLevels: true,
+                },
+              },
+              unitAccessibilityPriorityTypes: true,
+              unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
+            },
+          },
+        },
+      });
+    });
+
+    it('should duplicate a listing, excluding units', async () => {
+      const listing = mockListing(1, { numberToMake: 2, date: new Date() });
+
+      const newName = 'duplicate name';
+
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        ...listing,
+        jurisdictions: {
+          id: randomUUID(),
+        },
+      });
+
+      prisma.listings.create = jest.fn().mockResolvedValue({
+        ...listing,
+        id: 'duplicate id',
+        name: newName,
+        units: [],
+      });
+
+      const newListing = await service.duplicate(
+        {
+          includeUnits: false,
+          name: newName,
+          storedListing: {
+            id: listing.id.toString(),
+          },
+        },
+        user,
+      );
+
+      expect(newListing.name).toBe(newName);
+      expect(newListing.units).toEqual([]);
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: listing.id.toString(),
+        },
+        include: {
+          applicationMethods: {
+            include: {
+              paperApplications: {
+                include: {
+                  assets: true,
+                },
+              },
+            },
+          },
+          jurisdictions: true,
+          listingEvents: {
+            include: {
+              assets: true,
+            },
+          },
+          listingFeatures: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingUtilities: true,
+          listingsApplicationDropOffAddress: true,
+          listingsApplicationPickUpAddress: true,
+          listingsBuildingAddress: true,
+          listingsBuildingSelectionCriteriaFile: true,
+          listingsApplicationMailingAddress: true,
+          listingsLeasingAgentAddress: true,
+          listingsResult: true,
+          requestedChangesUser: true,
+          reservedCommunityTypes: true,
+          units: {
+            include: {
+              amiChart: {
+                include: {
+                  jurisdictions: true,
+                  unitGroupAmiLevels: true,
+                },
+              },
+              unitAccessibilityPriorityTypes: true,
+              unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
+            },
+          },
+        },
+      });
+    });
+
+    it('should fail to duplicate a listing with the same name', async () => {
+      const listing = mockListing(1, { numberToMake: 2, date: new Date() });
+
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        ...listing,
+        jurisdictions: {
+          id: randomUUID(),
+        },
+      });
+
+      await expect(
+        async () =>
+          await service.duplicate(
+            {
+              includeUnits: false,
+              name: listing.name,
+              storedListing: {
+                id: listing.id.toString(),
+              },
+            },
+            user,
+          ),
+      ).rejects.toThrowError();
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: listing.id.toString(),
+        },
+        include: {
+          applicationMethods: {
+            include: {
+              paperApplications: {
+                include: {
+                  assets: true,
+                },
+              },
+            },
+          },
+          jurisdictions: true,
+          listingEvents: {
+            include: {
+              assets: true,
+            },
+          },
+          listingFeatures: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingUtilities: true,
+          listingsApplicationDropOffAddress: true,
+          listingsApplicationPickUpAddress: true,
+          listingsBuildingAddress: true,
+          listingsBuildingSelectionCriteriaFile: true,
+          listingsApplicationMailingAddress: true,
+          listingsLeasingAgentAddress: true,
+          listingsResult: true,
+          requestedChangesUser: true,
+          reservedCommunityTypes: true,
+          units: {
+            include: {
+              amiChart: {
+                include: {
+                  jurisdictions: true,
+                  unitGroupAmiLevels: true,
+                },
+              },
+              unitAccessibilityPriorityTypes: true,
+              unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
+            },
+          },
+        },
+      });
+    });
+  });
+
   describe('Test delete endpoint', () => {
     it('should delete a listing', async () => {
       const id = randomUUID();

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -810,7 +810,7 @@ describe('Testing lottery service', () => {
   });
 
   describe('Test autoPublishResults endpoint', () => {
-    it('should call the updateMany', async () => {
+    it('should call the update', async () => {
       prisma.listings.findMany = jest.fn().mockResolvedValue([
         {
           id: 'example id1',

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -330,6 +330,28 @@ export class ListingsService {
     })
   }
   /**
+   * Duplicate listing
+   */
+  duplicate(
+    params: {
+      /** requestBody */
+      body?: ListingDuplicate
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<Listing> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/listings/duplicate"
+
+      const configs: IRequestConfig = getConfigs("post", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
    * Trigger the listing process job
    */
   process(options: IRequestOptions = {}): Promise<SuccessDTO> {
@@ -3772,6 +3794,17 @@ export interface ListingCreate {
 
   /**  */
   requestedChangesUser?: IdDTO
+}
+
+export interface ListingDuplicate {
+  /**  */
+  name: string
+
+  /**  */
+  includeUnits: boolean
+
+  /**  */
+  storedListing: IdDTO
 }
 
 export interface ListingUpdate {


### PR DESCRIPTION
This PR addresses [#(799)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/metrotranscom/doorway/799)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description
Releases:
https://github.com/bloom-housing/bloom/pull/4313
https://github.com/bloom-housing/bloom/pull/4307
https://github.com/bloom-housing/bloom/pull/4314

## How Can This Be Tested/Reviewed?

Run partner portal and api and login as a admin user.
Have the listing id for the listing you would like to duplicate.
Fill out the payload for listings/duplicate. Set storedListing.id to the above.
Cases:

Set name to a unique name, set includeUnits to true. Should create a new draft listing with the name given which is otherwise identical to the original listing, including the units.
Set name to a unique name, set includeUnits to false. Should create a new draft listing with the name given which is otherwise identical to the original listing, excluding the units.
Set name to a the same name as the original listing. Should error with 400 BadRequest and a message 'New listing name must be unique'.
You can view the newly created in the Partners Portal

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
