### PR TITLE
fix: add releaseDate to partner card (#4315)(release)

### DIFF
--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -197,6 +197,10 @@ const Lottery = (props: { listing: Listing | undefined }) => {
         (event) => event.type === ListingEventsTypeEnum.publicLottery
       )
       if (listing.lotteryStatus === LotteryStatusEnum.releasedToPartners) {
+        // reverse array to find most recent release date
+        const lotteryReleaseDate = lotteryActivityLogData
+          ?.reverse()
+          ?.find((logItem) => logItem.status === LotteryStatusEnum.releasedToPartners)?.logDate
         return (
           <CardSection>
             <Icon size="xl">
@@ -210,8 +214,8 @@ const Lottery = (props: { listing: Listing | undefined }) => {
               <p>
                 {t("listings.lottery.partnerPublishTimestamp", {
                   adminName: t("listings.lottery.partnerPublishTimestampAdmin"),
-                  date: "DATE",
-                  time: "TIME",
+                  date: dayjs(lotteryReleaseDate).format("MM/DD/YYYY"),
+                  time: dayjs(lotteryReleaseDate).format("h:mm a"),
                   portal: t("listings.lottery.partnerPublishTimestampPortal"),
                 })}
               </p>


### PR DESCRIPTION
This PR addresses #4300 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR completes an outstanding todo to include the releaseDate in the partners messaging seen in the issue description. It also handles the case of releasing and retracting by finding the most recent release date.

## How Can This Be Tested/Reviewed?

This can be tested by creating a lottery listing as an admin and releasing that lottery. Then as a partner user see the date and time reflected in the lottery publish card. You can also test retracting and releasing the lottery to see the time updated.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
