### PR TITLE
release: history log fix

### DIFF
--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -959,13 +959,19 @@ export class LotteryService {
         updatedAt: OrderByEnum.ASC,
       },
     });
+
+    let previouslyActive = true;
     const filteredActivityLogs = activityLogs.filter((log) => {
       const logString = JSON.stringify(log.metadata);
       // only return closed listing status updates
       if (logString.includes('status')) {
-        if (logString.includes(ListingsStatusEnum.closed)) {
+        if (logString.includes(ListingsStatusEnum.closed) && previouslyActive) {
+          previouslyActive = false;
           return true;
-        } else return false;
+        } else if (logString.includes(ListingsStatusEnum.active)) {
+          previouslyActive = true;
+        }
+        return false;
       }
       return true;
     });

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -1057,6 +1057,8 @@ describe('Testing lottery service', () => {
       },
     } as User;
 
+    const openedDate = new Date();
+    openedDate.setDate(openedDate.getDate() - 11);
     const closedDate = new Date();
     closedDate.setDate(closedDate.getDate() - 10);
     const ranDate = new Date();
@@ -1076,8 +1078,24 @@ describe('Testing lottery service', () => {
       canOrThrowMock.mockResolvedValue(true);
       prisma.activityLog.findMany = jest.fn().mockResolvedValue([
         {
+          metadata: { status: 'active' },
+          updatedAt: openedDate,
+          userAccounts: {
+            firstName: 'Abc',
+            lastName: 'Def',
+          },
+        },
+        {
           metadata: { status: 'closed' },
           updatedAt: closedDate,
+          userAccounts: {
+            firstName: 'Abc',
+            lastName: 'Def',
+          },
+        },
+        {
+          metadata: { status: 'closed' },
+          updatedAt: ranDate,
           userAccounts: {
             firstName: 'Abc',
             lastName: 'Def',


### PR DESCRIPTION
This PR addresses [#(4310)](https://github.com/bloom-housing/bloom/issues/4310)

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Releases [fix: history log fix](https://github.com/bloom-housing/bloom/pull/4353)

## How Can This Be Tested/Reviewed?

For a lottery listing, close the listing and check it it appears in the history log. Make a change and save it to the listing, a new log should not be present. Reopen the listing, close the listing again, a new log should appear. All lottery related logs should still function as expected.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
