### PR TITLE
fix: remove opt out preferences from export and lottery (#4351)

### DIFF
--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -156,6 +156,7 @@ export const stagingSeed = async (
   });
   const workInCityQuestion = await prismaClient.multiselectQuestions.create({
     data: multiselectQuestionFactory(jurisdiction.id, {
+      optOut: true,
       multiselectQuestion: {
         text: 'Work in the city',
         description: 'At least one member of my household works in the city',

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -242,21 +242,28 @@ export class LotteryService {
     );
 
     // loop over each preference on the listing and store the relative position of the applications
-    for (let i = 0; i < preferencesOnListing.length; i++) {
-      const { id, text } = preferencesOnListing[i];
+    for (const preferenceOnListing of preferencesOnListing) {
+      const { id, text, optOutText } = preferenceOnListing;
 
       const applicationsWithThisPreference: Application[] = [];
       const ordinalArrayWithThisPreference: number[] = [];
 
       // filter down to only the applications that have this particular preference
       let preferenceOrdinal = 1;
-      for (let j = 0; j < filteredApplications.length; j++) {
+      for (const filteredApplication of filteredApplications) {
+        const foundPreference = filteredApplication.preferences.find(
+          (preference) => preference.key === text && preference.claimed,
+        );
         if (
-          filteredApplications[j].preferences.some(
-            (preference) => preference.key === text && preference.claimed,
-          )
+          foundPreference?.claimed &&
+          // if at least one option is checked it should not be the same as the opt out text
+          (!foundPreference.options?.length ||
+            foundPreference.options.some(
+              (preference) =>
+                preference.checked === true && preference.key !== optOutText,
+            ))
         ) {
-          applicationsWithThisPreference.push(filteredApplications[j]);
+          applicationsWithThisPreference.push(filteredApplication);
           ordinalArrayWithThisPreference.push(preferenceOrdinal);
           preferenceOrdinal++;
         }

--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -346,6 +346,8 @@ export const constructMultiselectQuestionHeaders = (
         format: (val: any): string => {
           const claimedString: string[] = [];
           val?.options?.forEach((option) => {
+            // Note: the option can be the opt out text so if it is checked
+            // the opt out text will appear. That is intended behavior
             if (option.checked) {
               claimedString.push(option.key);
             }

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -209,6 +209,7 @@ describe('Testing lottery service', () => {
         {
           id: randomUUID(),
           text: 'example text',
+          options: [],
         } as unknown as MultiselectQuestion,
       ];
       for (let i = 0; i < 10; i++) {
@@ -219,6 +220,7 @@ describe('Testing lottery service', () => {
             {
               key: 'example text',
               claimed: i % 2 === 0,
+              options: [{ key: 'example option', checked: i % 2 === 0 }],
             },
           ],
         } as unknown as Application);
@@ -265,6 +267,68 @@ describe('Testing lottery service', () => {
 
       expect(prisma.applicationLotteryPositions.createMany).toBeCalledTimes(2);
       expect(prisma.applicationLotteryTotal.create).toBeCalledTimes(2);
+    });
+
+    it('should not store preference ordinal if opted out', async () => {
+      const listingId = randomUUID();
+      const applications: Application[] = [];
+      const preferences: MultiselectQuestion[] = [
+        {
+          id: randomUUID(),
+          text: 'example text',
+          optOutText: 'opt out text',
+          options: [{ key: 'example option' }],
+        } as unknown as MultiselectQuestion,
+      ];
+      applications.push({
+        id: randomUUID(),
+        markedAsDuplicate: false,
+        preferences: [
+          {
+            key: 'example text',
+            claimed: true,
+            options: [
+              {
+                key: 'example option',
+                checked: false,
+              },
+              {
+                key: 'opt out text',
+                checked: true,
+              },
+            ],
+          },
+        ],
+      } as unknown as Application);
+
+      prisma.applicationLotteryPositions.createMany = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
+      prisma.applicationLotteryTotal.create = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
+      await service.lotteryRandomizer(listingId, applications, preferences);
+
+      const args = (prisma.applicationLotteryPositions.createMany as any).mock
+        .calls[0][0].data;
+
+      expect(args[0]).toEqual({
+        listingId,
+        applicationId: expect.anything(),
+        ordinal: 1,
+        multiselectQuestionId: null,
+      });
+
+      const argsWithPreference = (
+        prisma.applicationLotteryPositions.createMany as any
+      ).mock.calls[1];
+
+      expect(argsWithPreference).toBeUndefined();
+
+      expect(prisma.applicationLotteryPositions.createMany).toBeCalledTimes(1);
+      expect(prisma.applicationLotteryTotal.create).toBeCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
Pulls in Commit from core for issue #4282

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

Can test using the same steps as found here: https://github.com/bloom-housing/bloom/pull/4351