### PR TITLE
feat: correction script for sparks homes application preferences

### DIFF
--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -152,4 +152,19 @@ export class ScirptRunnerController {
   ): Promise<SuccessDTO> {
     return await this.scriptRunnerService.updateCodeExpirationTranslations(req);
   }
+
+  @Put('correctApplicationPreferenceDataForSparksHomes')
+  @ApiOperation({
+    summary:
+      'A script that updates the preference keys for applications on Spark Homes',
+    operationId: 'correctApplicationPreferenceDataForSparksHomes',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  async correctApplicationPreferenceDataForSparksHomes(
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.scriptRunnerService.correctApplicationPreferenceDataForSparksHomes(
+      req,
+    );
+  }
 }

--- a/api/src/modules/script-runner.module.ts
+++ b/api/src/modules/script-runner.module.ts
@@ -5,16 +5,9 @@ import { PrismaModule } from './prisma.module';
 import { PermissionModule } from './permission.module';
 import { EmailModule } from './email.module';
 import { AmiChartModule } from './ami-chart.module';
-import { ApplicationModule } from './application.module';
 
 @Module({
-  imports: [
-    PrismaModule,
-    PermissionModule,
-    EmailModule,
-    AmiChartModule,
-    ApplicationModule,
-  ],
+  imports: [PrismaModule, PermissionModule, EmailModule, AmiChartModule],
   controllers: [ScirptRunnerController],
   providers: [ScriptRunnerService],
   exports: [ScriptRunnerService],

--- a/api/src/modules/script-runner.module.ts
+++ b/api/src/modules/script-runner.module.ts
@@ -5,9 +5,16 @@ import { PrismaModule } from './prisma.module';
 import { PermissionModule } from './permission.module';
 import { EmailModule } from './email.module';
 import { AmiChartModule } from './ami-chart.module';
+import { ApplicationModule } from './application.module';
 
 @Module({
-  imports: [PrismaModule, PermissionModule, EmailModule, AmiChartModule],
+  imports: [
+    PrismaModule,
+    PermissionModule,
+    EmailModule,
+    AmiChartModule,
+    ApplicationModule,
+  ],
   controllers: [ScirptRunnerController],
   providers: [ScriptRunnerService],
   exports: [ScriptRunnerService],

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -17,7 +17,6 @@ import { Application } from '../dtos/applications/application.dto';
 import { AmiChartImportDTO } from '../dtos/script-runner/ami-chart-import.dto';
 import { AmiChartCreate } from '../dtos/ami-charts/ami-chart-create.dto';
 import { AmiChartService } from './ami-chart.service';
-import { ApplicationService } from './application.service';
 
 /**
   this is the service for running scripts
@@ -29,7 +28,6 @@ export class ScriptRunnerService {
     private prisma: PrismaService,
     private emailService: EmailService,
     private amiChartService: AmiChartService,
-    private applicationService: ApplicationService,
   ) {}
 
   /**
@@ -519,10 +517,13 @@ export class ScriptRunnerService {
       requestingUser,
     );
 
-    const applications = await this.applicationService.list(
-      { listingId: 'a055ce66-a074-4f3a-b67b-6776bec9926e' },
-      req,
-    );
+    const applications = await this.prisma.applications.findMany({
+      select: {
+        id: true,
+        preferences: true,
+      },
+      where: { listingId: 'a055ce66-a074-4f3a-b67b-6776bec9926e' },
+    });
 
     const options = [
       {
@@ -535,7 +536,8 @@ export class ScriptRunnerService {
       },
     ];
 
-    applications.items.forEach(async (applicaiton) => {
+    console.log(`Updating ${applications.length} applications`);
+    for (const applicaiton of applications) {
       const blob = applicaiton.preferences;
 
       const preference = blob[0];
@@ -562,7 +564,7 @@ export class ScriptRunnerService {
           id: applicaiton.id,
         },
       });
-    });
+    }
 
     await this.markScriptAsComplete(
       'Correct application preference data for Sparks Homes',

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -12,9 +12,6 @@ import { PrismaService } from '../../../src/services/prisma.service';
 import { User } from '../../../src/dtos/users/user.dto';
 import { EmailService } from '../../../src/services/email.service';
 import { AmiChartService } from '../../../src/services/ami-chart.service';
-import { ApplicationService } from '../../../src/services/application.service';
-import { GeocodingService } from '../../../src/services/geocoding.service';
-import { PermissionService } from '../../../src/services/permission.service';
 
 const externalPrismaClient = mockDeep<PrismaClient>();
 
@@ -35,9 +32,6 @@ describe('Testing script runner service', () => {
           },
         },
         AmiChartService,
-        ApplicationService,
-        GeocodingService,
-        PermissionService,
       ],
     }).compile();
 

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2168,28 +2168,6 @@ export class ScriptRunnerService {
     })
   }
   /**
-   * A script that creates a new reserved community type
-   */
-  createNewReservedCommunityType(
-    params: {
-      /** requestBody */
-      body?: IdDTO
-    } = {} as any,
-    options: IRequestOptions = {}
-  ): Promise<SuccessDTO> {
-    return new Promise((resolve, reject) => {
-      let url = basePath + "/scriptRunner/createNewReservedCommunityType"
-
-      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
-
-      let data = params.body
-
-      configs.data = data
-
-      axios(configs, resolve, reject)
-    })
-  }
-  /**
    * A script that takes in a standardized string and outputs the input for the ami chart create endpoint
    */
   amiChartImport(
@@ -2249,6 +2227,62 @@ export class ScriptRunnerService {
   optOutExistingLotteries(options: IRequestOptions = {}): Promise<SuccessDTO> {
     return new Promise((resolve, reject) => {
       let url = basePath + "/scriptRunner/optOutExistingLotteries"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = null
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * A script that creates a new reserved community type
+   */
+  createNewReservedCommunityType(
+    params: {
+      /** requestBody */
+      body?: CommunityTypeDTO
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/createNewReservedCommunityType"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * A script that updates single use code translations to show extended expiration time
+   */
+  updateCodeExpirationTranslations(options: IRequestOptions = {}): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/updateCodeExpirationTranslations"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = null
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * A script that updates the preference keys for applications on Spark Homes
+   */
+  correctApplicationPreferenceDataForSparksHomes(
+    options: IRequestOptions = {}
+  ): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/correctApplicationPreferenceDataForSparksHomes"
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
@@ -5855,6 +5889,17 @@ export interface AmiChartImportDTO {
 
   /**  */
   jurisdictionId: string
+}
+
+export interface CommunityTypeDTO {
+  /**  */
+  id: string
+
+  /**  */
+  name: string
+
+  /**  */
+  description?: string
 }
 
 export interface ApplicationCsvQueryParams {


### PR DESCRIPTION
This PR addresses [#(794)](https://github.com/housingbayarea/bloom/issues/794)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Script collects the existing applications to Sparks Homes and updates the preferences jsonb for each application with corrected options strings.

## How Can This Be Tested/Reviewed?

Pull down prob db copy from Heroku and setup locally.
Check the preferences field for applications associated with listing id 'a055ce66-a074-4f3a-b67b-6776bec9926e'
Start app, sign in as an admin through partner portal or api.
Through the api, call `/scriptRunner/correctApplicationPreferenceDataForSparksHomes`.
Check the preferences field for applications associated with listing id 'a055ce66-a074-4f3a-b67b-6776bec9926e'
and assert update worked.

query:
`SELECT preferences
FROM applications
WHERE listing_id='a055ce66-a074-4f3a-b67b-6776bec9926e';`

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
