### PR TITLE
fix: remove smc references in footers

### DIFF
--- a/sites/public/src/page_content/jurisdiction_overrides/alameda/jurisdiction-footer-section.tsx
+++ b/sites/public/src/page_content/jurisdiction_overrides/alameda/jurisdiction-footer-section.tsx
@@ -30,10 +30,6 @@ export const JurisdictionFooterSection = () => {
             {t("footer.SFHousingPortal")}
           </a>
           |
-          <a className="px-2" href={t("footer.SMCHousingUrl")} target="_blank" rel="noreferrer">
-            {t("footer.SMCHousingPortal")}
-          </a>
-          |
           <a className="px-2" href={t("footer.SJHousingUrl")} target="_blank" rel="noreferrer">
             {t("footer.SJHousingPortal")}
           </a>

--- a/sites/public/src/page_content/jurisdiction_overrides/san_jose/jurisdiction-footer-section.tsx
+++ b/sites/public/src/page_content/jurisdiction_overrides/san_jose/jurisdiction-footer-section.tsx
@@ -45,15 +45,6 @@ export const JurisdictionFooterSection = () => {
             {t("footer.SFHousingPortal")}
           </a>
           |
-          <a
-            className="px-2"
-            href="https://smc.housingbayarea.org/"
-            target="_blank"
-            rel="noreferrer"
-          >
-            {t("footer.SMPortal")}
-          </a>
-          |
           <a className="px-2" href="https://housing.acgov.org/" target="_blank" rel="noreferrer">
             {t("footer.ACPortal")}
           </a>


### PR DESCRIPTION
This PR addresses #4456

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

This removes the links to SMC site on both Alameda and San Jose

## How Can This Be Tested/Reviewed?

- Start up public site with jurisdiction set to `Alameda`
  - No link to SMC should be on the footer
- Start up public site with jurisdiction set to `San Jose`
  - No link to SMC should be on the footer


## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
