### PR TITLE
feat: [GenAI] new listing gen ai export endpoint

### DIFF
--- a/api/src/controllers/listing.controller.ts
+++ b/api/src/controllers/listing.controller.ts
@@ -105,6 +105,26 @@ export class ListingController {
     return await this.listingCsvExportService.exportFile(req, res, queryParams);
   }
 
+  @Get(`gen-ai-export`)
+  @ApiOperation({
+    summary: 'Listing export for gen-ai',
+    operationId: 'genAIExport',
+  })
+  @Header('Content-Type', 'application/zip')
+  @UseGuards(ApiKeyGuard, OptionalAuthGuard, PermissionGuard)
+  async genAIExport(
+    @Request() req: ExpressRequest,
+    @Res({ passthrough: true }) res: Response,
+    @Query(new ValidationPipe(defaultValidationPipeOptions))
+    queryParams: ListingCsvQueryParams,
+  ): Promise<StreamableFile> {
+    return await this.listingCsvExportService.genAIExport(
+      req,
+      res,
+      queryParams,
+    );
+  }
+
   @Get('mapMarkers')
   @ApiOperation({
     summary: 'Get listing map markers',

--- a/api/src/dtos/listings/listing-csv-query-params.dto.ts
+++ b/api/src/dtos/listings/listing-csv-query-params.dto.ts
@@ -1,6 +1,6 @@
 import { Expose } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
 
 export class ListingCsvQueryParams {
@@ -13,4 +13,11 @@ export class ListingCsvQueryParams {
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   timeZone?: string;
+
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
+  @ApiPropertyOptional()
+  jurisdictionId?: string;
 }

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -242,6 +242,8 @@ export class ListingsService {
     params: {
       /**  */
       timeZone?: string
+      /**  */
+      jurisdictionId?: string
     } = {} as any,
     options: IRequestOptions = {}
   ): Promise<any> {
@@ -249,7 +251,30 @@ export class ListingsService {
       let url = basePath + "/listings/csv"
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-      configs.params = { timeZone: params["timeZone"] }
+      configs.params = { timeZone: params["timeZone"], jurisdictionId: params["jurisdictionId"] }
+
+      /** 适配ios13，get请求不允许带body */
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Listing export for gen-ai
+   */
+  genAiExport(
+    params: {
+      /**  */
+      timeZone?: string
+      /**  */
+      jurisdictionId?: string
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<any> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/listings/gen-ai-export"
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
+      configs.params = { timeZone: params["timeZone"], jurisdictionId: params["jurisdictionId"] }
 
       /** 适配ios13，get请求不允许带body */
 
@@ -2311,7 +2336,6 @@ export class ScriptRunnerService {
       axios(configs, resolve, reject)
     })
   }
-
   /**
    * A script that updates the preference keys for applications on Spark Homes
    */
@@ -5938,7 +5962,6 @@ export interface AmiChartImportDTO {
   /**  */
   jurisdictionId: string
 }
-
 
 export interface AmiChartUpdateImportDTO {
   /**  */


### PR DESCRIPTION
This PR addresses https://github.com/bloom-housing/bloom/issues/4470

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description
This creates a new GenAI export endpoint that does exactly what the listing csv export does in terms of listings and units but adds an additional csv in the zip for the ami chart data 

## How Can This Be Tested/Reviewed?

Provide instructions so we can review, including any needed configuration, and the test cases that need to be QAd.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
