### PR TITLE
fix: reduce the view for user edit

### DIFF
--- a/sites/partners/src/lib/hooks.ts
+++ b/sites/partners/src/lib/hooks.ts
@@ -50,6 +50,7 @@ type UseListingsDataProps = PaginationProps & {
   sort?: ColumnOrder[]
   roles?: UserRole
   userJurisidctionIds?: string[]
+  view?: ListingViews
 }
 
 export function useSingleListingData(listingId: string) {
@@ -73,6 +74,7 @@ export function useListingsData({
   sort,
   roles,
   userJurisidctionIds,
+  view,
 }: UseListingsDataProps) {
   const params = {
     page,

--- a/sites/partners/src/pages/users/index.tsx
+++ b/sites/partners/src/pages/users/index.tsx
@@ -3,7 +3,7 @@ import Head from "next/head"
 import dayjs from "dayjs"
 import { useSWRConfig } from "swr"
 import { AgTable, useAgTable, t, AlertBox } from "@bloom-housing/ui-components"
-import { User } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { ListingViews, User } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { Button, Icon } from "@bloom-housing/ui-seeds"
 import { AuthContext } from "@bloom-housing/shared-helpers"
 import Layout from "../../layouts"
@@ -113,6 +113,7 @@ const Users = () => {
 
   const { listingDtos } = useListingsData({
     limit: "all",
+    view: ListingViews.fundamentals,
   })
 
   if (error) return <div>{t("t.errorOccurred")}</div>


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When attempting to edit a user we do a call to get a list of all of the listings. This is for the displaying of the listing checkboxes. However, there are now too many listings in HBA and the response is too big for Netlify to return. This is an extra big response because we are returning way more values of the listings than what is needed. 

This PR changes the requested view from "base" to "fundamentals" so units data is not returned.

Long term we should also create a view that only has ids and names.

## How Can This Be Tested/Reviewed?

Editing a partner user should still work


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
