### PR TITLE
fix: publishedAt on create (#4479)

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -895,6 +895,8 @@ export class ListingService implements OnModuleInit {
             }
           : undefined,
         requestedChangesUser: undefined,
+        publishedAt:
+          dto.status === ListingsStatusEnum.active ? new Date() : undefined,
         contentUpdatedAt: new Date(),
         copyOf: copyOfId
           ? {

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -1895,6 +1895,7 @@ describe('Testing listing service', () => {
         data: {
           ...val,
           contentUpdatedAt: expect.anything(),
+          publishedAt: expect.anything(),
           assets: {
             create: [exampleAsset],
           },


### PR DESCRIPTION
This PR addresses #773 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

During Qa, it was discovered that the publishedAt date was showing as none for many open listings. This was because we were not covering the case where a user publishes a listing from scratch, never first saving it as a draft.

## How Can This Be Tested/Reviewed?

Create a listing from scratch and publish it without saving it as a draft. In the partner's listing table, you should see today's date.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
