### PR TITLE
fix: handle copying app methods (#4491)

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -999,6 +999,21 @@ export class ListingService implements OnModuleInit {
       ordinal: unsavedImage.ordinal,
     }));
 
+    const applicationMethods = mappedListing.applicationMethods?.map(
+      (applicationMethod) => ({
+        ...applicationMethod,
+        paperApplications: applicationMethod.paperApplications?.map(
+          (paperApplication) => ({
+            ...paperApplication,
+            assets: {
+              fileId: paperApplication.assets.fileId,
+              label: paperApplication.assets.label,
+            },
+          }),
+        ),
+      }),
+    );
+
     if (!dto.includeUnits) {
       delete mappedListing['units'];
     }
@@ -1015,6 +1030,7 @@ export class ListingService implements OnModuleInit {
           ordinal: question.ordinal,
         })),
       listingImages: listingImages,
+      applicationMethods: applicationMethods,
       lotteryLastRunAt: undefined,
       lotteryLastPublishedAt: undefined,
       lotteryStatus: undefined,


### PR DESCRIPTION
This PR addresses #4490
- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the duplicate function in the listing service to transform the application methods array to how the listing create function expects it. 

## How Can This Be Tested/Reviewed?

Test copying a listing with no paper app, paper app selected but not uploaded, one paper app, multiple paper apps... and ensure that the listing and assets are copied over without error.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
