### PR TITLE
release: feature flag consumption (#4489)

### DIFF
--- a/api/prisma/seed-helpers/feature-flag-factory.ts
+++ b/api/prisma/seed-helpers/feature-flag-factory.ts
@@ -1,0 +1,23 @@
+import { Prisma } from '@prisma/client';
+import { randomBoolean } from './boolean-generator';
+import { randomAdjective, randomName } from './word-generator';
+
+export const featureFlagFactory = (
+  name = randomName(),
+  active = randomBoolean(),
+  description = `${randomAdjective()} feature flag`,
+  jurisdictionIds?: string[],
+): Prisma.FeatureFlagsCreateInput => ({
+  name: name,
+  description: description,
+  active: active,
+  jurisdictions: jurisdictionIds
+    ? {
+        connect: jurisdictionIds.map((jurisdiction) => {
+          return {
+            id: jurisdiction,
+          };
+        }),
+      }
+    : undefined,
+});

--- a/api/src/controllers/feature-flag.controller.ts
+++ b/api/src/controllers/feature-flag.controller.ts
@@ -1,0 +1,110 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Put,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import {
+  ApiExtraModels,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { FeatureFlagService } from '../services/feature-flag.service';
+import { FeatureFlag } from '../dtos/feature-flags/feature-flag.dto';
+import { FeatureFlagAssociate } from '../dtos/feature-flags/feature-flag-associate.dto';
+import { FeatureFlagCreate } from '../dtos/feature-flags/feature-flag-create.dto';
+import { FeatureFlagUpdate } from '../dtos/feature-flags/feature-flag-update.dto';
+import { defaultValidationPipeOptions } from '../utilities/default-validation-pipe-options';
+import { IdDTO } from '../dtos/shared/id.dto';
+import { SuccessDTO } from '../dtos/shared/success.dto';
+import { PermissionTypeDecorator } from '../decorators/permission-type.decorator';
+import { OptionalAuthGuard } from '../guards/optional.guard';
+import { PermissionGuard } from '../guards/permission.guard';
+import { ApiKeyGuard } from '../guards/api-key.guard';
+
+@Controller('featureFlags')
+@ApiTags('featureFlags')
+@UsePipes(new ValidationPipe(defaultValidationPipeOptions))
+@ApiExtraModels(
+  FeatureFlagAssociate,
+  FeatureFlagCreate,
+  FeatureFlagUpdate,
+  IdDTO,
+)
+@PermissionTypeDecorator('featureFlags')
+@UseGuards(ApiKeyGuard, OptionalAuthGuard, PermissionGuard)
+export class FeatureFlagController {
+  constructor(private readonly featureFlagService: FeatureFlagService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List of feature flags', operationId: 'list' })
+  @ApiOkResponse({ type: FeatureFlag, isArray: true })
+  async list(): Promise<FeatureFlag[]> {
+    return await this.featureFlagService.list();
+  }
+
+  @Post()
+  @ApiOperation({
+    summary: 'Create a feature flag',
+    operationId: 'create',
+  })
+  @ApiOkResponse({ type: FeatureFlag })
+  async create(@Body() featureFlag: FeatureFlagCreate): Promise<FeatureFlag> {
+    return await this.featureFlagService.create(featureFlag);
+  }
+
+  @Put()
+  @ApiOperation({
+    summary: 'Update a feature flag',
+    operationId: 'update',
+  })
+  @ApiOkResponse({ type: FeatureFlag })
+  async update(@Body() featureFlag: FeatureFlagUpdate): Promise<FeatureFlag> {
+    return await this.featureFlagService.update(featureFlag);
+  }
+
+  @Delete()
+  @ApiOperation({
+    summary: 'Delete a feature flag by id',
+    operationId: 'delete',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  async delete(@Body() dto: IdDTO): Promise<SuccessDTO> {
+    return await this.featureFlagService.delete(dto.id);
+  }
+
+  @Put(`associateJurisdictions`)
+  @ApiOperation({
+    summary: 'Associate and disassociate jurisdictions with a feature flag',
+    operationId: 'associateJurisdictions',
+  })
+  @ApiOkResponse({ type: FeatureFlag })
+  async associateJurisdictions(
+    @Body() featureFlagAssociate: FeatureFlagAssociate,
+  ): Promise<FeatureFlag> {
+    return await this.featureFlagService.associateJurisdictions(
+      featureFlagAssociate,
+    );
+  }
+
+  @Get(`:featureFlagId`)
+  @ApiOperation({
+    summary: 'Get a feature flag by id',
+    operationId: 'retrieve',
+  })
+  @ApiOkResponse({ type: FeatureFlag })
+  async retrieve(
+    @Param('featureFlagId', new ParseUUIDPipe({ version: '4' }))
+    featureFlagId: string,
+  ): Promise<FeatureFlag> {
+    return this.featureFlagService.findOne(featureFlagId);
+  }
+}

--- a/api/src/dtos/feature-flags/feature-flag-associate.dto.ts
+++ b/api/src/dtos/feature-flags/feature-flag-associate.dto.ts
@@ -1,0 +1,31 @@
+import { Expose } from 'class-transformer';
+import { IsArray, IsDefined, IsString, IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class FeatureFlagAssociate {
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  id: string;
+
+  @Expose()
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, {
+    groups: [ValidationsGroupsEnum.default],
+    each: true,
+  })
+  @ApiProperty()
+  associate: string[];
+
+  @Expose()
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, {
+    groups: [ValidationsGroupsEnum.default],
+    each: true,
+  })
+  @ApiProperty()
+  remove: string[];
+}

--- a/api/src/dtos/feature-flags/feature-flag-create.dto.ts
+++ b/api/src/dtos/feature-flags/feature-flag-create.dto.ts
@@ -1,0 +1,4 @@
+import { OmitType } from '@nestjs/swagger';
+import { FeatureFlagUpdate } from './feature-flag-update.dto';
+
+export class FeatureFlagCreate extends OmitType(FeatureFlagUpdate, ['id']) {}

--- a/api/src/dtos/feature-flags/feature-flag-update.dto.ts
+++ b/api/src/dtos/feature-flags/feature-flag-update.dto.ts
@@ -1,0 +1,8 @@
+import { OmitType } from '@nestjs/swagger';
+import { FeatureFlag } from './feature-flag.dto';
+
+export class FeatureFlagUpdate extends OmitType(FeatureFlag, [
+  'createdAt',
+  'updatedAt',
+  'jurisdictions',
+]) {}

--- a/api/src/dtos/feature-flags/feature-flag.dto.ts
+++ b/api/src/dtos/feature-flags/feature-flag.dto.ts
@@ -1,0 +1,39 @@
+import { Expose, Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsDefined,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { AbstractDTO } from '../shared/abstract.dto';
+import { IdDTO } from '../shared/id.dto';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class FeatureFlag extends AbstractDTO {
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @MaxLength(256, { groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  name: string;
+
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  description: string;
+
+  @Expose()
+  @IsBoolean({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  active: boolean;
+
+  @Expose()
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
+  @Type(() => IdDTO)
+  @ApiProperty({ type: IdDTO, isArray: true })
+  jurisdictions: IdDTO[];
+}

--- a/api/src/dtos/jurisdictions/jurisdiction-update.dto.ts
+++ b/api/src/dtos/jurisdictions/jurisdiction-update.dto.ts
@@ -4,5 +4,6 @@ import { Jurisdiction } from './jurisdiction.dto';
 export class JurisdictionUpdate extends OmitType(Jurisdiction, [
   'createdAt',
   'updatedAt',
+  'featureFlags',
   'multiselectQuestions',
 ]) {}

--- a/api/src/dtos/jurisdictions/jurisdiction.dto.ts
+++ b/api/src/dtos/jurisdictions/jurisdiction.dto.ts
@@ -1,4 +1,4 @@
-import { AbstractDTO } from '../shared/abstract.dto';
+import { Expose, Type } from 'class-transformer';
 import {
   IsString,
   MaxLength,
@@ -9,11 +9,12 @@ import {
   ValidateNested,
   IsBoolean,
 } from 'class-validator';
-import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
-import { LanguagesEnum, UserRoleEnum } from '@prisma/client';
-import { Expose, Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { LanguagesEnum, UserRoleEnum } from '@prisma/client';
+import { FeatureFlag } from '../feature-flags/feature-flag.dto';
+import { AbstractDTO } from '../shared/abstract.dto';
 import { IdDTO } from '../shared/id.dto';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
 
 export class Jurisdiction extends AbstractDTO {
   @Expose()
@@ -140,4 +141,11 @@ export class Jurisdiction extends AbstractDTO {
     isArray: true,
   })
   duplicateListingPermissions: UserRoleEnum[];
+
+  @Expose()
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => FeatureFlag)
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty({ type: FeatureFlag, isArray: true })
+  featureFlags: FeatureFlag[];
 }

--- a/api/src/modules/app.module.ts
+++ b/api/src/modules/app.module.ts
@@ -22,6 +22,7 @@ import { ThrottlerModule } from '@nestjs/throttler';
 import { ThrottleGuard } from '../guards/throttler.guard';
 import { ScirptRunnerModule } from './script-runner.module';
 import { LotteryModule } from './lottery.module';
+import { FeatureFlagModule } from './feature-flag.module';
 
 @Module({
   imports: [
@@ -42,6 +43,7 @@ import { LotteryModule } from './lottery.module';
     MapLayerModule,
     ScirptRunnerModule,
     LotteryModule,
+    FeatureFlagModule,
     ThrottlerModule.forRoot([
       {
         ttl: Number(process.env.THROTTLE_TTL),
@@ -77,6 +79,7 @@ import { LotteryModule } from './lottery.module';
     MapLayerModule,
     ScirptRunnerModule,
     LotteryModule,
+    FeatureFlagModule,
   ],
 })
 export class AppModule {}

--- a/api/src/modules/feature-flag.module.ts
+++ b/api/src/modules/feature-flag.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { FeatureFlagController } from '../controllers/feature-flag.controller';
+import { FeatureFlagService } from '../services/feature-flag.service';
+import { JurisdictionModule } from './jurisdiction.module';
+import { PermissionModule } from './permission.module';
+import { PrismaModule } from './prisma.module';
+
+@Module({
+  imports: [JurisdictionModule, PermissionModule, PrismaModule],
+  controllers: [FeatureFlagController],
+  providers: [FeatureFlagService],
+  exports: [FeatureFlagService],
+})
+export class FeatureFlagModule {}

--- a/api/src/permission-configs/permission_policy.csv
+++ b/api/src/permission-configs/permission_policy.csv
@@ -81,6 +81,8 @@ p, partner, paperApplication, true, read
 p, admin, mapLayers, true, .*
 p, jurisdictionAdmin, mapLayers, true, .*
 
+p, admin, featureFlags, true, .*
+
 g, admin, jurisdictionAdmin
 g, jurisdictionAdmin, partner
 g, partner, user

--- a/api/src/services/feature-flag.service.ts
+++ b/api/src/services/feature-flag.service.ts
@@ -1,0 +1,207 @@
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import { JurisdictionService } from './jurisdiction.service';
+import { PrismaService } from './prisma.service';
+import { FeatureFlag } from '../dtos/feature-flags/feature-flag.dto';
+import { FeatureFlagAssociate } from '../dtos/feature-flags/feature-flag-associate.dto';
+import { FeatureFlagCreate } from '../dtos/feature-flags/feature-flag-create.dto';
+import { FeatureFlagUpdate } from '../dtos/feature-flags/feature-flag-update.dto';
+import { SuccessDTO } from '../dtos/shared/success.dto';
+import { mapTo } from '../utilities/mapTo';
+
+/**
+      this is the service for feature flags
+      it handles all the backend's business logic for reading/writing/deleting feature flag data
+    */
+@Injectable()
+export class FeatureFlagService {
+  constructor(
+    private prisma: PrismaService,
+    private jurisdictionService: JurisdictionService,
+  ) {}
+
+  /**
+        this will get a set of feature flags
+      */
+  async list(): Promise<FeatureFlag[]> {
+    const rawfeatureFlags = await this.prisma.featureFlags.findMany({
+      include: {
+        jurisdictions: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+    return mapTo(FeatureFlag, rawfeatureFlags);
+  }
+
+  /*
+        this will return 1 feature flag or error
+      */
+  async findOne(featureFlagId: string): Promise<FeatureFlag> {
+    if (!featureFlagId) {
+      throw new BadRequestException('a feature flag id must be provided');
+    }
+
+    const rawFeatureFlag = await this.prisma.featureFlags.findFirst({
+      include: {
+        jurisdictions: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      where: {
+        id: featureFlagId,
+      },
+    });
+
+    if (!rawFeatureFlag) {
+      throw new NotFoundException(
+        `feature flag id ${featureFlagId} was requested but not found`,
+      );
+    }
+
+    return mapTo(FeatureFlag, rawFeatureFlag);
+  }
+
+  /*
+        this will create a feature flag
+      */
+  async create(dto: FeatureFlagCreate): Promise<FeatureFlag> {
+    const rawResult = await this.prisma.featureFlags.create({
+      data: {
+        ...dto,
+      },
+      include: {
+        jurisdictions: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return mapTo(FeatureFlag, rawResult);
+  }
+
+  /*
+        this will update a feature flag's name or description field
+        if no feature flag has the id of the incoming argument an error is thrown
+      */
+  async update(dto: FeatureFlagUpdate): Promise<FeatureFlag> {
+    await this.findOrThrow(dto.id);
+
+    const rawResults = await this.prisma.featureFlags.update({
+      data: {
+        ...dto,
+        id: undefined,
+      },
+      include: {
+        jurisdictions: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      where: {
+        id: dto.id,
+      },
+    });
+    return mapTo(FeatureFlag, rawResults);
+  }
+
+  /*
+        this will delete a feature flag
+      */
+  async delete(featureFlagId: string): Promise<SuccessDTO> {
+    await this.findOrThrow(featureFlagId);
+    await this.prisma.featureFlags.delete({
+      where: {
+        id: featureFlagId,
+      },
+    });
+    return {
+      success: true,
+    } as SuccessDTO;
+  }
+
+  /*
+        this will either find a record or throw a customized error
+      */
+  async findOrThrow(featureFlagId: string): Promise<boolean> {
+    const featureFlag = await this.prisma.featureFlags.findFirst({
+      where: {
+        id: featureFlagId,
+      },
+    });
+
+    if (!featureFlag) {
+      throw new NotFoundException(
+        `feature flag id ${featureFlagId} was requested but not found`,
+      );
+    }
+
+    return true;
+  }
+
+  async associateJurisdictions(
+    dto: FeatureFlagAssociate,
+  ): Promise<FeatureFlag> {
+    await this.findOrThrow(dto.id);
+
+    const idsToAssociateSet = new Set(dto.associate);
+
+    dto.remove.forEach((id) => {
+      if (idsToAssociateSet.has(id)) {
+        // Remove the item from the set
+        idsToAssociateSet.delete(id);
+      }
+    });
+
+    const idsToAssociate = [...idsToAssociateSet];
+
+    for (const id of idsToAssociate) {
+      try {
+        await this.jurisdictionService.findOrThrow(id);
+      } catch (e) {
+        throw new BadRequestException(
+          `jurisdiction id ${id} was requested for association but not found`,
+        );
+      }
+    }
+
+    const rawResults = await this.prisma.featureFlags.update({
+      data: {
+        jurisdictions: {
+          connect: idsToAssociate.map((id) => {
+            return { id: id };
+          }),
+          disconnect: dto.remove.map((id) => {
+            return { id: id };
+          }),
+        },
+      },
+      include: {
+        jurisdictions: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      where: {
+        id: dto.id,
+      },
+    });
+    return mapTo(FeatureFlag, rawResults);
+  }
+}

--- a/api/src/services/jurisdiction.service.ts
+++ b/api/src/services/jurisdiction.service.ts
@@ -12,6 +12,7 @@ import { Prisma } from '@prisma/client';
 import { JurisdictionUpdate } from '../dtos/jurisdictions/jurisdiction-update.dto';
 
 const view: Prisma.JurisdictionsInclude = {
+  featureFlags: true,
   multiselectQuestions: true,
 };
 /**

--- a/api/test/integration/feature-flag.e2e-spec.ts
+++ b/api/test/integration/feature-flag.e2e-spec.ts
@@ -1,0 +1,314 @@
+import cookieParser from 'cookie-parser';
+import { randomUUID } from 'crypto';
+import request from 'supertest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { AppModule } from '../../src/modules/app.module';
+import { PrismaService } from '../../src/services/prisma.service';
+import { featureFlagFactory } from '../../prisma/seed-helpers/feature-flag-factory';
+import { jurisdictionFactory } from '../../prisma/seed-helpers/jurisdiction-factory';
+import { randomName } from '../../prisma/seed-helpers/word-generator';
+import { userFactory } from '../../prisma/seed-helpers/user-factory';
+import { Login } from '../../src/dtos/auth/login.dto';
+
+describe('Feature Flag Controller Tests', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let adminAccessToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    prisma = moduleFixture.get<PrismaService>(PrismaService);
+    app.use(cookieParser());
+    await app.init();
+
+    const storedUser = await prisma.userAccounts.create({
+      data: await userFactory({
+        roles: { isAdmin: true },
+        mfaEnabled: false,
+        confirmedAt: new Date(),
+      }),
+    });
+    const resLogIn = await request(app.getHttpServer())
+      .post('/auth/login')
+      .set({ passkey: process.env.API_PASS_KEY || '' })
+      .send({
+        email: storedUser.email,
+        password: 'Abcdef12345!',
+      } as Login)
+      .expect(201);
+    adminAccessToken = resLogIn.header?.['set-cookie'].find((cookie) =>
+      cookie.startsWith('access-token='),
+    );
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await app.close();
+  });
+
+  describe('list endpoint', () => {
+    it('should return all existing feature flags', async () => {
+      const featureFlagA = await prisma.featureFlags.create({
+        data: featureFlagFactory(),
+      });
+      const featureFlagB = await prisma.featureFlags.create({
+        data: featureFlagFactory(),
+      });
+
+      const res = await request(app.getHttpServer())
+        .get(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+
+      expect(res.body.length).toBeGreaterThanOrEqual(2);
+      const featureFlags = res.body.map((value) => value.name);
+      expect(featureFlags).toContain(featureFlagA.name);
+      expect(featureFlags).toContain(featureFlagB.name);
+    });
+  });
+
+  describe('create endpoint', () => {
+    it('should create a feature flag', async () => {
+      const body = {
+        name: randomName(),
+        description: 'new description',
+        active: true,
+      };
+
+      const res = await request(app.getHttpServer())
+        .post(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
+        .set('Cookie', adminAccessToken)
+        .expect(201);
+
+      expect(res.body).toEqual({
+        ...body,
+        jurisdictions: [],
+        id: expect.anything(),
+        createdAt: expect.anything(),
+        updatedAt: expect.anything(),
+      });
+    });
+  });
+
+  describe('update endpoint', () => {
+    it('should update an existing feature flag', async () => {
+      const featureFlag = await prisma.featureFlags.create({
+        data: featureFlagFactory(),
+      });
+
+      const body = {
+        id: featureFlag.id,
+        name: `updated ${randomName()}`,
+        description: 'updated description',
+        active: !featureFlag.active,
+      };
+
+      const res = await request(app.getHttpServer())
+        .put(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+
+      expect(res.body).toEqual({
+        ...body,
+        jurisdictions: [],
+        createdAt: expect.anything(),
+        updatedAt: expect.anything(),
+      });
+    });
+
+    it('should error when trying to update a feature flag that does not exist', async () => {
+      const body = {
+        id: randomUUID(),
+        name: 'updated name',
+        description: 'updated description',
+        active: true,
+      };
+
+      const res = await request(app.getHttpServer())
+        .put(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
+        .set('Cookie', adminAccessToken)
+        .expect(404);
+
+      expect(res.body.message).toEqual(
+        `feature flag id ${body.id} was requested but not found`,
+      );
+    });
+  });
+
+  describe('delete endpoint', () => {
+    it('should delete an existing feature flag', async () => {
+      const featureFlag = await prisma.featureFlags.create({
+        data: featureFlagFactory(),
+      });
+
+      const res = await request(app.getHttpServer())
+        .delete(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({ id: featureFlag.id })
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+
+      const featureFlagAfterDelete = await prisma.featureFlags.findUnique({
+        where: { id: featureFlag.id },
+      });
+      expect(featureFlagAfterDelete).toBeNull();
+      expect(res.body.success).toEqual(true);
+    });
+
+    it('should error when trying to delete a feature flag that does not exist', async () => {
+      const id = randomUUID();
+
+      const res = await request(app.getHttpServer())
+        .delete(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({ id: id })
+        .set('Cookie', adminAccessToken)
+        .expect(404);
+
+      expect(res.body.message).toEqual(
+        `feature flag id ${id} was requested but not found`,
+      );
+    });
+  });
+
+  describe('associateJurisdictions endpoint', () => {
+    it('should associate and remove jurisdictions to an existing feature flag', async () => {
+      const jurisdiction1 = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      const jurisdiction2 = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      const jurisdiction3 = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      const featureFlag = await prisma.featureFlags.create({
+        data: featureFlagFactory(undefined, undefined, undefined, [
+          jurisdiction1.id,
+          jurisdiction2.id,
+        ]),
+      });
+
+      const body = {
+        id: featureFlag.id,
+        associate: [jurisdiction3.id],
+        remove: [jurisdiction2.id],
+      };
+
+      const res = await request(app.getHttpServer())
+        .put(`/featureFlags/associateJurisdictions`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+
+      expect(res.body).toEqual({
+        ...featureFlag,
+        jurisdictions: [
+          {
+            id: jurisdiction1.id,
+            name: jurisdiction1.name,
+          },
+          {
+            id: jurisdiction3.id,
+            name: jurisdiction3.name,
+          },
+        ],
+        createdAt: expect.anything(),
+        updatedAt: expect.anything(),
+      });
+    });
+
+    it('should not associate a jurisdiction also set to remove to an existing feature flag', async () => {
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      const featureFlag = await prisma.featureFlags.create({
+        data: featureFlagFactory(),
+      });
+
+      const body = {
+        id: featureFlag.id,
+        associate: [jurisdiction.id],
+        remove: [jurisdiction.id],
+      };
+
+      const res = await request(app.getHttpServer())
+        .put(`/featureFlags/associateJurisdictions`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+
+      expect(res.body).toEqual({
+        ...featureFlag,
+        jurisdictions: [],
+        createdAt: expect.anything(),
+        updatedAt: expect.anything(),
+      });
+    });
+
+    it('should error when trying to associateJurisdictions a feature flag that does not exist', async () => {
+      const body = {
+        id: randomUUID(),
+        associate: [],
+        remove: [],
+      };
+
+      const res = await request(app.getHttpServer())
+        .put(`/featureFlags/associateJurisdictions`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
+        .set('Cookie', adminAccessToken)
+        .expect(404);
+
+      expect(res.body.message).toEqual(
+        `feature flag id ${body.id} was requested but not found`,
+      );
+    });
+  });
+
+  describe('retrieve endpoint', () => {
+    it('should return an existing feature flag by id', async () => {
+      const featureFlag = await prisma.featureFlags.create({
+        data: featureFlagFactory(),
+      });
+
+      const res = await request(app.getHttpServer())
+        .get(`/featureFlags/${featureFlag.id}`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+
+      expect(res.body.name).toEqual(featureFlag.name);
+      expect(res.body.description).toEqual(featureFlag.description);
+      expect(res.body.active).toEqual(featureFlag.active);
+    });
+  });
+
+  it('should error when trying to retrieve a feature flag that does not exist', async () => {
+    const id = randomUUID();
+
+    const res = await request(app.getHttpServer())
+      .get(`/featureFlags/${id}`)
+      .set({ passkey: process.env.API_PASS_KEY || '' })
+      .set('Cookie', adminAccessToken)
+      .expect(404);
+
+    expect(res.body.message).toEqual(
+      `feature flag id ${id} was requested but not found`,
+    );
+  });
+});

--- a/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
@@ -64,6 +64,7 @@ import {
   createSimpleListing,
 } from './helpers';
 import { ApplicationFlaggedSetService } from '../../../src/services/application-flagged-set.service';
+import { featureFlagFactory } from '../../../prisma/seed-helpers/feature-flag-factory';
 
 const testEmailService = {
   confirmation: jest.fn(),
@@ -1415,6 +1416,95 @@ describe('Testing Permissioning of endpoints as Admin User', () => {
           id: listing.id,
           lotteryStatus: 'ran',
         })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+  });
+
+  describe('Testing feature flag endpoints', () => {
+    it('should succeed for list endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+
+    it('should succeed for create endpoint', async () => {
+      const body = {
+        name: 'new name',
+        description: 'new description',
+        active: true,
+      };
+
+      await request(app.getHttpServer())
+        .post(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
+        .set('Cookie', cookies)
+        .expect(201);
+    });
+
+    it('should succeed for update endpoint', async () => {
+      const featureFlag = await prisma.featureFlags.create({
+        data: featureFlagFactory(),
+      });
+
+      const body = {
+        id: featureFlag.id,
+        name: 'updated name',
+        description: 'updated description',
+        active: !featureFlag.active,
+      };
+
+      await request(app.getHttpServer())
+        .put(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+
+    it('should succeed for delete endpoint', async () => {
+      const featureFlag = await prisma.featureFlags.create({
+        data: featureFlagFactory(),
+      });
+
+      await request(app.getHttpServer())
+        .delete(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({ id: featureFlag.id })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+
+    it('should succeed for associate jurisdictions endpoint', async () => {
+      const featureFlag = await prisma.featureFlags.create({
+        data: featureFlagFactory(),
+      });
+
+      const body = {
+        id: featureFlag.id,
+        associate: [],
+        remove: [],
+      };
+
+      await request(app.getHttpServer())
+        .put(`/featureFlags/associateJurisdictions`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+
+    it('should succeed for retrieve endpoint', async () => {
+      const featureFlag = await prisma.featureFlags.create({
+        data: featureFlagFactory(),
+      });
+
+      await request(app.getHttpServer())
+        .get(`/featureFlags/${featureFlag.id}`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
         .expect(200);
     });

--- a/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
@@ -1379,4 +1379,58 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
         .expect(403);
     });
   });
+
+  describe('Testing feature flag endpoints', () => {
+    it('should error as forbidden for list endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for create endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for update endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for delete endpoint', async () => {
+      await request(app.getHttpServer())
+        .delete(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for associate jurisdictions endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags/associateJurisdictions`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for retrieve endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags/example`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
 });

--- a/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
@@ -1318,4 +1318,58 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the wron
         .expect(403);
     });
   });
+
+  describe('Testing feature flag endpoints', () => {
+    it('should error as forbidden for list endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for create endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for update endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for delete endpoint', async () => {
+      await request(app.getHttpServer())
+        .delete(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for associate jurisdictions endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags/associateJurisdictions`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for retrieve endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags/example`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
 });

--- a/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
@@ -1229,4 +1229,58 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
         .expect(403);
     });
   });
+
+  describe('Testing feature flag endpoints', () => {
+    it('should error as forbidden for list endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for create endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for update endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for delete endpoint', async () => {
+      await request(app.getHttpServer())
+        .delete(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for associate jurisdictions endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags/associateJurisdictions`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for retrieve endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags/example`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
 });

--- a/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
@@ -1297,4 +1297,58 @@ describe('Testing Permissioning of endpoints as partner with correct listing', (
         .expect(200);
     });
   });
+
+  describe('Testing feature flag endpoints', () => {
+    it('should error as forbidden for list endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for create endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for update endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for delete endpoint', async () => {
+      await request(app.getHttpServer())
+        .delete(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for associate jurisdictions endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags/associateJurisdictions`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for retrieve endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags/example`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
 });

--- a/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
@@ -1259,4 +1259,58 @@ describe('Testing Permissioning of endpoints as partner with wrong listing', () 
         .expect(403);
     });
   });
+
+  describe('Testing feature flag endpoints', () => {
+    it('should error as forbidden for list endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for create endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for update endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for delete endpoint', async () => {
+      await request(app.getHttpServer())
+        .delete(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for associate jurisdictions endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags/associateJurisdictions`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for retrieve endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags/example`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
 });

--- a/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
@@ -1300,4 +1300,58 @@ describe('Testing Permissioning of endpoints as public user', () => {
         .expect(403);
     });
   });
+
+  describe('Testing feature flag endpoints', () => {
+    it('should error as forbidden for list endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for create endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for update endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for delete endpoint', async () => {
+      await request(app.getHttpServer())
+        .delete(`/featureFlags`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for associate jurisdictions endpoint', async () => {
+      await request(app.getHttpServer())
+        .put(`/featureFlags/associateJurisdictions`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({})
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+
+    it('should error as forbidden for retrieve endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/featureFlags/example`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
 });

--- a/api/test/unit/services/feature-flag.service.spec.ts
+++ b/api/test/unit/services/feature-flag.service.spec.ts
@@ -1,0 +1,345 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { randomUUID } from 'crypto';
+import { FeatureFlagAssociate } from '../../../src/dtos/feature-flags/feature-flag-associate.dto';
+import { FeatureFlagCreate } from '../../../src/dtos/feature-flags/feature-flag-create.dto';
+import { FeatureFlagUpdate } from '../../../src/dtos/feature-flags/feature-flag-update.dto';
+import { FeatureFlagService } from '../../../src/services/feature-flag.service';
+import { JurisdictionService } from '../../../src/services/jurisdiction.service';
+import { PrismaService } from '../../../src/services/prisma.service';
+
+describe('Testing feature flag service', () => {
+  let service: FeatureFlagService;
+  let prisma: PrismaService;
+
+  const mockFeatureFlag = (position: number, date: Date, active = true) => {
+    return {
+      id: randomUUID(),
+      createdAt: date,
+      updatedAt: date,
+      name: `feature flag ${position}`,
+      description: `feature flag description ${position}`,
+      active: active,
+    };
+  };
+
+  const mockFeatureFlagSet = (numberToCreate: number, date: Date) => {
+    const toReturn = [];
+    for (let i = 0; i < numberToCreate; i++) {
+      toReturn.push(mockFeatureFlag(i, date));
+    }
+    return toReturn;
+  };
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [FeatureFlagService, JurisdictionService, PrismaService],
+    }).compile();
+
+    service = module.get<FeatureFlagService>(FeatureFlagService);
+    prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  describe('Testing list()', () => {
+    it('should return list of feature flags', async () => {
+      const date = new Date();
+      const mockedValue = mockFeatureFlagSet(3, date);
+      prisma.featureFlags.findMany = jest.fn().mockResolvedValue(mockedValue);
+
+      expect(await service.list()).toEqual(mockedValue);
+
+      expect(prisma.featureFlags.findMany).toHaveBeenCalledWith({
+        include: {
+          jurisdictions: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('Testing findOne()', () => {
+    it('should find and return one feature flag', async () => {
+      const date = new Date();
+      const mockedValue = mockFeatureFlag(1, date);
+      prisma.featureFlags.findFirst = jest.fn().mockResolvedValue(mockedValue);
+
+      expect(await service.findOne(mockedValue.id)).toEqual(mockedValue);
+
+      expect(prisma.featureFlags.findFirst).toHaveBeenCalledWith({
+        include: {
+          jurisdictions: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+        where: {
+          id: mockedValue.id,
+        },
+      });
+    });
+
+    it('should not find a feature flag and throw error', async () => {
+      prisma.featureFlags.findFirst = jest.fn().mockResolvedValue(null);
+
+      await expect(
+        async () => await service.findOne('example Id'),
+      ).rejects.toThrowError(
+        'feature flag id example Id was requested but not found',
+      );
+
+      expect(prisma.featureFlags.findFirst).toHaveBeenCalledWith({
+        include: {
+          jurisdictions: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+        where: {
+          id: 'example Id',
+        },
+      });
+    });
+  });
+
+  describe('Testing create()', () => {
+    it('should create a new feature flag record', async () => {
+      const date = new Date();
+      const mockedValue = mockFeatureFlag(1, date);
+      prisma.featureFlags.create = jest.fn().mockResolvedValue(mockedValue);
+
+      const params: FeatureFlagCreate = {
+        name: mockedValue.name,
+        description: mockedValue.description,
+        active: mockedValue.active,
+      };
+
+      expect(await service.create(params)).toEqual(mockedValue);
+
+      expect(prisma.featureFlags.create).toHaveBeenCalledWith({
+        data: {
+          name: mockedValue.name,
+          description: mockedValue.description,
+          active: mockedValue.active,
+        },
+        include: {
+          jurisdictions: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('Testing update()', () => {
+    it('should update existing feature flag record', async () => {
+      const date = new Date();
+
+      const mockedValue = mockFeatureFlag(1, date);
+
+      prisma.featureFlags.findFirst = jest.fn().mockResolvedValue(mockedValue);
+      prisma.featureFlags.update = jest.fn().mockResolvedValue({
+        ...mockedValue,
+        name: 'updated feature flag 1',
+      });
+
+      const params: FeatureFlagUpdate = {
+        name: 'updated feature flag 1',
+        id: mockedValue.id,
+        description: mockedValue.description,
+        active: mockedValue.active,
+      };
+
+      expect(await service.update(params)).toEqual({
+        id: mockedValue.id,
+        name: 'updated feature flag 1',
+        description: mockedValue.description,
+        active: mockedValue.active,
+        createdAt: date,
+        updatedAt: date,
+        jurisdictions: undefined,
+      });
+
+      expect(prisma.featureFlags.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: mockedValue.id,
+        },
+      });
+
+      expect(prisma.featureFlags.update).toHaveBeenCalledWith({
+        data: {
+          name: 'updated feature flag 1',
+          description: mockedValue.description,
+          active: mockedValue.active,
+        },
+        include: {
+          jurisdictions: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+        where: {
+          id: mockedValue.id,
+        },
+      });
+    });
+
+    it('should not find a feature flag and throw error', async () => {
+      prisma.featureFlags.findFirst = jest.fn().mockResolvedValue(null);
+      prisma.featureFlags.update = jest.fn().mockResolvedValue(null);
+
+      const params: FeatureFlagUpdate = {
+        id: 'example id',
+        name: 'example feature flag',
+        description: 'example description',
+        active: true,
+      };
+
+      await expect(
+        async () => await service.update(params),
+      ).rejects.toThrowError(
+        'feature flag id example id was requested but not found',
+      );
+
+      expect(prisma.featureFlags.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'example id',
+        },
+      });
+    });
+  });
+
+  describe('Testing delete()', () => {
+    it('should delete feature flag record', async () => {
+      const date = new Date();
+      const mockedValue = mockFeatureFlag(1, date);
+
+      prisma.featureFlags.findFirst = jest.fn().mockResolvedValue(mockedValue);
+      prisma.featureFlags.delete = jest.fn().mockResolvedValue(mockedValue);
+
+      expect(await service.delete(mockedValue.id)).toEqual({
+        success: true,
+      });
+
+      expect(prisma.featureFlags.delete).toHaveBeenCalledWith({
+        where: {
+          id: mockedValue.id,
+        },
+      });
+
+      expect(prisma.featureFlags.delete).toHaveBeenCalledWith({
+        where: {
+          id: mockedValue.id,
+        },
+      });
+    });
+  });
+
+  describe('Testing associateJurisdictions()', () => {
+    it('should associate and remove jurisdictions from feature flag record', async () => {
+      const date = new Date();
+
+      const mockedValue = mockFeatureFlag(1, date);
+      const unchangingJurisdiction = {
+        id: 'jurisdiction id 1',
+        name: 'jurisdiction name 1',
+      };
+      const associateJurisdiction = {
+        id: 'jurisdiction id 2',
+        name: 'jurisdiction name 2',
+      };
+      const removeJurisdiction = {
+        id: 'jurisdiction id 3',
+        name: 'jurisdiction name 3',
+      };
+
+      prisma.featureFlags.findFirst = jest.fn().mockResolvedValue({
+        ...mockedValue,
+        jurisdictions: [unchangingJurisdiction, removeJurisdiction],
+      });
+      prisma.jurisdictions.findFirst = jest
+        .fn()
+        .mockResolvedValue({ id: 'id' });
+      prisma.featureFlags.update = jest.fn().mockResolvedValue({
+        ...mockedValue,
+        jurisdictions: [unchangingJurisdiction, associateJurisdiction],
+      });
+
+      const params: FeatureFlagAssociate = {
+        id: mockedValue.id,
+        associate: [associateJurisdiction.id],
+        remove: [removeJurisdiction.id],
+      };
+
+      expect(await service.associateJurisdictions(params)).toEqual({
+        id: mockedValue.id,
+        name: mockedValue.name,
+        description: mockedValue.description,
+        active: mockedValue.active,
+        createdAt: date,
+        updatedAt: date,
+        jurisdictions: [unchangingJurisdiction, associateJurisdiction],
+      });
+
+      expect(prisma.featureFlags.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: mockedValue.id,
+        },
+      });
+
+      expect(prisma.featureFlags.update).toHaveBeenCalledWith({
+        data: {
+          jurisdictions: {
+            connect: [{ id: associateJurisdiction.id }],
+            disconnect: [{ id: removeJurisdiction.id }],
+          },
+        },
+        include: {
+          jurisdictions: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+        where: {
+          id: mockedValue.id,
+        },
+      });
+    });
+
+    it('should not find a feature flag and throw error', async () => {
+      prisma.featureFlags.findFirst = jest.fn().mockResolvedValue(null);
+      prisma.featureFlags.update = jest.fn().mockResolvedValue(null);
+
+      const params: FeatureFlagAssociate = {
+        id: 'example id',
+        associate: [],
+        remove: [],
+      };
+
+      await expect(
+        async () => await service.associateJurisdictions(params),
+      ).rejects.toThrowError(
+        'feature flag id example id was requested but not found',
+      );
+
+      expect(prisma.featureFlags.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'example id',
+        },
+      });
+    });
+  });
+});

--- a/api/test/unit/services/jurisdiction.service.spec.ts
+++ b/api/test/unit/services/jurisdiction.service.spec.ts
@@ -54,6 +54,7 @@ describe('Testing jurisdiction service', () => {
 
     expect(prisma.jurisdictions.findMany).toHaveBeenCalledWith({
       include: {
+        featureFlags: true,
         multiselectQuestions: true,
       },
     });
@@ -75,6 +76,7 @@ describe('Testing jurisdiction service', () => {
         },
       },
       include: {
+        featureFlags: true,
         multiselectQuestions: true,
       },
     });
@@ -96,6 +98,7 @@ describe('Testing jurisdiction service', () => {
         },
       },
       include: {
+        featureFlags: true,
         multiselectQuestions: true,
       },
     });
@@ -117,6 +120,7 @@ describe('Testing jurisdiction service', () => {
         },
       },
       include: {
+        featureFlags: true,
         multiselectQuestions: true,
       },
     });
@@ -138,6 +142,9 @@ describe('Testing jurisdiction service', () => {
       enablePartnerSettings: true,
       enableAccessibilityFeatures: true,
       enableUtilitiesIncluded: true,
+      allowSingleUseCodeLogin: false,
+      listingApprovalPermissions: [],
+      duplicateListingPermissions: [],
     };
 
     expect(await service.create(params)).toEqual(mockedValue);
@@ -154,8 +161,12 @@ describe('Testing jurisdiction service', () => {
         enablePartnerSettings: true,
         enableAccessibilityFeatures: true,
         enableUtilitiesIncluded: true,
+        allowSingleUseCodeLogin: false,
+        listingApprovalPermissions: [],
+        duplicateListingPermissions: [],
       },
       include: {
+        featureFlags: true,
         multiselectQuestions: true,
       },
     });
@@ -186,6 +197,9 @@ describe('Testing jurisdiction service', () => {
       enablePartnerSettings: true,
       enableAccessibilityFeatures: true,
       enableUtilitiesIncluded: true,
+      allowSingleUseCodeLogin: false,
+      listingApprovalPermissions: [],
+      duplicateListingPermissions: [],
     };
 
     expect(await service.update(params)).toEqual({
@@ -222,11 +236,15 @@ describe('Testing jurisdiction service', () => {
         enablePartnerSettings: true,
         enableAccessibilityFeatures: true,
         enableUtilitiesIncluded: true,
+        allowSingleUseCodeLogin: false,
+        listingApprovalPermissions: [],
+        duplicateListingPermissions: [],
       },
       where: {
         id: mockedJurisdiction.id,
       },
       include: {
+        featureFlags: true,
         multiselectQuestions: true,
       },
     });
@@ -248,6 +266,9 @@ describe('Testing jurisdiction service', () => {
       enablePartnerSettings: true,
       enableAccessibilityFeatures: true,
       enableUtilitiesIncluded: true,
+      allowSingleUseCodeLogin: false,
+      listingApprovalPermissions: [],
+      duplicateListingPermissions: [],
     };
 
     await expect(async () => await service.update(params)).rejects.toThrowError(

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2534,6 +2534,132 @@ export class LotteryService {
   }
 }
 
+export class FeatureFlagsService {
+  /**
+   * List of feature flags
+   */
+  list(options: IRequestOptions = {}): Promise<FeatureFlag[]> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/featureFlags"
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
+
+      /** 适配ios13，get请求不允许带body */
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Create a feature flag
+   */
+  create(
+    params: {
+      /** requestBody */
+      body?: FeatureFlagCreate
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<FeatureFlag> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/featureFlags"
+
+      const configs: IRequestConfig = getConfigs("post", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Update a feature flag
+   */
+  update(
+    params: {
+      /** requestBody */
+      body?: FeatureFlagUpdate
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<FeatureFlag> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/featureFlags"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Delete a feature flag by id
+   */
+  delete(
+    params: {
+      /** requestBody */
+      body?: IdDTO
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/featureFlags"
+
+      const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Associate and disassociate jurisdictions with a feature flag
+   */
+  associateJurisdictions(
+    params: {
+      /** requestBody */
+      body?: FeatureFlagAssociate
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<FeatureFlag> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/featureFlags/associateJurisdictions"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Get a feature flag by id
+   */
+  retrieve(
+    params: {
+      /**  */
+      featureFlagId: string
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<FeatureFlag> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/featureFlags/{featureFlagId}"
+      url = url.replace("{featureFlagId}", params["featureFlagId"] + "")
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
+
+      /** 适配ios13，get请求不允许带body */
+
+      axios(configs, resolve, reject)
+    })
+  }
+}
+
 export interface SuccessDTO {
   /**  */
   success: boolean
@@ -4970,6 +5096,29 @@ export interface JurisdictionUpdate {
   duplicateListingPermissions: UserRoleEnum[]
 }
 
+export interface FeatureFlag {
+  /**  */
+  id: string
+
+  /**  */
+  createdAt: Date
+
+  /**  */
+  updatedAt: Date
+
+  /**  */
+  name: string
+
+  /**  */
+  description: string
+
+  /**  */
+  active: boolean
+
+  /**  */
+  jurisdictions: IdDTO[]
+}
+
 export interface Jurisdiction {
   /**  */
   id: string
@@ -5030,6 +5179,9 @@ export interface Jurisdiction {
 
   /**  */
   duplicateListingPermissions: UserRoleEnum[]
+
+  /**  */
+  featureFlags: FeatureFlag[]
 }
 
 export interface MultiselectQuestionCreate {
@@ -6042,6 +6194,42 @@ export interface PublicLotteryTotal {
 
   /**  */
   multiselectQuestionId?: string
+}
+
+export interface FeatureFlagAssociate {
+  /**  */
+  id: string
+
+  /**  */
+  associate: string[]
+
+  /**  */
+  remove: string[]
+}
+
+export interface FeatureFlagCreate {
+  /**  */
+  name: string
+
+  /**  */
+  description: string
+
+  /**  */
+  active: boolean
+}
+
+export interface FeatureFlagUpdate {
+  /**  */
+  id: string
+
+  /**  */
+  name: string
+
+  /**  */
+  description: string
+
+  /**  */
+  active: boolean
 }
 
 export enum ListingViews {


### PR DESCRIPTION
This PR addresses [#(4459)](https://github.com/bloom-housing/bloom/issues/4459)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Creates the module, controller and service files for the new Feature Flag table. Allows for standard CRUD methods, as well as a list endpoint and an endpoint to add/remove jurisdiction associations with the flag (`associateJurisdictions`). Permissions are limited to admin only. Flags associated with jurisdictions will appear when jurisdiction data is returned.

## How Can This Be Tested/Reviewed?

Start up the backend. Login as an admin, either through the API or partners portal. Test each endpoint:
- Create a feature flag
- Get the feature flag using the id returned ^^
- Update the feature flag using the id
- Get the feature flag to verify update
- Associate jurisdiction(s) with the flag
- Get the feature flag to verify association
- Get the jurisdiction to verify association
- Call the list endpoint
- Remove the jurisdiction(s) using associateJurisdictions
- Get the feature flag to verify removal
- Get the jurisdiction to verify removal
- Delete feature flag
- Call list endpoint to verify

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
