### PR TITLE
fix: building selection criteria adjustment (#4505)

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -1022,20 +1022,28 @@ export class ListingService implements OnModuleInit {
 
     const newListingData: ListingCreate = {
       ...mappedListing,
-      name: dto.name,
+      applicationMethods: applicationMethods,
       assets: [],
-      status: ListingsStatusEnum.pending,
+      listingsBuildingSelectionCriteriaFile:
+        mappedListing.listingsBuildingSelectionCriteriaFile
+          ? {
+              fileId:
+                mappedListing.listingsBuildingSelectionCriteriaFile.fileId,
+              label: mappedListing.listingsBuildingSelectionCriteriaFile.label,
+            }
+          : undefined,
       listingEvents: listingEvents,
+      listingImages: listingImages,
       listingMultiselectQuestions:
         storedListing.listingMultiselectQuestions?.map((question) => ({
           id: question.multiselectQuestionId,
           ordinal: question.ordinal,
         })),
-      listingImages: listingImages,
-      applicationMethods: applicationMethods,
       lotteryLastRunAt: undefined,
       lotteryLastPublishedAt: undefined,
       lotteryStatus: undefined,
+      name: dto.name,
+      status: ListingsStatusEnum.pending,
     };
 
     const res = await this.create(


### PR DESCRIPTION
This PR addresses [#(982)](https://github.com/metrotranscom/doorway/issues/982)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Listings with a BuildingSelectionCriteriaFile could not be duplicated due to an issue re-creating the asset. This is fixed by not passing the existing asset id to the new copy.

## How Can This Be Tested/Reviewed?

- Create or edit a listing to have a building selection criteria file.
- Copy the listing
- Confirm the building selection criteria file is present on the copy listing
- Publish the copy listing
- Go to the public site, view the copy listing, view the building selection criteria file

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
