### PR TITLE
fix: set optOut watch default value (#4512)

### DIFF
--- a/sites/partners/src/components/settings/PreferenceDrawer.tsx
+++ b/sites/partners/src/components/settings/PreferenceDrawer.tsx
@@ -92,7 +92,11 @@ const PreferenceDrawer = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [questionData])
 
-  const optOutQuestion = watch("canYouOptOutQuestion")
+  const optOutQuestion = watch(
+    "canYouOptOutQuestion",
+    // set watch default value to mirror canYouOptOutQuestion default on load
+    questionData === null || questionData?.optOutText !== null ? YesNoEnum.yes : undefined
+  )
 
   const isAdditionalDetailsEnabled = profile?.jurisdictions?.some(
     (jurisdiction) => jurisdiction.enableGeocodingPreferences


### PR DESCRIPTION
This PR releases https://github.com/metrotranscom/doorway/issues/1004

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the watch function to include a default value. The issue was that we were defaulting the canYouOptOutQuestion to true on all preferences that didn't explicitly set to no but depending on the watch value to be Yes in order to show the optOutText field. As a result, the watch value was undefined on load and wouldn't set to Yes until the user directly interacted with the radio leading to the confusing experience described in ticket. This one line change handles that case. 

## How Can This Be Tested/Reviewed?

This can be tested by editing existing preferences and adding new ones. In both cases, if the canYouOptOutQuestion shows yes, the optOutText field should be visible

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
