### PR TITLE
fix: household member delete + order (#4510)

### DIFF
--- a/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsHouseholdMembers.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsHouseholdMembers.tsx
@@ -32,7 +32,10 @@ const DetailsHouseholdMembers = ({ setMembersDrawer }: DetailsHouseholdMembersPr
 
       return t("t.n/a")
     }
-    return application?.householdMember?.map((item) => ({
+    const orderedHouseholdMembers = application?.householdMember?.sort(
+      (a, b) => a.orderId - b.orderId
+    )
+    return orderedHouseholdMembers?.map((item) => ({
       name: { content: `${item.firstName} ${item.middleName} ${item.lastName}` },
       relationship: {
         content: item.relationship

--- a/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
@@ -77,7 +77,14 @@ const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormPr
 
   useEffect(() => {
     if (application?.householdMember) {
-      setHouseholdMembers(application.householdMember)
+      const householdMemberNum = application.householdMember.length
+      const orderedHouseholdMembers = application.householdMember
+        //reset order ids to show members in order user added them
+        .map((member, idx) => {
+          return { ...member, orderId: householdMemberNum - idx }
+        })
+        .sort((a, b) => a.orderId - b.orderId)
+      setHouseholdMembers(orderedHouseholdMembers)
     }
   }, [application, setHouseholdMembers])
 

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdMembers.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdMembers.tsx
@@ -170,7 +170,7 @@ const FormHouseholdMembers = ({
       </Drawer>
 
       <Dialog
-        isOpen={!!membersDeleteModal}
+        isOpen={membersDeleteModal !== null}
         ariaLabelledBy="form-household-members-dialog-header"
         ariaDescribedBy="form-household-members-dialog-content"
         onClose={() => setMembersDeleteModal(null)}


### PR DESCRIPTION
This PR addresses [#977 ](https://github.com/metrotranscom/doorway/issues/977)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the deleteModal open logic to handle an orderId=0. When a user applies online, the first household member is set to an OrderId of 0 but when added via the partner's side, it adds it with an orderId of 1. This PR also updates the ordering on the partner's side so that a user sees the household members in the order they added them (public side is already demonstrating this behavior). However, I stopped short of refactoring the orderId to be used more consistently to avoid any risks in conflicting with existing data. Instead, that work is captured here: https://github.com/bloom-housing/bloom/issues/4511

Note: I had originally assumed the orderId was null causing this issue but querying production showed no household members with null orderIds so this should resolve the issue.

## How Can This Be Tested/Reviewed?

This can be tested a few ways. On the public side, sign in and apply to a listing while adding household members, editing and deleting household members. Then submit, and do the same on an autofill application. Ensure that the household members behave as expected and maintain the order at which they were added.

Then on the partner's side, check these same applications and click delete to ensure the modal opens for each of them. Also, check that the order updates and saves correctly when deleting a household member.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
