### PR TITLE
fix: use correct ami percentage in csv (#4520)

### DIFF
--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -8,7 +8,6 @@ import {
   Logger,
   StreamableFile,
 } from '@nestjs/common';
-import { SchedulerRegistry } from '@nestjs/schedule';
 import {
   Request as ExpressRequest,
   Response as ExpressResponse,
@@ -67,7 +66,6 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
     private prisma: PrismaService,
     @Inject(Logger)
     private logger = new Logger(ListingCsvExporterService.name),
-    private schedulerRegistry: SchedulerRegistry,
   ) {}
 
   /**
@@ -845,7 +843,7 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
         label: 'AMI Chart',
       },
       {
-        path: 'unit.amiChart.items.0.percentOfAmi',
+        path: 'unit.amiPercentage',
         label: 'AMI Level',
       },
       {

--- a/api/test/unit/services/listing-csv-export.service.spec.ts
+++ b/api/test/unit/services/listing-csv-export.service.spec.ts
@@ -1,0 +1,82 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import fs from 'fs';
+import { ListingCsvExporterService } from '../../../src/services/listing-csv-export.service';
+import { PrismaService } from '../../../src/services/prisma.service';
+import Listing from '../../../src/dtos/listings/listing.dto';
+
+describe('Testing listing csv export service', () => {
+  let service: ListingCsvExporterService;
+  let writeStream;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PrismaService, ListingCsvExporterService, Logger],
+    }).compile();
+
+    service = module.get<ListingCsvExporterService>(ListingCsvExporterService);
+  });
+
+  beforeEach(() => {
+    writeStream = fs.createWriteStream('sampleFile.csv');
+    jest.spyOn(fs, 'createWriteStream').mockReturnValue(writeStream);
+  });
+
+  afterEach(() => {
+    writeStream.end();
+    fs.unlink('sampleFile.csv', () => {
+      // do nothing
+    });
+    jest.restoreAllMocks();
+  });
+
+  describe('createUnitCsv', () => {
+    it('should create the unit csv', async () => {
+      const unit = {
+        number: 1,
+        numBathrooms: 2,
+        floor: 3,
+        sqFeet: 1200,
+        minOccupancy: 1,
+        maxOccupancy: 8,
+        amiPercentage: 80,
+        monthlyRentAsPercentOfIncome: null,
+        monthlyRent: 4000,
+        unitTypes: { id: randomUUID(), name: 'studio' },
+        amiChart: { id: randomUUID(), name: 'Ami Chart Name' },
+      };
+      const mockListing = {
+        id: 'listing1-ID',
+        name: `listing1-Name`,
+        units: [unit],
+      };
+      const mockListing2 = {
+        id: 'listing2-ID',
+        name: `listing2-Name`,
+        units: [
+          {
+            ...unit,
+            monthlyRentAsPercentOfIncome: 30.0,
+            unitTypes: { id: randomUUID(), name: 'twoBdrm' },
+          },
+        ],
+      };
+      await service.createUnitCsv('sampleFile.csv', [
+        mockListing as unknown as Listing,
+        mockListing2 as unknown as Listing,
+      ]);
+      expect(writeStream.bytesWritten).toBeGreaterThan(0);
+      const content = fs.readFileSync('sampleFile.csv', 'utf8');
+      expect(content).toContain(
+        'Listing Id,Listing Name,Unit Number,Unit Type,Number of Bathrooms,Unit Floor,Square Footage,Minimum Occupancy,Max Occupancy,AMI Chart,AMI Level,Rent Type',
+      );
+      expect(content).toContain(
+        'listing1-ID,listing1-Name,1,studio,2,3,1200,1,8,Ami Chart Name,80,Fixed amount',
+      );
+      expect(content).toContain(
+        'listing2-ID,listing2-Name,1,twoBdrm,2,3,1200,1,8,Ami Chart Name,80,% of income',
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses #1027 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The listing units csv export is displaying the incorrect AMI Chart percentage. It is grabbing the first value from the amiChart instead of getting the percentage off of the unit table

Note:
- There are currently no tests that cover the CSV export. I have added a test as part of this change, but only test the unit CSV. More tests should be added

## How Can This Be Tested/Reviewed?

After a clean reseed In the partner site click the "Export to CSV" button on the listings page and compare the values to the listings

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
