### PR TITLE
release: include preference address (#4537)

### DIFF
--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -363,7 +363,7 @@ export const constructMultiselectQuestionHeaders = (
         ?.filter((option) => option.collectAddress)
         .forEach((option) => {
           headers.push({
-            path: `${applicationSection}.${question.text}.address`,
+            path: `${applicationSection}.${question.text}.${option.text}.address`,
             label: `${labelString} ${question.text} - ${option.text} - Address`,
             format: (val: ApplicationMultiselectQuestion): string => {
               return multiselectQuestionFormat(val, option.text, 'address');


### PR DESCRIPTION
This PR addresses [#(4536)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/4536)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

For preferences that required an address to be input, they were appearing for the application export but not for the lottery export. This adjustment allows it to work correctly for both.

## How Can This Be Tested/Reviewed?

On the partner site, create/update a listing to be a lottery listing with a preference that requires/allows for an address to be input.
Submit an application for the listing, claim the preference and include an address.
Export applications and verify the preference and preference address appear correctly.
Close the listing, run the lottery, export the lottery, and verify the preference and preference address appear correctly.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
