### PR TITLE
fix: set studio + sro to zero bedrooms (#4611)

### DIFF
--- a/sites/partners/src/lib/listings/UnitsFormatter.ts
+++ b/sites/partners/src/lib/listings/UnitsFormatter.ts
@@ -26,7 +26,7 @@ export default class UnitsFormatter extends Formatter {
           unit.numBedrooms = 1
           break
         default:
-          unit.numBedrooms = null
+          unit.numBedrooms = 0
       }
 
       Object.keys(unit).forEach((key) => {


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/1059 and https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/4220

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR saves Studios and SROs to have zero bedrooms rather than null bedrooms. This doesn't change much in core but it is critical for filtering in doorway which is a feature core will likely get soon.

After merge, I will be running the following query in Core, HBA, and Doorway since querying existing data showed that all null bedroom units were Studios or SROs
`Update units set num_bedrooms=0 where num_bedrooms is null;`

## How Can This Be Tested/Reviewed?

This can be tested by creating SROs and Studios on the partner side and then checking the units table to ensure they are saved as zero rather than null number of bedrooms.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
