### PR TITLE
fix: null checks in minMax process (#4632)

### DIFF
--- a/api/src/utilities/unit-utilities.ts
+++ b/api/src/utilities/unit-utilities.ts
@@ -373,24 +373,33 @@ export const getUnitsSummary = (unit: Unit, existingSummary?: UnitSummary) => {
   const summary = existingSummary;
 
   // Income Range
-  summary.minIncomeRange = minMaxCurrency(
-    summary.minIncomeRange,
-    getRoundedNumber(unit.monthlyIncomeMin),
-  );
+  if (unit.monthlyIncomeMin) {
+    summary.minIncomeRange = minMaxCurrency(
+      summary.minIncomeRange,
+      getRoundedNumber(unit.monthlyIncomeMin),
+    );
+  }
 
   // Occupancy Range
-  summary.occupancyRange = minMax(summary.occupancyRange, unit.minOccupancy);
-  summary.occupancyRange = minMax(summary.occupancyRange, unit.maxOccupancy);
+  if (unit.minOccupancy) {
+    summary.occupancyRange = minMax(summary.occupancyRange, unit.minOccupancy);
+  }
+  if (unit.maxOccupancy) {
+    summary.occupancyRange = minMax(summary.occupancyRange, unit.maxOccupancy);
+  }
 
   // Rent Ranges
-  summary.rentAsPercentIncomeRange = minMax(
-    summary.rentAsPercentIncomeRange,
-    parseFloat(unit.monthlyRentAsPercentOfIncome),
-  );
-  summary.rentRange = minMaxCurrency(
-    summary.rentRange,
-    getRoundedNumber(unit.monthlyRent),
-  );
+  if (unit.monthlyRentAsPercentOfIncome) {
+    summary.rentAsPercentIncomeRange = minMax(
+      summary.rentAsPercentIncomeRange,
+      parseFloat(unit.monthlyRentAsPercentOfIncome),
+    );
+  }
+  if (unit.monthlyRent)
+    summary.rentRange = minMaxCurrency(
+      summary.rentRange,
+      getRoundedNumber(unit.monthlyRent),
+    );
 
   // Floor Range
   if (unit.floor) {
@@ -398,7 +407,9 @@ export const getUnitsSummary = (unit: Unit, existingSummary?: UnitSummary) => {
   }
 
   // Area Range
-  summary.areaRange = minMax(summary.areaRange, parseFloat(unit.sqFeet));
+  if (unit.sqFeet) {
+    summary.areaRange = minMax(summary.areaRange, parseFloat(unit.sqFeet));
+  }
 
   return summary;
 };


### PR DESCRIPTION
This PR addresses #4631

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The units summarization process was failing to handle multiple units without rent information. The first unit was correctly handled with "t.n/a" in the getDefaultSummary function but then from there the inputs to a minMax function were t.n/a and null leading to the NaN. This fix avoids the minMax comparison if the unit's associated field is null.

## How Can This Be Tested/Reviewed?

Add multiple units of the same unit type to a listing that have no rent or rent as a percentage of income information. Ensure that the unit summary displays with n/a rather than NaN per month.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
