### PR TITLE
fix: prevent listings without AMI charts (#4169)

### DIFF
--- a/sites/partners/cypress/e2e/default/03-listing.spec.ts
+++ b/sites/partners/cypress/e2e/default/03-listing.spec.ts
@@ -182,6 +182,9 @@ describe("Listing Management Tests", () => {
     cy.getByID("monthlyRent").type(listing["monthlyRent"])
     cy.getByID("unitAccessibilityPriorityTypes.id").select(listing["priorityType.id"])
     cy.get("button").contains("Save & Exit").click()
+    cy.getByID("amiChart.id").select(1).trigger("change")
+    cy.getByID("amiPercentage").select(1)
+    cy.get("button").contains("Save & Exit").click()
     cy.get("#add-preferences-button").contains("Add Preference").click()
     cy.get(".seeds-card-section > .seeds-button").contains("Select Preferences").click()
     cy.get(

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -515,10 +515,14 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                       register={register}
                       controlClassName="control"
                       options={amiChartsOptions}
+                      error={fieldHasError(errors?.amiChart?.id)}
+                      errorMessage={t("errors.requiredFieldError")}
+                      validation={{ required: true }}
                       inputProps={{
                         onChange: (value) => {
                           setValue("amiPercentage", undefined)
                           clearErrors("amiPercentage")
+                          clearErrors("amiChart.id")
                           ;[...Array(maxAmiHouseholdSize)].forEach((_, index) => {
                             setValue(`maxIncomeHouseholdSize${index + 1}`, undefined)
                           })


### PR DESCRIPTION
Releases the below commit from core
(Looks like it did make its way into Doorway)