### PR TITLE
release: user favorite listings (#4658)

### DIFF
--- a/api/prisma/migrations/24_user_favorite_listings/migration.sql
+++ b/api/prisma/migrations/24_user_favorite_listings/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "_favorite_listings" (
+    "A" UUID NOT NULL,
+    "B" UUID NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_favorite_listings_AB_unique" ON "_favorite_listings"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_favorite_listings_B_index" ON "_favorite_listings"("B");
+
+-- AddForeignKey
+ALTER TABLE "_favorite_listings" ADD CONSTRAINT "_favorite_listings_A_fkey" FOREIGN KEY ("A") REFERENCES "listings"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_favorite_listings" ADD CONSTRAINT "_favorite_listings_B_fkey" FOREIGN KEY ("B") REFERENCES "user_accounts"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -614,6 +614,7 @@ model Listings {
   listingsApplicationPickUpAddress      Address?                      @relation("application_pick_up_address", fields: [applicationPickUpAddressId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   listingsBuildingAddress               Address?                      @relation("building_address", fields: [buildingAddressId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   userAccounts                          UserAccounts[]
+  userAccountFavorites                  UserAccounts[]                @relation("favorite_listings")
   units                                 Units[]
   unitGroup                             UnitGroup[]
   userPreferences                       UserPreferences[]
@@ -859,6 +860,7 @@ model UserAccounts {
   userPreferences          UserPreferences?
   userRoles                UserRoles?
   requestedChangesListings Listings[]              @relation("requested_changes_user")
+  favoriteListings         Listings[]              @relation("favorite_listings")
 
   @@map("user_accounts")
 }

--- a/api/prisma/seed-helpers/user-factory.ts
+++ b/api/prisma/seed-helpers/user-factory.ts
@@ -3,48 +3,42 @@ import { randomAdjective, randomNoun } from './word-generator';
 import { passwordToHash } from '../../src/utilities/password-helpers';
 
 export const userFactory = async (optionalParams?: {
-  roles?: Prisma.UserRolesUncheckedCreateWithoutUserAccountsInput;
-  firstName?: string;
-  middleName?: string;
-  lastName?: string;
-  email?: string;
-  singleUseCode?: string;
-  mfaEnabled?: boolean;
+  acceptedTerms?: boolean;
   confirmedAt?: Date;
+  email?: string;
+  favoriteListings?: string[];
+  firstName?: string;
+  jurisdictionIds?: string[];
+  lastName?: string;
+  listings?: string[];
+  mfaEnabled?: boolean;
+  middleName?: string;
+  password?: string;
   phoneNumber?: string;
   phoneNumberVerified?: boolean;
-  jurisdictionIds?: string[];
-  listings?: string[];
-  acceptedTerms?: boolean;
-  password?: string;
+  roles?: Prisma.UserRolesUncheckedCreateWithoutUserAccountsInput;
+  singleUseCode?: string;
 }): Promise<Prisma.UserAccountsCreateInput> => ({
+  agreedToTermsOfService: optionalParams?.acceptedTerms || false,
+  confirmedAt: optionalParams?.confirmedAt || null,
   email:
     optionalParams?.email?.toLocaleLowerCase() ||
     `${randomNoun().toLowerCase()}${randomNoun().toLowerCase()}@${randomAdjective().toLowerCase()}.com`,
   firstName: optionalParams?.firstName || 'First',
-  middleName: optionalParams?.middleName || 'Middle',
   lastName: optionalParams?.lastName || 'Last',
+  middleName: optionalParams?.middleName || 'Middle',
+  mfaEnabled: optionalParams?.mfaEnabled || false,
   passwordHash: optionalParams?.password
     ? await passwordToHash(optionalParams?.password)
     : await passwordToHash('Abcdef12345!'),
-  userRoles: {
-    create: {
-      isAdmin: optionalParams?.roles?.isAdmin || false,
-      isJurisdictionalAdmin:
-        optionalParams?.roles?.isJurisdictionalAdmin || false,
-      isPartner: optionalParams?.roles?.isPartner || false,
-    },
-  },
-  singleUseCode: optionalParams?.singleUseCode || null,
-  mfaEnabled: optionalParams?.mfaEnabled || false,
-  confirmedAt: optionalParams?.confirmedAt || null,
-  singleUseCodeUpdatedAt: optionalParams?.mfaEnabled ? new Date() : undefined,
   phoneNumber: optionalParams?.phoneNumber || null,
   phoneNumberVerified: optionalParams?.phoneNumberVerified || null,
-  agreedToTermsOfService: optionalParams?.acceptedTerms || false,
-  listings: optionalParams?.listings
+  singleUseCode: optionalParams?.singleUseCode || null,
+  singleUseCodeUpdatedAt: optionalParams?.mfaEnabled ? new Date() : undefined,
+
+  favoriteListings: optionalParams?.favoriteListings
     ? {
-        connect: optionalParams.listings.map((listing) => {
+        connect: optionalParams.favoriteListings.map((listing) => {
           return { id: listing };
         }),
       }
@@ -58,4 +52,19 @@ export const userFactory = async (optionalParams?: {
         }),
       }
     : undefined,
+  listings: optionalParams?.listings
+    ? {
+        connect: optionalParams.listings.map((listing) => {
+          return { id: listing };
+        }),
+      }
+    : undefined,
+  userRoles: {
+    create: {
+      isAdmin: optionalParams?.roles?.isAdmin || false,
+      isJurisdictionalAdmin:
+        optionalParams?.roles?.isJurisdictionalAdmin || false,
+      isPartner: optionalParams?.roles?.isPartner || false,
+    },
+  },
 });

--- a/api/src/controllers/user.controller.ts
+++ b/api/src/controllers/user.controller.ts
@@ -36,6 +36,7 @@ import { UserUpdate } from '../dtos/users/user-update.dto';
 import { SuccessDTO } from '../dtos/shared/success.dto';
 import { UserCreate } from '../dtos/users/user-create.dto';
 import { UserCreateParams } from '../dtos/users/user-create-params.dto';
+import { UserFavoriteListing } from '../dtos/users/user-favorite-listing.dto';
 import { EmailAndAppUrl } from '../dtos/users/email-and-app-url.dto';
 import { ConfirmationRequest } from '../dtos/users/confirmation-request.dto';
 import { UserInvite } from '../dtos/users/user-invite.dto';
@@ -110,41 +111,11 @@ export class UserController {
     return await this.userCSVExportService.exportFile(req, res);
   }
 
-  @Get(`:id`)
-  @ApiOperation({
-    summary: 'Get user by id',
-    operationId: 'retrieve',
-  })
-  @ApiOkResponse({ type: User })
-  @UseGuards(JwtAuthGuard, PermissionGuard)
-  async retrieve(
-    @Param('id', new ParseUUIDPipe({ version: '4' })) userId: string,
-  ): Promise<User> {
-    return this.userService.findOne(userId);
-  }
-
   @Put('forgot-password')
   @ApiOperation({ summary: 'Forgot Password', operationId: 'forgotPassword' })
   @ApiOkResponse({ type: SuccessDTO })
   async forgotPassword(@Body() dto: EmailAndAppUrl): Promise<SuccessDTO> {
     return await this.userService.forgotPassword(dto);
-  }
-
-  @Put(':id')
-  @ApiOperation({ summary: 'Update user', operationId: 'update' })
-  @ApiOkResponse({ type: User })
-  @UseGuards(JwtAuthGuard, PermissionGuard)
-  @UseInterceptors(ActivityLogInterceptor)
-  async update(
-    @Request() req: ExpressRequest,
-    @Body() dto: UserUpdate,
-  ): Promise<User> {
-    const jurisdictionName = req.headers['jurisdictionname'] || '';
-    return await this.userService.update(
-      dto,
-      mapTo(User, req['user']),
-      jurisdictionName as string,
-    );
   }
 
   @Delete()
@@ -239,5 +210,52 @@ export class UserController {
     @Body() dto: ConfirmationRequest,
   ): Promise<SuccessDTO> {
     return await this.userService.isUserConfirmationTokenValid(dto);
+  }
+
+  @Put(`modifyFavoriteListings`)
+  @ApiOperation({
+    summary: 'Add or remove a listing from user favorites',
+    operationId: 'modifyFavoriteListings',
+  })
+  @ApiOkResponse({ type: UserFavoriteListing })
+  @UseGuards(JwtAuthGuard, UserProfilePermissionGuard)
+  async modifyFavoriteListings(
+    @Request() req: ExpressRequest,
+    @Body() dto: UserFavoriteListing,
+  ): Promise<User> {
+    return await this.userService.modifyFavoriteListings(
+      dto,
+      mapTo(User, req['user']),
+    );
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update user', operationId: 'update' })
+  @ApiOkResponse({ type: User })
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  @UseInterceptors(ActivityLogInterceptor)
+  async update(
+    @Request() req: ExpressRequest,
+    @Body() dto: UserUpdate,
+  ): Promise<User> {
+    const jurisdictionName = req.headers['jurisdictionname'] || '';
+    return await this.userService.update(
+      dto,
+      mapTo(User, req['user']),
+      jurisdictionName as string,
+    );
+  }
+
+  @Get(`:id`)
+  @ApiOperation({
+    summary: 'Get user by id',
+    operationId: 'retrieve',
+  })
+  @ApiOkResponse({ type: User })
+  @UseGuards(JwtAuthGuard, PermissionGuard)
+  async retrieve(
+    @Param('id', new ParseUUIDPipe({ version: '4' })) userId: string,
+  ): Promise<User> {
+    return this.userService.findOne(userId);
   }
 }

--- a/api/src/dtos/users/user-favorite-listing.dto.ts
+++ b/api/src/dtos/users/user-favorite-listing.dto.ts
@@ -1,0 +1,21 @@
+import { Expose } from 'class-transformer';
+import { IsDefined, IsEnum, IsString, IsUUID } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { ModificationEnum } from '../../enums/shared/modification-enum';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class UserFavoriteListing {
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  id: string;
+
+  @Expose()
+  @ApiProperty({ enum: ModificationEnum, enumName: 'ModificationEnum' })
+  @IsEnum(ModificationEnum, {
+    groups: [ValidationsGroupsEnum.default],
+  })
+  action: ModificationEnum;
+}

--- a/api/src/dtos/users/user.dto.ts
+++ b/api/src/dtos/users/user.dto.ts
@@ -142,4 +142,11 @@ export class User extends AbstractDTO {
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   @ApiPropertyOptional()
   activeRefreshToken?: string;
+
+  @Expose()
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
+  @Type(() => IdDTO)
+  @ApiPropertyOptional({ type: IdDTO, isArray: true })
+  favoriteListings?: IdDTO[];
 }

--- a/api/src/enums/shared/modification-enum.ts
+++ b/api/src/enums/shared/modification-enum.ts
@@ -1,0 +1,4 @@
+export enum ModificationEnum {
+  add = 'add',
+  remove = 'remove',
+}

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -42,6 +42,8 @@ import { getPublicEmailURL } from '../utilities/get-public-email-url';
 import { UserRole } from '../dtos/users/user-role.dto';
 import { RequestSingleUseCode } from '../dtos/single-use-code/request-single-use-code.dto';
 import { getSingleUseCode } from '../utilities/get-single-use-code';
+import { UserFavoriteListing } from '../dtos/users/user-favorite-listing.dto';
+import { ModificationEnum } from '../enums/shared/modification-enum';
 
 /*
   this is the service for users
@@ -58,6 +60,12 @@ const views: Partial<Record<UserViews, Prisma.UserAccountsInclude>> = {
 views.full = {
   ...views.base,
   listings: true,
+  favoriteListings: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
 };
 
 type findByOptions = {
@@ -980,5 +988,45 @@ export class UserService {
     await this.emailService.sendSingleUseCode(mapTo(User, user), singleUseCode);
 
     return { success: true };
+  }
+
+  async modifyFavoriteListings(dto: UserFavoriteListing, requestingUser: User) {
+    const listing = await this.prisma.listings.findUnique({
+      where: {
+        id: dto.id,
+      },
+    });
+
+    if (!listing) {
+      throw new NotFoundException(
+        `listingId ${dto.id} was requested but not found`,
+      );
+    }
+
+    let dataClause;
+    switch (dto.action) {
+      case ModificationEnum.add:
+        dataClause = {
+          connect: { id: dto.id },
+        };
+        break;
+      case ModificationEnum.remove:
+        dataClause = {
+          disconnect: { id: dto.id },
+        };
+        break;
+    }
+
+    const rawResults = await this.prisma.userAccounts.update({
+      data: {
+        favoriteListings: dataClause,
+      },
+      include: views.full,
+      where: {
+        id: requestingUser.id,
+      },
+    });
+
+    return mapTo(User, rawResults);
   }
 }

--- a/api/test/integration/user.e2e-spec.ts
+++ b/api/test/integration/user.e2e-spec.ts
@@ -15,11 +15,13 @@ import { ConfirmationRequest } from '../../src/dtos/users/confirmation-request.d
 import { UserService } from '../../src/services/user.service';
 import { UserCreate } from '../../src/dtos/users/user-create.dto';
 import { jurisdictionFactory } from '../../prisma/seed-helpers/jurisdiction-factory';
+import { listingFactory } from '../../prisma/seed-helpers/listing-factory';
 import { applicationFactory } from '../../prisma/seed-helpers/application-factory';
 import { UserInvite } from '../../src/dtos/users/user-invite.dto';
 import { EmailService } from '../../src/services/email.service';
 import { Login } from '../../src/dtos/auth/login.dto';
 import { RequestMfaCode } from '../../src/dtos/mfa/request-mfa-code.dto';
+import { ModificationEnum } from '../../src/enums/shared/modification-enum';
 
 describe('User Controller Tests', () => {
   let app: INestApplication;
@@ -846,5 +848,99 @@ describe('User Controller Tests', () => {
     expect(res.body.success).toEqual(true);
 
     expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
+  });
+
+  describe('modify favorite listings endpoint', () => {
+    let favoriteListingsCookies = '';
+    let jurisdictionId;
+    let removeListingId;
+
+    beforeAll(async () => {
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+
+      jurisdictionId = jurisdiction.id;
+
+      const removeListing = await prisma.listings.create({
+        data: await listingFactory(jurisdictionId, prisma),
+      });
+
+      removeListingId = removeListing.id;
+
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory({
+          confirmedAt: new Date(),
+          favoriteListings: [removeListingId],
+          mfaEnabled: false,
+          password: 'Abcdef12345!',
+        }),
+      });
+
+      const resLogIn = await request(app.getHttpServer())
+        .post('/auth/login')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: userA.email,
+          password: 'Abcdef12345!',
+        } as Login)
+        .expect(201);
+
+      favoriteListingsCookies = resLogIn.headers['set-cookie'];
+    });
+
+    it('should add a listing to favorite listing', async () => {
+      const addListing = await prisma.listings.create({
+        data: await listingFactory(jurisdictionId, prisma),
+      });
+
+      const res = await request(app.getHttpServer())
+        .put(`/user/modifyFavoriteListings`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          id: addListing.id,
+          action: ModificationEnum.add,
+        })
+        .set('Cookie', favoriteListingsCookies)
+        .expect(200);
+
+      expect(res.body.favoriteListings.length).toBeGreaterThanOrEqual(1);
+
+      const ids = res.body.favoriteListings.map((listing) => listing.id);
+      expect(ids).toContain(addListing.id);
+    });
+
+    it('should remove a listing from favorite listing', async () => {
+      const res = await request(app.getHttpServer())
+        .put(`/user/modifyFavoriteListings`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          id: removeListingId,
+          action: ModificationEnum.remove,
+        })
+        .set('Cookie', favoriteListingsCookies)
+        .expect(200);
+
+      const ids = res.body.favoriteListings.map((listing) => listing.id);
+      expect(ids).not.toContain(removeListingId);
+    });
+
+    it('should throw a not found error when listing does not exist', async () => {
+      const invalidId = randomUUID();
+
+      const res = await request(app.getHttpServer())
+        .put(`/user/modifyFavoriteListings`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          id: invalidId,
+          action: ModificationEnum.add,
+        })
+        .set('Cookie', favoriteListingsCookies)
+        .expect(404);
+
+      expect(res.body.message).toEqual(
+        `listingId ${invalidId} was requested but not found`,
+      );
+    });
   });
 });

--- a/api/test/unit/services/user.service.spec.ts
+++ b/api/test/unit/services/user.service.spec.ts
@@ -16,6 +16,7 @@ import { SendGridService } from '../../../src/services/sendgrid.service';
 import { User } from '../../../src/dtos/users/user.dto';
 import { PermissionService } from '../../../src/services/permission.service';
 import { permissionActions } from '../../../src/enums/permissions/permission-actions-enum';
+import { ModificationEnum } from '../../../src/enums/shared/modification-enum';
 import { OrderByEnum } from '../../../src/enums/shared/order-by-enum';
 import { UserViews } from '../../../src/enums/user/view-enum';
 
@@ -133,6 +134,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
         skip: 0,
@@ -178,6 +185,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
         skip: 5,
@@ -251,6 +264,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
         skip: 0,
@@ -272,9 +291,15 @@ describe('Testing user service', () => {
 
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          listings: true,
           jurisdictions: true,
+          listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id: 'example Id',
@@ -291,9 +316,15 @@ describe('Testing user service', () => {
 
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
-          listings: true,
           jurisdictions: true,
+          listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id: 'example Id',
@@ -379,6 +410,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -419,6 +456,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email,
@@ -688,6 +731,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email,
@@ -728,6 +777,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email,
@@ -760,6 +815,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email,
@@ -799,6 +860,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email,
@@ -824,6 +891,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email,
@@ -857,6 +930,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email,
@@ -895,6 +974,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email,
@@ -932,6 +1017,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email,
@@ -957,6 +1048,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email,
@@ -1079,6 +1176,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -1097,6 +1200,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -1150,6 +1259,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -1170,6 +1285,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -1225,6 +1346,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -1284,6 +1411,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -1337,6 +1470,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -1356,6 +1495,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -1411,6 +1556,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -1457,6 +1608,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -1504,6 +1661,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           id,
@@ -1555,6 +1718,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email: 'partnerUser@email.com',
@@ -1629,6 +1798,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email: 'partnerUser@email.com',
@@ -1639,6 +1814,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         data: {
           confirmedAt: null,
@@ -1713,6 +1894,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email: 'partnerUser@email.com',
@@ -1776,6 +1963,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         where: {
           email: 'publicUser@email.com',
@@ -1804,6 +1997,12 @@ describe('Testing user service', () => {
           jurisdictions: true,
           listings: true,
           userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
         },
         data: {
           confirmationToken: expect.anything(),
@@ -1946,279 +2145,411 @@ describe('Testing user service', () => {
     });
   });
 
-  it('should request single use code but user does not exist', async () => {
-    const id = randomUUID();
-    emailService.sendSingleUseCode = jest.fn();
-    prisma.userAccounts.findFirst = jest.fn().mockResolvedValue(null);
-    prisma.userAccounts.update = jest.fn().mockResolvedValue({
-      id,
+  describe('requestSingleUseCode', () => {
+    it('should request single use code but user does not exist', async () => {
+      const id = randomUUID();
+      emailService.sendSingleUseCode = jest.fn();
+      prisma.userAccounts.findFirst = jest.fn().mockResolvedValue(null);
+      prisma.userAccounts.update = jest.fn().mockResolvedValue({
+        id,
+      });
+
+      const res = await service.requestSingleUseCode(
+        {
+          email: 'example@exygy.com',
+        },
+        { headers: { jurisdictionname: 'juris 1' } } as unknown as Request,
+      );
+
+      expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
+        where: {
+          email: 'example@exygy.com',
+        },
+        include: {
+          jurisdictions: true,
+        },
+      });
+      expect(prisma.userAccounts.update).not.toHaveBeenCalled();
+      expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
+      expect(res).toEqual({
+        success: true,
+      });
     });
 
-    const res = await service.requestSingleUseCode(
-      {
-        email: 'example@exygy.com',
-      },
-      { headers: { jurisdictionname: 'juris 1' } } as unknown as Request,
-    );
+    it('should request single use code but jurisdiction does not exist', async () => {
+      const id = randomUUID();
+      emailService.sendSingleUseCode = jest.fn();
+      prisma.userAccounts.findFirst = jest.fn().mockResolvedValue({
+        id,
+      });
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue(null);
+      prisma.userAccounts.update = jest.fn().mockResolvedValue({
+        id,
+      });
 
-    expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
-      where: {
-        email: 'example@exygy.com',
-      },
-      include: {
-        jurisdictions: true,
-      },
-    });
-    expect(prisma.userAccounts.update).not.toHaveBeenCalled();
-    expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
-    expect(res).toEqual({
-      success: true,
-    });
-  });
+      await expect(
+        async () =>
+          await service.requestSingleUseCode(
+            {
+              email: 'example@exygy.com',
+            },
+            { headers: { jurisdictionname: 'juris 1' } } as unknown as Request,
+          ),
+      ).rejects.toThrowError('Jurisidiction juris 1 does not exists');
 
-  it('should request single use code but jurisdiction does not exist', async () => {
-    const id = randomUUID();
-    emailService.sendSingleUseCode = jest.fn();
-    prisma.userAccounts.findFirst = jest.fn().mockResolvedValue({
-      id,
-    });
-    prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue(null);
-    prisma.userAccounts.update = jest.fn().mockResolvedValue({
-      id,
-    });
-
-    await expect(
-      async () =>
-        await service.requestSingleUseCode(
-          {
-            email: 'example@exygy.com',
-          },
-          { headers: { jurisdictionname: 'juris 1' } } as unknown as Request,
-        ),
-    ).rejects.toThrowError('Jurisidiction juris 1 does not exists');
-
-    expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
-      where: {
-        email: 'example@exygy.com',
-      },
-      include: {
-        jurisdictions: true,
-      },
-    });
-    expect(prisma.jurisdictions.findFirst).toHaveBeenCalledWith({
-      select: {
-        id: true,
-        allowSingleUseCodeLogin: true,
-      },
-      where: {
-        name: 'juris 1',
-      },
-      orderBy: {
-        allowSingleUseCodeLogin: OrderByEnum.DESC,
-      },
-    });
-    expect(prisma.userAccounts.update).not.toHaveBeenCalled();
-    expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
-  });
-
-  it('should request single use code but jurisdiction disallows single use code login', async () => {
-    const id = randomUUID();
-    emailService.sendSingleUseCode = jest.fn();
-    prisma.userAccounts.findFirst = jest.fn().mockResolvedValue({
-      id,
-    });
-    prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
-      id: randomUUID(),
-      allowSingleUseCodeLogin: false,
-    });
-    prisma.userAccounts.update = jest.fn().mockResolvedValue({
-      id,
+      expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
+        where: {
+          email: 'example@exygy.com',
+        },
+        include: {
+          jurisdictions: true,
+        },
+      });
+      expect(prisma.jurisdictions.findFirst).toHaveBeenCalledWith({
+        select: {
+          id: true,
+          allowSingleUseCodeLogin: true,
+        },
+        where: {
+          name: 'juris 1',
+        },
+        orderBy: {
+          allowSingleUseCodeLogin: OrderByEnum.DESC,
+        },
+      });
+      expect(prisma.userAccounts.update).not.toHaveBeenCalled();
+      expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
     });
 
-    await expect(
-      async () =>
-        await service.requestSingleUseCode(
-          {
-            email: 'example@exygy.com',
-          },
-          { headers: { jurisdictionname: 'juris 1' } } as unknown as Request,
-        ),
-    ).rejects.toThrowError('Single use code login is not setup for juris 1');
+    it('should request single use code but jurisdictionname was not sent', async () => {
+      const id = randomUUID();
+      emailService.sendSingleUseCode = jest.fn();
+      prisma.userAccounts.findFirst = jest.fn().mockResolvedValue({
+        id,
+      });
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
+        id,
+      });
+      prisma.userAccounts.update = jest.fn().mockResolvedValue({
+        id,
+      });
 
-    expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
-      where: {
-        email: 'example@exygy.com',
-      },
-      include: {
-        jurisdictions: true,
-      },
-    });
-    expect(prisma.jurisdictions.findFirst).toHaveBeenCalledWith({
-      select: {
-        id: true,
-        allowSingleUseCodeLogin: true,
-      },
-      where: {
-        name: 'juris 1',
-      },
-      orderBy: {
-        allowSingleUseCodeLogin: OrderByEnum.DESC,
-      },
-    });
-    expect(prisma.userAccounts.update).not.toHaveBeenCalled();
-    expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
-  });
+      await expect(
+        async () =>
+          await service.requestSingleUseCode(
+            {
+              email: 'example@exygy.com',
+            },
+            {} as unknown as Request,
+          ),
+      ).rejects.toThrowError(
+        'jurisdictionname is missing from the request headers',
+      );
 
-  it('should request single use code but jurisdictionname was not sent', async () => {
-    const id = randomUUID();
-    emailService.sendSingleUseCode = jest.fn();
-    prisma.userAccounts.findFirst = jest.fn().mockResolvedValue({
-      id,
-    });
-    prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
-      id,
-    });
-    prisma.userAccounts.update = jest.fn().mockResolvedValue({
-      id,
+      expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
+        where: {
+          email: 'example@exygy.com',
+        },
+        include: {
+          jurisdictions: true,
+        },
+      });
+      expect(prisma.jurisdictions.findFirst).not.toHaveBeenCalled();
+      expect(prisma.userAccounts.update).not.toHaveBeenCalled();
+      expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
     });
 
-    await expect(
-      async () =>
-        await service.requestSingleUseCode(
-          {
-            email: 'example@exygy.com',
-          },
-          {} as unknown as Request,
-        ),
-    ).rejects.toThrowError(
-      'jurisdictionname is missing from the request headers',
-    );
+    it('should request single use code but jurisdiction disallows single use code login', async () => {
+      const id = randomUUID();
+      emailService.sendSingleUseCode = jest.fn();
+      prisma.userAccounts.findFirst = jest.fn().mockResolvedValue({
+        id,
+      });
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
+        id: randomUUID(),
+        allowSingleUseCodeLogin: false,
+      });
+      prisma.userAccounts.update = jest.fn().mockResolvedValue({
+        id,
+      });
 
-    expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
-      where: {
-        email: 'example@exygy.com',
-      },
-      include: {
-        jurisdictions: true,
-      },
-    });
-    expect(prisma.jurisdictions.findFirst).not.toHaveBeenCalled();
-    expect(prisma.userAccounts.update).not.toHaveBeenCalled();
-    expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
-  });
+      await expect(
+        async () =>
+          await service.requestSingleUseCode(
+            {
+              email: 'example@exygy.com',
+            },
+            { headers: { jurisdictionname: 'juris 1' } } as unknown as Request,
+          ),
+      ).rejects.toThrowError('Single use code login is not setup for juris 1');
 
-  it('should successfully request single use code when previous code is still valid', async () => {
-    process.env.MFA_CODE_LENGTH = '5';
-    process.env.MFA_CODE_VALID = '60000';
-    const id = randomUUID();
-    emailService.sendSingleUseCode = jest.fn();
-    prisma.userAccounts.findFirst = jest.fn().mockResolvedValue({
-      id,
-      singleUseCode: '00000',
-      singleUseCodeUpdatedAt: new Date(),
-    });
-    prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
-      id,
-      allowSingleUseCodeLogin: true,
-    });
-    prisma.userAccounts.update = jest.fn().mockResolvedValue({
-      id,
+      expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
+        where: {
+          email: 'example@exygy.com',
+        },
+        include: {
+          jurisdictions: true,
+        },
+      });
+      expect(prisma.jurisdictions.findFirst).toHaveBeenCalledWith({
+        select: {
+          id: true,
+          allowSingleUseCodeLogin: true,
+        },
+        where: {
+          name: 'juris 1',
+        },
+        orderBy: {
+          allowSingleUseCodeLogin: OrderByEnum.DESC,
+        },
+      });
+      expect(prisma.userAccounts.update).not.toHaveBeenCalled();
+      expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
     });
 
-    const res = await service.requestSingleUseCode(
-      {
-        email: 'example@exygy.com',
-      },
-      { headers: { jurisdictionname: 'juris 1' } } as unknown as Request,
-    );
-
-    expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
-      where: {
-        email: 'example@exygy.com',
-      },
-      include: {
-        jurisdictions: true,
-      },
-    });
-    expect(prisma.jurisdictions.findFirst).toHaveBeenCalledWith({
-      select: {
-        id: true,
-        allowSingleUseCodeLogin: true,
-      },
-      where: {
-        name: 'juris 1',
-      },
-      orderBy: {
-        allowSingleUseCodeLogin: OrderByEnum.DESC,
-      },
-    });
-    expect(prisma.userAccounts.update).toHaveBeenCalledWith({
-      data: {
+    it('should successfully request single use code when previous code is still valid', async () => {
+      process.env.MFA_CODE_LENGTH = '5';
+      process.env.MFA_CODE_VALID = '60000';
+      const id = randomUUID();
+      emailService.sendSingleUseCode = jest.fn();
+      prisma.userAccounts.findFirst = jest.fn().mockResolvedValue({
+        id,
         singleUseCode: '00000',
-        singleUseCodeUpdatedAt: expect.anything(),
-      },
-      where: {
+        singleUseCodeUpdatedAt: new Date(),
+      });
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
         id,
-      },
-    });
-    expect(emailService.sendSingleUseCode).toHaveBeenCalled();
-    expect(res.success).toEqual(true);
-  });
-  it('should successfully request single use code when previous code is outdated', async () => {
-    const id = randomUUID();
-    emailService.sendSingleUseCode = jest.fn();
-    prisma.userAccounts.findFirst = jest.fn().mockResolvedValue({
-      id,
-      singleUseCode: '00000',
-      singleUseCodeUpdatedAt: new Date(
-        new Date().getTime() - Number(process.env.MFA_CODE_VALUE) * 2,
-      ),
-    });
-    prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
-      id,
-      allowSingleUseCodeLogin: true,
-    });
-    prisma.userAccounts.update = jest.fn().mockResolvedValue({
-      id,
-    });
-
-    const res = await service.requestSingleUseCode(
-      {
-        email: 'example@exygy.com',
-      },
-      { headers: { jurisdictionname: 'juris 1' } } as unknown as Request,
-    );
-
-    expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
-      where: {
-        email: 'example@exygy.com',
-      },
-      include: {
-        jurisdictions: true,
-      },
-    });
-    expect(prisma.jurisdictions.findFirst).toHaveBeenCalledWith({
-      select: {
-        id: true,
         allowSingleUseCodeLogin: true,
-      },
-      where: {
-        name: 'juris 1',
-      },
-      orderBy: {
-        allowSingleUseCodeLogin: OrderByEnum.DESC,
-      },
-    });
-    expect(prisma.userAccounts.update).toHaveBeenCalledWith({
-      data: {
-        singleUseCode: expect.not.stringMatching('00000'),
-        singleUseCodeUpdatedAt: expect.anything(),
-      },
-      where: {
+      });
+      prisma.userAccounts.update = jest.fn().mockResolvedValue({
         id,
-      },
+      });
+
+      const res = await service.requestSingleUseCode(
+        {
+          email: 'example@exygy.com',
+        },
+        { headers: { jurisdictionname: 'juris 1' } } as unknown as Request,
+      );
+
+      expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
+        where: {
+          email: 'example@exygy.com',
+        },
+        include: {
+          jurisdictions: true,
+        },
+      });
+      expect(prisma.jurisdictions.findFirst).toHaveBeenCalledWith({
+        select: {
+          id: true,
+          allowSingleUseCodeLogin: true,
+        },
+        where: {
+          name: 'juris 1',
+        },
+        orderBy: {
+          allowSingleUseCodeLogin: OrderByEnum.DESC,
+        },
+      });
+      expect(prisma.userAccounts.update).toHaveBeenCalledWith({
+        data: {
+          singleUseCode: '00000',
+          singleUseCodeUpdatedAt: expect.anything(),
+        },
+        where: {
+          id,
+        },
+      });
+      expect(emailService.sendSingleUseCode).toHaveBeenCalled();
+      expect(res.success).toEqual(true);
     });
-    expect(emailService.sendSingleUseCode).toHaveBeenCalled();
-    expect(res.success).toEqual(true);
+    it('should successfully request single use code when previous code is outdated', async () => {
+      const id = randomUUID();
+      emailService.sendSingleUseCode = jest.fn();
+      prisma.userAccounts.findFirst = jest.fn().mockResolvedValue({
+        id,
+        singleUseCode: '00000',
+        singleUseCodeUpdatedAt: new Date(
+          new Date().getTime() - Number(process.env.MFA_CODE_VALUE) * 2,
+        ),
+      });
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue({
+        id,
+        allowSingleUseCodeLogin: true,
+      });
+      prisma.userAccounts.update = jest.fn().mockResolvedValue({
+        id,
+      });
+
+      const res = await service.requestSingleUseCode(
+        {
+          email: 'example@exygy.com',
+        },
+        { headers: { jurisdictionname: 'juris 1' } } as unknown as Request,
+      );
+
+      expect(prisma.userAccounts.findFirst).toHaveBeenCalledWith({
+        where: {
+          email: 'example@exygy.com',
+        },
+        include: {
+          jurisdictions: true,
+        },
+      });
+      expect(prisma.jurisdictions.findFirst).toHaveBeenCalledWith({
+        select: {
+          id: true,
+          allowSingleUseCodeLogin: true,
+        },
+        where: {
+          name: 'juris 1',
+        },
+        orderBy: {
+          allowSingleUseCodeLogin: OrderByEnum.DESC,
+        },
+      });
+      expect(prisma.userAccounts.update).toHaveBeenCalledWith({
+        data: {
+          singleUseCode: expect.not.stringMatching('00000'),
+          singleUseCodeUpdatedAt: expect.anything(),
+        },
+        where: {
+          id,
+        },
+      });
+      expect(emailService.sendSingleUseCode).toHaveBeenCalled();
+      expect(res.success).toEqual(true);
+    });
+  });
+
+  describe('modifyFavoriteListings', () => {
+    it('should add a listing to favorite listings', async () => {
+      const userId = randomUUID();
+      const listingId = randomUUID();
+
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        listingId,
+      });
+      prisma.userAccounts.update = jest.fn().mockResolvedValue({
+        userId,
+      });
+
+      await service.modifyFavoriteListings(
+        {
+          id: listingId,
+          action: ModificationEnum.add,
+        },
+        {
+          id: userId,
+        } as unknown as User,
+      );
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: listingId,
+        },
+      });
+      expect(prisma.userAccounts.update).toHaveBeenCalledWith({
+        data: {
+          favoriteListings: {
+            connect: { id: listingId },
+          },
+        },
+        include: {
+          jurisdictions: true,
+          listings: true,
+          userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+        where: {
+          id: userId,
+        },
+      });
+    });
+
+    it('should remove a listing from favorite listings', async () => {
+      const userId = randomUUID();
+      const listingId = randomUUID();
+
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        listingId,
+      });
+      prisma.userAccounts.update = jest.fn().mockResolvedValue({
+        userId,
+      });
+
+      await service.modifyFavoriteListings(
+        {
+          id: listingId,
+          action: ModificationEnum.remove,
+        },
+        {
+          id: userId,
+        } as unknown as User,
+      );
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: listingId,
+        },
+      });
+      expect(prisma.userAccounts.update).toHaveBeenCalledWith({
+        data: {
+          favoriteListings: {
+            disconnect: { id: listingId },
+          },
+        },
+        include: {
+          jurisdictions: true,
+          listings: true,
+          userRoles: true,
+          favoriteListings: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+        where: {
+          id: userId,
+        },
+      });
+    });
+
+    it('should throw a not found error when listing does not exist', async () => {
+      const userId = randomUUID();
+      const listingId = randomUUID();
+
+      prisma.listings.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.userAccounts.update = jest.fn().mockResolvedValue(null);
+
+      await expect(
+        async () =>
+          await service.modifyFavoriteListings(
+            {
+              id: listingId,
+              action: ModificationEnum.add,
+            },
+            {
+              id: userId,
+            } as unknown as User,
+          ),
+      ).rejects.toThrowError(
+        `listingId ${listingId} was requested but not found`,
+      );
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: listingId,
+        },
+      });
+      expect(prisma.userAccounts.update).not.toHaveBeenCalledWith();
+    });
   });
 });

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -1779,49 +1779,6 @@ export class UserService {
     })
   }
   /**
-   * Get user by id
-   */
-  retrieve(
-    params: {
-      /**  */
-      id: string
-    } = {} as any,
-    options: IRequestOptions = {}
-  ): Promise<User> {
-    return new Promise((resolve, reject) => {
-      let url = basePath + "/user/{id}"
-      url = url.replace("{id}", params["id"] + "")
-
-      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
-
-      axios(configs, resolve, reject)
-    })
-  }
-  /**
-   * Update user
-   */
-  update(
-    params: {
-      /** requestBody */
-      body?: UserUpdate
-    } = {} as any,
-    options: IRequestOptions = {}
-  ): Promise<User> {
-    return new Promise((resolve, reject) => {
-      let url = basePath + "/user/{id}"
-
-      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
-
-      let data = params.body
-
-      configs.data = data
-
-      axios(configs, resolve, reject)
-    })
-  }
-  /**
    * Forgot Password
    */
   forgotPassword(
@@ -1949,6 +1906,71 @@ export class UserService {
       let data = params.body
 
       configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Add or remove a listing from user favorites
+   */
+  modifyFavoriteListings(
+    params: {
+      /** requestBody */
+      body?: UserFavoriteListing
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<UserFavoriteListing> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/user/modifyFavoriteListings"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Update user
+   */
+  update(
+    params: {
+      /** requestBody */
+      body?: UserUpdate
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<User> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/user/{id}"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Get user by id
+   */
+  retrieve(
+    params: {
+      /**  */
+      id: string
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<User> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/user/{id}"
+      url = url.replace("{id}", params["id"] + "")
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
+
+      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -5925,6 +5947,9 @@ export interface User {
 
   /**  */
   activeRefreshToken?: string
+
+  /**  */
+  favoriteListings?: IdDTO[]
 }
 
 export interface UserFilterParams {
@@ -5938,56 +5963,6 @@ export interface PaginatedUser {
 
   /**  */
   meta: PaginationMeta
-}
-
-export interface UserUpdate {
-  /**  */
-  id: string
-
-  /**  */
-  firstName: string
-
-  /**  */
-  middleName?: string
-
-  /**  */
-  lastName: string
-
-  /**  */
-  dob?: Date
-
-  /**  */
-  phoneNumber?: string
-
-  /**  */
-  listings: IdDTO[]
-
-  /**  */
-  userRoles?: UserRole
-
-  /**  */
-  language?: LanguagesEnum
-
-  /**  */
-  agreedToTermsOfService: boolean
-
-  /**  */
-  email?: string
-
-  /**  */
-  newEmail?: string
-
-  /**  */
-  password?: string
-
-  /**  */
-  currentPassword?: string
-
-  /**  */
-  appUrl?: string
-
-  /**  */
-  jurisdictions?: IdDTO[]
 }
 
 export interface UserCreate {
@@ -6014,6 +5989,9 @@ export interface UserCreate {
 
   /**  */
   agreedToTermsOfService: boolean
+
+  /**  */
+  favoriteListings?: IdDTO[]
 
   /**  */
   newEmail?: string
@@ -6063,6 +6041,9 @@ export interface UserInvite {
   language?: LanguagesEnum
 
   /**  */
+  favoriteListings?: IdDTO[]
+
+  /**  */
   newEmail?: string
 
   /**  */
@@ -6083,6 +6064,67 @@ export interface RequestSingleUseCode {
 export interface ConfirmationRequest {
   /**  */
   token: string
+}
+
+export interface UserFavoriteListing {
+  /**  */
+  id: string
+
+  /**  */
+  action: ModificationEnum
+}
+
+export interface UserUpdate {
+  /**  */
+  id: string
+
+  /**  */
+  firstName: string
+
+  /**  */
+  middleName?: string
+
+  /**  */
+  lastName: string
+
+  /**  */
+  dob?: Date
+
+  /**  */
+  phoneNumber?: string
+
+  /**  */
+  listings: IdDTO[]
+
+  /**  */
+  userRoles?: UserRole
+
+  /**  */
+  language?: LanguagesEnum
+
+  /**  */
+  agreedToTermsOfService: boolean
+
+  /**  */
+  favoriteListings?: IdDTO[]
+
+  /**  */
+  email?: string
+
+  /**  */
+  newEmail?: string
+
+  /**  */
+  password?: string
+
+  /**  */
+  currentPassword?: string
+
+  /**  */
+  appUrl?: string
+
+  /**  */
+  jurisdictions?: IdDTO[]
 }
 
 export interface Login {
@@ -6504,6 +6546,11 @@ export enum ApplicationsFilterEnum {
   "lottery" = "lottery",
   "closed" = "closed",
   "open" = "open",
+}
+
+export enum ModificationEnum {
+  "add" = "add",
+  "remove" = "remove",
 }
 
 export enum MfaType {


### PR DESCRIPTION
This PR addresses [#(4609)](https://github.com/bloom-housing/bloom/issues/4609)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Creates a favorite listings many-to-many join table for users -> listings. Adds an endpoint to modify the favorite listings for a user. Can either add a listing to the favorites or remove a listing.

Repeat calls to add a listing that is already favorited or to remove a listing that is not favorited have no consequence. Attempting to add/remove a listing id that does not exist will cause a not found error.

## How Can This Be Tested/Reviewed?

Spin up public site and backend.
Create a public user, confirm account and sign in.
Using OpenAPI or calling the API directly using the user cookies, call the `/users/modifyFavoriteListings` POST endpoint with an existing listing id and action as `add`.
Verify listing id appears in favoriteListings on the user in the response.
Call endpoint again with the same id and the action as `remove`.
Verify listing id no longer appears in favoriteListings on the user in the response.
Call endpoint again with a nonexistent listing id, either action.
Verify 404 was thrown.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
