### PR TITLE
feat: new maintenance message

### DIFF
--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -79,6 +79,7 @@
   "account.viewApplications": "Ver aplicaciones",
   "alert.maintenance": "Este sitio está en mantenimiento programado. Nos disculpamos por cualquier inconveniente.",
   "alert.transition": "Se realizará la transición de este sitio al Doorway Housing Portal y se redirigirá a <a className='lined' href='https://www.housingbayarea.org/es' target='_blank'>housingbayarea.org</a>.",
+  "alert.transitionv3": "Este sitio se integrará al portal de viviendas Doorway. Visite <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a> para encontrar nuevas oportunidades de viviendas asequibles a partir del 12 de mayo.",
   "application.ada.hearing": "Para dificultades auditivas",
   "application.ada.label": "Viviendas accesibles de conformidad con ADA",
   "application.ada.mobility": "Para dificultades en la movilidad",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -79,6 +79,7 @@
   "alert.maintenance": "This site is undergoing scheduled maintenance. We apologize for any inconvenience.",
   "alert.transition": "This site will be transitioning into the Doorway Housing Portal and will redirect to <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a>.",
   "alert.transitionv2": "This site is transitioning to the <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>Doorway Housing Portal</a>. If you have questions about your account or applications, please contact Doorway@smchousing.org.",
+  "alert.transitionv3": "This site will be folding into the Doorway Housing Portal. Please visit <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a> to find new affordable housing opportunities starting May 12th.",
   "application.ada.hearing": "For Hearing Impairments",
   "application.ada.label": "ADA Accessible Units",
   "application.ada.mobility": "For Mobility Impairments",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -79,6 +79,7 @@
   "account.viewApplications": "Tingnan ang mga application",
   "alert.maintenance": "Ang site na ito ay sumasailalim sa naka-iskedyul na pagpapanatili. Humihingi kami ng paumanhin para sa anumang abala.",
   "alert.transition": "Ang site na ito ay magiging Doorway Housing Portal at magre-redirect sa <a className='lined' href='https://www.housingbayarea.org/tl' target='_blank'>housingbayarea.org</a>.",
+  "alert.transitionv3": "Ang site na ito ay matitiklop sa Doorway Housing Portal. Pakibisita ang <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a> upang makahanap ng mga bagong pagkakataon sa abot-kayang pabahay simula ika-12 ng Mayo.",
   "application.ada.hearing": "Para Sa Mga Kapansanan Sa Pandinig",
   "application.ada.label": "Mga Accessible Unit ng ADA",
   "application.ada.mobility": "Para Sa Mga Kapansanan Sa Pagkilos",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -79,6 +79,7 @@
   "account.viewApplications": "Xem ứng dụng",
   "alert.maintenance": "Trang web này đang được bảo trì theo lịch trình. Chúng tôi xin lỗi vì bất cứ sự bất tiện nào.",
   "alert.transition": "Trang web này sẽ chuyển sang Doorway Housing Portal và sẽ chuyển hướng đến <a className='lined' href='https://www.housingbayarea.org/vi' target='_blank'>housingbayarea.org</a>.",
+  "alert.transitionv3": "Trang web này sẽ được đưa vào Cổng thông tin nhà ở Doorway. Vui lòng truy cập <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a> để tìm các cơ hội nhà ở giá rẻ mới bắt đầu từ ngày 12 tháng 5.",
   "application.ada.hearing": "Dành cho các cư dân bị Suy giảm Thính lực",
   "application.ada.label": "Các Căn nhà Dễ tiếp cập của ADA",
   "application.ada.mobility": "Dành cho các cư dân Vận động Khó khăn",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -79,6 +79,7 @@
   "account.viewApplications": "查看应用程序",
   "alert.maintenance": "该网站正在进行定期维护。很抱歉给您带来不便。",
   "alert.transition": "此网站将转换为住房门户网站/ Doorway Housing Portal 并且其网址 将更新到 <a className='lined' href='https://www.housingbayarea.org/zh' target='_blank'>housingbayarea.org</a>.",
+  "alert.transitionv3": "該網站將折疊到門口住房門戶網站中。從 5 月 12 日起，請造訪 <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a> 尋找新的經濟適用房機會。",
   "application.ada.hearing": "聽障",
   "application.ada.label": "《美國殘疾人法案》(ADA) 規定的無障礙單位",
   "application.ada.mobility": "行動不便",

--- a/sites/public/src/layouts/application.tsx
+++ b/sites/public/src/layouts/application.tsx
@@ -113,7 +113,7 @@ const Layout = (props) => {
         {getInMaintenance() && (
           <div className={styles["site-alert-banner-container"]}>
             <Message className={styles["site-alert-banner-content"]} variant={"primary"}>
-              <Markdown>{t("alert.maintenance")}</Markdown>
+              <Markdown>{t("alert.transitionv3")}</Markdown>
             </Message>
           </div>
         )}


### PR DESCRIPTION
This PR addresses #4690

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds a new maintenance message for the Alameda transition.

## How Can This Be Tested/Reviewed?

I tested the message locally by manually toggling maintenance mode to be on.

![Screenshot 2025-03-10 at 4 54 37 PM](https://github.com/user-attachments/assets/89d9568c-c0f2-4376-b664-3ff52eac5039)
![Screenshot 2025-03-10 at 4 54 44 PM](https://github.com/user-attachments/assets/8acc8523-876a-4632-a065-16c81cf61fd5)

After this is merged, to turn this on in production, I will set the following variable on only the Alameda public site:
`MAINTENANCE_WINDOW=2025-03-12 00:00 -08:00,2025-05-12 00:00 -08:00`

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
