### PR TITLE
test: partners forgot password integration tests 

### DIFF
--- a/shared-helpers/src/views/forgot-password/FormForgotPassword.tsx
+++ b/shared-helpers/src/views/forgot-password/FormForgotPassword.tsx
@@ -1,20 +1,13 @@
-import React, { useContext } from "react"
+import React from "react"
 import { Button } from "@bloom-housing/ui-seeds"
-import {
-  Field,
-  Form,
-  t,
-  AlertBox,
-  AlertNotice,
-  ErrorMessage,
-  NavigationContext,
-} from "@bloom-housing/ui-components"
+import { Field, Form, t, AlertBox, AlertNotice, ErrorMessage } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import { NetworkErrorReset, NetworkStatusContent } from "../../auth/catchNetworkError"
 import type { UseFormMethods } from "react-hook-form"
 import { BloomCard } from "../components/BloomCard"
 import { emailRegex } from "../../utilities/regex"
 import styles from "./FormForgotPassword.module.scss"
+import { useRouter } from "next/router"
 
 export type FormForgotPasswordProps = {
   control: FormForgotPasswordControl
@@ -46,7 +39,7 @@ const FormForgotPassword = ({
     window.scrollTo(0, 0)
   }
 
-  const { router } = useContext(NavigationContext)
+  const router = useRouter()
 
   return (
     <BloomCard title={t("authentication.forgotPassword.sendEmail")} iconSymbol={"profile"}>

--- a/sites/partners/__tests__/forgot-password.test.tsx
+++ b/sites/partners/__tests__/forgot-password.test.tsx
@@ -1,0 +1,147 @@
+/* eslint-disable import/no-named-as-default */
+import React from "react"
+import { setupServer } from "msw/lib/node"
+import { fireEvent, mockNextRouter, render, waitFor } from "./testUtils"
+import ForgotPassword from "../src/pages/forgot-password"
+import userEvent from "@testing-library/user-event"
+import { rest } from "msw"
+
+const server = setupServer()
+window.scrollTo = jest.fn()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  window.sessionStorage.clear()
+})
+
+afterAll(() => server.close())
+
+describe("forgot-password", () => {
+  it("should display all required inputs", () => {
+    mockNextRouter()
+
+    const { getByText, getByLabelText } = render(<ForgotPassword />)
+
+    expect(getByText("Send email", { selector: "h1" }))
+    expect(getByLabelText("Email"))
+    expect(getByText("Send email", { selector: "button" }))
+    expect(getByText("Cancel"))
+  })
+
+  describe("should show alert box messages", () => {
+    it("should display no alert box at first render", () => {
+      mockNextRouter()
+      const { queryByText } = render(<ForgotPassword />)
+
+      expect(
+        queryByText("There are errors you'll need to resolve before moving on.")
+      ).not.toBeInTheDocument()
+      expect(queryByText("Please enter a valid email address")).not.toBeInTheDocument()
+    })
+
+    it("should display alert box on missing input", async () => {
+      const { getByText, getByLabelText, findByText, queryByText } = render(<ForgotPassword />)
+
+      const submitButton = getByText("Send email", { selector: "button" })
+      const emailInput = getByLabelText("Email")
+      await waitFor(() => fireEvent.click(submitButton))
+
+      const inputErrorMessage = await findByText("Please enter a valid email address")
+      const componentErrorMessage = await findByText(
+        "There are errors you'll need to resolve before moving on."
+      )
+
+      expect(inputErrorMessage).toBeInTheDocument()
+      expect(componentErrorMessage).toBeInTheDocument()
+
+      // Should hide on valid input
+      await waitFor(() => userEvent.type(emailInput, "test@example.com"))
+
+      expect(
+        queryByText("There are errors you'll need to resolve before moving on.")
+      ).not.toBeInTheDocument()
+      expect(queryByText("Please enter a valid email address")).not.toBeInTheDocument()
+    })
+
+    it("should display alert box on invalid input", async () => {
+      const { getByText, getByLabelText, findByText, queryByText } = render(<ForgotPassword />)
+
+      const submitButton = getByText("Send email", { selector: "button" })
+      const emailInput = getByLabelText("Email")
+      await waitFor(async () => {
+        await userEvent.type(emailInput, "test")
+        fireEvent.click(submitButton)
+      })
+
+      const inputErrorMessage = await findByText("Please enter a valid email address")
+      const componentErrorMessage = await findByText(
+        "There are errors you'll need to resolve before moving on."
+      )
+
+      expect(inputErrorMessage).toBeInTheDocument()
+      expect(componentErrorMessage).toBeInTheDocument()
+
+      // Should hide on valid input
+      await waitFor(() => userEvent.type(emailInput, "test@example.com"))
+
+      expect(
+        queryByText("There are errors you'll need to resolve before moving on.")
+      ).not.toBeInTheDocument()
+      expect(queryByText("Please enter a valid email address")).not.toBeInTheDocument()
+    })
+  })
+
+  it("should navigate back on cancel", async () => {
+    const { backMock } = mockNextRouter()
+
+    const { getByText } = render(<ForgotPassword />)
+
+    const cancelButton = getByText("Cancel")
+    fireEvent.click(cancelButton)
+    await waitFor(() => expect(backMock).toHaveBeenCalledTimes(1))
+  })
+
+  it("should navigate to sign in page on submit", async () => {
+    const { pushMock } = mockNextRouter()
+    jest.spyOn(console, "error").mockImplementation()
+    server.use(
+      rest.put("http://localhost/api/adapter/user/forgot-password", (_req, res, ctx) => {
+        return res(ctx.json({ success: true }))
+      })
+    )
+    const { getByText, getByLabelText } = render(<ForgotPassword />)
+
+    const submitButton = getByText("Send email", { selector: "button" })
+    const emailInput = getByLabelText("Email")
+    await waitFor(async () => {
+      await userEvent.type(emailInput, "test@example.com")
+      fireEvent.click(submitButton)
+      expect(pushMock).toHaveBeenCalledWith("/sign-in")
+    })
+  })
+
+  it("should show error message on failed submit", async () => {
+    mockNextRouter()
+    jest.spyOn(console, "error").mockImplementation()
+    server.use(
+      rest.put("http://localhost/api/adapter/user/forgot-password", (_req, res, ctx) => {
+        return res(ctx.status(400), ctx.json({ message: "Failed" }))
+      })
+    )
+    const { getByText, getByLabelText, findByText } = render(<ForgotPassword />)
+
+    const submitButton = getByText("Send email", { selector: "button" })
+    const emailInput = getByLabelText("Email")
+    await waitFor(async () => {
+      await userEvent.type(emailInput, "test@example.com")
+      fireEvent.click(submitButton)
+    })
+
+    const genericError = await findByText("Please try again, or contact support for help.")
+    expect(genericError).toBeInTheDocument()
+  })
+})

--- a/sites/partners/__tests__/testUtils.tsx
+++ b/sites/partners/__tests__/testUtils.tsx
@@ -28,11 +28,13 @@ export const mockNextRouter = (query?: any) => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const useRouter = jest.spyOn(require("next/router"), "useRouter")
   const pushMock = jest.fn()
+  const backMock = jest.fn()
   useRouter.mockImplementation(() => ({
     pathname: "/",
     query: query ?? "",
     push: pushMock,
+    back: backMock,
   }))
 
-  return { useRouter, pushMock }
+  return { useRouter, pushMock, backMock }
 }


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Update partners site forgot password component to use Next router
* Add new router `back()` mock call to uni test helpers
* Create partners site forgot password page integration tests

## How Can This Be Tested/Reviewed?

* Run the unit tests for the partners site source code

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
