### PR TITLE
feat: Public sites forgot-password integration tests 

### DIFF
--- a/sites/public/__tests__/pages/forgot-password.test.tsx
+++ b/sites/public/__tests__/pages/forgot-password.test.tsx
@@ -1,0 +1,83 @@
+import React from "react"
+import { AuthContext } from "@bloom-housing/shared-helpers"
+import { fireEvent, mockNextRouter, render, waitFor } from "../testUtils"
+import { user } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import { ForgotPassword } from "../../src/pages/forgot-password"
+
+beforeAll(() => {
+  mockNextRouter()
+  window.scrollTo = jest.fn()
+})
+
+const renderForgotPasswordPage = () =>
+  render(
+    <AuthContext.Provider
+      value={{
+        profile: { ...user, listings: [], jurisdictions: [] },
+      }}
+    >
+      <ForgotPassword />
+    </AuthContext.Provider>
+  )
+
+describe("Forgot Password Page", () => {
+  it("renders all page elements including fields, buttons and links", () => {
+    const { getByText, getByLabelText } = renderForgotPasswordPage()
+
+    expect(getByText("Send email", { selector: "h1" })).toBeInTheDocument()
+    expect(getByLabelText("Email")).toBeInTheDocument()
+    expect(getByText("Send email", { selector: "button" })).toBeInTheDocument()
+    expect(getByText("Cancel", { selector: "button" })).toBeInTheDocument()
+  })
+
+  describe("Field validation errors", () => {
+    it("show validation error on empty email submit", async () => {
+      const { findByText, getByText, queryByText } = renderForgotPasswordPage()
+
+      expect(
+        queryByText("There are errors you'll need to resolve before moving on.")
+      ).not.toBeInTheDocument()
+      expect(queryByText("Please enter a valid email address")).not.toBeInTheDocument()
+
+      fireEvent.click(getByText("Send email", { selector: "button" }))
+      expect(
+        await findByText("There are errors you'll need to resolve before moving on.")
+      ).toBeInTheDocument()
+      expect(await findByText("Please enter a valid email address")).toBeInTheDocument()
+    })
+
+    it("show validation error on invalid email", async () => {
+      const { findByText, getByText, getByLabelText, queryByText } = renderForgotPasswordPage()
+
+      expect(
+        queryByText("There are errors you'll need to resolve before moving on.")
+      ).not.toBeInTheDocument()
+      expect(queryByText("Please enter a valid email address")).not.toBeInTheDocument()
+
+      fireEvent.change(getByLabelText("Email"), { target: { value: "test" } })
+      fireEvent.click(getByText("Send email", { selector: "button" }))
+      expect(
+        await findByText("There are errors you'll need to resolve before moving on.")
+      ).toBeInTheDocument()
+      expect(await findByText("Please enter a valid email address")).toBeInTheDocument()
+    })
+  })
+
+  it("should navigate back on cancel", async () => {
+    const { backMock } = mockNextRouter()
+    const { getByText } = renderForgotPasswordPage()
+
+    fireEvent.click(getByText("Cancel", { selector: "button" }))
+    await waitFor(() => expect(backMock).toBeCalled())
+  })
+
+  it("should navigate to sign-in on submit", async () => {
+    const { pushMock } = mockNextRouter()
+    const { getByText, getByLabelText } = renderForgotPasswordPage()
+    fireEvent.change(getByLabelText("Email"), { target: { value: "example@admin.com" } })
+    fireEvent.click(getByText("Send email", { selector: "button" }))
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/sign-in")
+    })
+  })
+})

--- a/sites/public/__tests__/testUtils.tsx
+++ b/sites/public/__tests__/testUtils.tsx
@@ -71,8 +71,13 @@ export { customRender as render }
 export const mockNextRouter = () => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const useRouter = jest.spyOn(require("next/router"), "useRouter")
+  const pushMock = jest.fn()
+  const backMock = jest.fn()
   useRouter.mockImplementation(() => ({
     pathname: "/",
+    push: pushMock,
+    back: backMock,
   }))
-  return useRouter
+
+  return { useRouter, pushMock, backMock }
 }


### PR DESCRIPTION
This PR addresses #4555

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Update public sites test utils next router mock
* Add public sites "Forgot Password" page integration tests

## How Can This Be Tested/Reviewed?

Run the `yarn jest -w -t "Forgot Password Page"` in the `public` sites folder

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
