### PR TITLE
feat: Application View component integration tests

### DIFF
--- a/sites/public/.jest/setup-tests.js
+++ b/sites/public/.jest/setup-tests.js
@@ -5,6 +5,9 @@ import "@testing-library/jest-dom/extend-expect"
 import general from "../page_content/locale_overrides/general.json"
 addTranslation({ ...generalTranslations, ...general })
 import "@testing-library/jest-dom"
+import "whatwg-fetch"
+import { serviceOptions } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import axios from "axios"
 
 // see: https://jestjs.io/docs/en/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 window.matchMedia = jest.fn().mockImplementation((query) => {
@@ -21,6 +24,12 @@ window.matchMedia = jest.fn().mockImplementation((query) => {
 })
 
 process.env.backendApiBase = "http://localhost:3100"
+
+global.beforeEach(() => {
+  serviceOptions.axios = axios.create({
+    baseURL: "http://localhost:3100",
+  })
+})
 
 // Need to set __next on base div to handle the overlay
 const portalRoot = document.createElement("div")

--- a/sites/public/__tests__/components/applications/ApplicationsView.test.tsx
+++ b/sites/public/__tests__/components/applications/ApplicationsView.test.tsx
@@ -1,0 +1,385 @@
+import React from "react"
+import { cleanup } from "@testing-library/react"
+import { mockNextRouter, render, waitFor, within, screen } from "../../testUtils"
+import { AuthContext } from "@bloom-housing/shared-helpers"
+import ApplicationsView, {
+  ApplicationsIndexEnum,
+} from "../../../src/components/account/ApplicationsView"
+import { GenericRouter, NavigationContext } from "@bloom-housing/ui-components"
+import { application, listing, user } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import {
+  ApplicationsService,
+  ListingsStatusEnum,
+  LotteryStatusEnum,
+  PublicAppsViewResponse,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { setupServer } from "msw/lib/node"
+import { rest } from "msw"
+import userEvent from "@testing-library/user-event"
+
+const server = setupServer()
+window.scrollTo = jest.fn()
+
+const mockRouter: GenericRouter = {
+  pathname: "",
+  asPath: "",
+  back: jest.fn(),
+  push(url: string) {
+    this.pathname = url
+    this.asPath = url
+  },
+}
+
+beforeAll(() => {
+  server.listen()
+  mockNextRouter()
+  process.env.showPublicLottery = "TRUE"
+})
+
+beforeEach(() => {
+  mockRouter.push("")
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  cleanup()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+function getApplications(
+  openCount = 0,
+  closedCount = 0,
+  lotteryCount = 0,
+  filterType = ApplicationsIndexEnum.all
+): PublicAppsViewResponse {
+  return {
+    displayApplications: [
+      ...(openCount &&
+      (filterType === ApplicationsIndexEnum.all || filterType === ApplicationsIndexEnum.open)
+        ? Array(openCount).fill({
+            ...application,
+            listings: { ...listing, status: ListingsStatusEnum.active },
+          })
+        : []),
+      ...(closedCount &&
+      (filterType === ApplicationsIndexEnum.all || filterType === ApplicationsIndexEnum.closed)
+        ? Array(closedCount).fill({
+            ...application,
+            listings: {
+              ...listing,
+              status: ListingsStatusEnum.pending,
+              lotteryStatus: LotteryStatusEnum.publishedToPublic,
+            },
+          })
+        : []),
+      ...(lotteryCount &&
+      (filterType === ApplicationsIndexEnum.all || filterType === ApplicationsIndexEnum.lottery)
+        ? Array(lotteryCount).fill({
+            ...application,
+            listings: { ...listing, status: ListingsStatusEnum.closed },
+          })
+        : []),
+    ],
+    applicationsCount: {
+      total: openCount + closedCount + lotteryCount,
+      lottery: lotteryCount,
+      closed: closedCount,
+      open: openCount,
+    },
+  }
+}
+
+function renderApplicationsView(filterType = ApplicationsIndexEnum.all) {
+  return render(
+    <AuthContext.Provider
+      value={{
+        profile: { ...user, jurisdictions: [], listings: [] },
+        applicationsService: new ApplicationsService(),
+      }}
+    >
+      <ApplicationsView filterType={filterType} />
+    </AuthContext.Provider>
+  )
+}
+
+describe("<ApplicationsView>", () => {
+  it("should redirect to sign-in page for non logged user", async () => {
+    server.use(
+      rest.get("http://localhost:3100/applications/publicAppsView", (_req, res) => {
+        return res()
+      })
+    )
+
+    render(
+      <NavigationContext.Provider
+        value={{
+          router: mockRouter,
+          LinkComponent: (props) => <a href={props.href}>{props.children}</a>,
+        }}
+      >
+        <AuthContext.Provider
+          value={{
+            profile: undefined,
+            initialStateLoaded: true,
+          }}
+        >
+          <ApplicationsView filterType={ApplicationsIndexEnum.all} />
+        </AuthContext.Provider>
+      </NavigationContext.Provider>
+    )
+
+    await waitFor(() => expect(mockRouter.pathname).toEqual("/sign-in"))
+  })
+
+  it("should render the page with application fetching error", async () => {
+    server.use(
+      rest.get("http://localhost:3100/applications/publicAppsView", (_req, res, ctx) => {
+        return res(ctx.status(500)) // Return status code 500 to mock an server fetching error
+      })
+    )
+    renderApplicationsView()
+
+    // Dashboard heading
+    expect(screen.getByRole("heading", { level: 1, name: /my applications/i })).toBeInTheDocument()
+    expect(
+      screen.getByText("See lottery dates and listings for properties for which you've applied")
+    ).toBeInTheDocument()
+
+    // Application section (Missing fallback component)
+    expect(
+      await screen.findByRole("heading", { level: 2, name: /error fetching applications/i })
+    ).toBeInTheDocument()
+  })
+
+  describe("should render page with proper missing applications message", () => {
+    it("should render the page without any existing applications", async () => {
+      server.use(
+        rest.get("http://localhost:3100/applications/publicAppsView", (_req, res, ctx) => {
+          return res(ctx.json(getApplications()))
+        })
+      )
+
+      renderApplicationsView()
+
+      // Dashboard heading
+      expect(
+        screen.getByRole("heading", { level: 1, name: /my applications/i })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText("See lottery dates and listings for properties for which you've applied")
+      ).toBeInTheDocument()
+
+      // Application section (Missing fallback component)
+      expect(
+        await screen.findByText("It looks like you haven't applied to any listings yet.")
+      ).toBeInTheDocument()
+      const browseListingsButton = await screen.findByRole("link", { name: /Browse Listings/i })
+      expect(browseListingsButton).toBeInTheDocument()
+      expect(browseListingsButton).toHaveAttribute("href", "/listings")
+
+      // Tab Panel
+      const allApplicationsTab = screen.getByTestId("total-applications-tab")
+      expect(
+        within(allApplicationsTab).getByText("All my applications", { selector: "span" })
+      ).toBeInTheDocument()
+      expect(within(allApplicationsTab).getByText("0")).toBeInTheDocument()
+
+      const closedApplicationsTab = screen.getByTestId("closed-applications-tab")
+      expect(
+        within(closedApplicationsTab).getByText("Applications closed", { selector: "span" })
+      ).toBeInTheDocument()
+      expect(within(closedApplicationsTab).getByText("0")).toBeInTheDocument()
+
+      const openApplicationsTab = screen.getByTestId("open-applications-tab")
+      expect(
+        within(openApplicationsTab).getByText("Accepting applications", { selector: "span" })
+      ).toBeInTheDocument()
+      expect(within(openApplicationsTab).getByText("0")).toBeInTheDocument()
+
+      const lotteryTab = screen.getByTestId("lottery-runs-tab")
+      expect(within(lotteryTab).getByText("Lottery run", { selector: "span" })).toBeInTheDocument()
+      expect(within(lotteryTab).getByText("0")).toBeInTheDocument()
+    })
+
+    it("should show missing lottery runs when on the matching tab", async () => {
+      server.use(
+        rest.get("http://localhost:3100/applications/publicAppsView", (_req, res, ctx) => {
+          return res(ctx.json(getApplications(2, 2, 0, ApplicationsIndexEnum.lottery)))
+        })
+      )
+
+      renderApplicationsView(ApplicationsIndexEnum.lottery)
+      // Tab Panel
+      const allApplicationsTab = screen.getByTestId("total-applications-tab")
+      expect(await within(allApplicationsTab).findByText("4")).toBeInTheDocument()
+
+      const closedApplicationsTab = screen.getByTestId("closed-applications-tab")
+      expect(within(closedApplicationsTab).getByText("2")).toBeInTheDocument()
+
+      const openApplicationsTab = screen.getByTestId("open-applications-tab")
+      expect(within(openApplicationsTab).getByText("2")).toBeInTheDocument()
+
+      const lotteryTab = screen.getByTestId("lottery-runs-tab")
+      expect(within(lotteryTab).getByText("0")).toBeInTheDocument()
+
+      expect(
+        await screen.findByText(
+          "None of the listings you've applied to have released lottery results."
+        )
+      ).toBeInTheDocument()
+    })
+
+    it("should show missing closed application when on the matching tab", async () => {
+      server.use(
+        rest.get("http://localhost:3100/applications/publicAppsView", (_req, res, ctx) => {
+          return res(ctx.json(getApplications(2, 0, 2, ApplicationsIndexEnum.closed)))
+        })
+      )
+
+      renderApplicationsView(ApplicationsIndexEnum.closed)
+      // Tab Panel
+      const allApplicationsTab = screen.getByTestId("total-applications-tab")
+      expect(await within(allApplicationsTab).findByText("4")).toBeInTheDocument()
+
+      const closedApplicationsTab = screen.getByTestId("closed-applications-tab")
+      expect(within(closedApplicationsTab).getByText("0")).toBeInTheDocument()
+
+      const openApplicationsTab = screen.getByTestId("open-applications-tab")
+      expect(within(openApplicationsTab).getByText("2")).toBeInTheDocument()
+
+      const lotteryTab = screen.getByTestId("lottery-runs-tab")
+      expect(within(lotteryTab).getByText("2")).toBeInTheDocument()
+
+      expect(
+        await screen.findByText(
+          "The listings you've applied to are either still accepting applications or already have lottery results posted."
+        )
+      ).toBeInTheDocument()
+    })
+
+    it("should show missing open application when on the matching tab", async () => {
+      server.use(
+        rest.get("http://localhost:3100/applications/publicAppsView", (_req, res, ctx) => {
+          return res(ctx.json(getApplications(0, 2, 2, ApplicationsIndexEnum.open)))
+        })
+      )
+
+      renderApplicationsView(ApplicationsIndexEnum.open)
+      // Tab Panel
+      const allApplicationsTab = screen.getByTestId("total-applications-tab")
+      expect(await within(allApplicationsTab).findByText("4")).toBeInTheDocument()
+
+      const closedApplicationsTab = screen.getByTestId("closed-applications-tab")
+      expect(within(closedApplicationsTab).getByText("2")).toBeInTheDocument()
+
+      const openApplicationsTab = screen.getByTestId("open-applications-tab")
+      expect(within(openApplicationsTab).getByText("0")).toBeInTheDocument()
+
+      const lotteryTab = screen.getByTestId("lottery-runs-tab")
+      expect(within(lotteryTab).getByText("2")).toBeInTheDocument()
+
+      expect(
+        await screen.findByText(
+          "None of the listings you've applied to are still accepting applications."
+        )
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("should show the page with only proper applications count", async () => {
+    server.use(
+      rest.get("http://localhost:3100/applications/publicAppsView", (_req, res, ctx) => {
+        return res(ctx.json(getApplications(1, 2, 3)))
+      })
+    )
+    renderApplicationsView(ApplicationsIndexEnum.open)
+
+    expect(
+      screen.queryByText("It looks like you haven't applied to any listings yet.")
+    ).not.toBeInTheDocument()
+
+    expect(await screen.findAllByRole("link", { name: /view application/i })).toHaveLength(6)
+    expect(await screen.findAllByRole("link", { name: /see listing/i })).toHaveLength(6)
+
+    const allApplicationsTab = screen.getByTestId("total-applications-tab")
+    expect(within(allApplicationsTab).getByText("6")).toBeInTheDocument()
+
+    const closedApplicationsTab = screen.getByTestId("closed-applications-tab")
+    expect(within(closedApplicationsTab).getByText("2")).toBeInTheDocument()
+
+    const openApplicationsTab = screen.getByTestId("open-applications-tab")
+    expect(within(openApplicationsTab).getByText("1")).toBeInTheDocument()
+
+    const lotteryTab = screen.getByTestId("lottery-runs-tab")
+    expect(within(lotteryTab).getByText("3")).toBeInTheDocument()
+  })
+
+  describe("should navigate to filtered views on tab click", () => {
+    beforeEach(() => {
+      server.use(
+        rest.get("http://localhost:3100/applications/publicAppsView", (_req, res, ctx) => {
+          return res(ctx.json(getApplications(1, 1, 1)))
+        })
+      )
+    })
+
+    it("should navigate to all applications view", async () => {
+      const { pushMock } = mockNextRouter()
+      renderApplicationsView()
+
+      expect(await screen.findAllByRole("link", { name: /view application/i })).toHaveLength(3)
+      expect(await screen.findAllByRole("link", { name: /see listing/i })).toHaveLength(3)
+
+      const allAplicationsTab = screen.getByTestId("total-applications-tab")
+      await userEvent.click(allAplicationsTab)
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith("/account/applications")
+      })
+    })
+
+    it("should navigate to open application only view", async () => {
+      const { pushMock } = mockNextRouter()
+      renderApplicationsView()
+
+      expect(await screen.findAllByRole("link", { name: /view application/i })).toHaveLength(3)
+      expect(await screen.findAllByRole("link", { name: /see listing/i })).toHaveLength(3)
+
+      const openApplicationsTab = screen.getByTestId("open-applications-tab")
+      await userEvent.click(openApplicationsTab)
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith("/account/applications/open")
+      })
+    })
+
+    it("should navigate to closed application only view", async () => {
+      const { pushMock } = mockNextRouter()
+      renderApplicationsView()
+
+      expect(await screen.findAllByRole("link", { name: /view application/i })).toHaveLength(3)
+      expect(await screen.findAllByRole("link", { name: /see listing/i })).toHaveLength(3)
+
+      const closedApplicationsTab = screen.getByTestId("closed-applications-tab")
+      await userEvent.click(closedApplicationsTab)
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith("/account/applications/closed")
+      })
+    })
+
+    it("should navigate to lottery runs only view", async () => {
+      const { pushMock } = mockNextRouter()
+      renderApplicationsView()
+
+      expect(await screen.findAllByRole("link", { name: /view application/i })).toHaveLength(3)
+      expect(await screen.findAllByRole("link", { name: /see listing/i })).toHaveLength(3)
+
+      const lotteryTab = screen.getByTestId("lottery-runs-tab")
+      await userEvent.click(lotteryTab)
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith("/account/applications/lottery")
+      })
+    })
+  })
+})

--- a/sites/public/src/components/account/ApplicationsView.tsx
+++ b/sites/public/src/components/account/ApplicationsView.tsx
@@ -146,7 +146,10 @@ const ApplicationsView = (props: ApplicationsViewProps) => {
               selectedIndex={props.filterType}
             >
               <Tabs.TabList>
-                <Tabs.Tab className={styles["application-count-tab"]}>
+                <Tabs.Tab
+                  className={styles["application-count-tab"]}
+                  data-testid="total-applications-tab"
+                >
                   <span>{t("account.allMyApplications")}</span>
                   <span>{applicationsCount?.total}</span>
                 </Tabs.Tab>
@@ -154,15 +157,22 @@ const ApplicationsView = (props: ApplicationsViewProps) => {
                   className={`${styles["application-count-tab"]} ${
                     !showPublicLottery ? styles["application-hide-tab"] : ""
                   }`}
+                  data-testid="lottery-runs-tab"
                 >
                   <span>{t("account.lotteryRun")}</span>
                   <span>{applicationsCount?.lottery}</span>
                 </Tabs.Tab>
-                <Tabs.Tab className={styles["application-count-tab"]}>
+                <Tabs.Tab
+                  className={styles["application-count-tab"]}
+                  data-testid="closed-applications-tab"
+                >
                   <span>{t("account.closedApplications")}</span>
                   <span>{applicationsCount?.closed}</span>
                 </Tabs.Tab>
-                <Tabs.Tab className={styles["application-count-tab"]}>
+                <Tabs.Tab
+                  className={styles["application-count-tab"]}
+                  data-testid="open-applications-tab"
+                >
                   <span>{t("account.openApplications")}</span>
                   <span>{applicationsCount?.open}</span>
                 </Tabs.Tab>


### PR DESCRIPTION
This PR addresses #4547

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Add testId props in the Application View component to improve integration testing
* Add `<ApplicationsView>` component integration tests

## How Can This Be Tested/Reviewed?

Run the following command in the main directory:
``` bash
cd sites/public && yarn jest -w --verbose -t "<ApplicationsView>"
```

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
