### PR TITLE
Feat: public create account integration tests

### DIFF
--- a/sites/public/__tests__/pages/create-account.test.tsx
+++ b/sites/public/__tests__/pages/create-account.test.tsx
@@ -1,0 +1,475 @@
+import { fireEvent, mockNextRouter, render, waitFor, screen, act } from "../testUtils"
+import { user } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import React from "react"
+import CreateAccount from "../../src/pages/create-account"
+import userEvent from "@testing-library/user-event"
+import { setupServer } from "msw/lib/node"
+import { rest } from "msw"
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+  mockNextRouter()
+  window.scrollTo = jest.fn()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  window.localStorage.clear()
+  window.sessionStorage.clear()
+})
+
+afterAll(() => server.close())
+
+describe("Create Account Page", () => {
+  it("should render the page with all fileds, buttons and links", () => {
+    render(<CreateAccount />)
+
+    const verifyInitialInput = (input: HTMLElement) => {
+      expect(input).toBeInTheDocument()
+      expect(input).toBeValid()
+      expect(input).toBeEnabled()
+    }
+
+    expect(screen.getByRole("heading", { name: /create account/i, level: 1 })).toBeInTheDocument()
+
+    expect(screen.getByText("Your Name", { selector: "legend" })).toBeInTheDocument()
+    verifyInitialInput(screen.getByRole("textbox", { name: /first or given name/i }))
+    verifyInitialInput(screen.getByRole("textbox", { name: /middle name \(optional\)/i }))
+    verifyInitialInput(screen.getByRole("textbox", { name: /last or family name/i }))
+
+    expect(screen.getByText("Your date of birth", { selector: "legend" })).toBeInTheDocument()
+    verifyInitialInput(screen.getByRole("textbox", { name: /month/i }))
+    verifyInitialInput(screen.getByRole("textbox", { name: /day/i }))
+    verifyInitialInput(screen.getByRole("textbox", { name: /year/i }))
+    expect(
+      screen.getByText("This is collected to verify that you are at least 18 years old.", {
+        selector: "p",
+      })
+    ).toBeInTheDocument()
+    expect(screen.getByText("For example: 01 19 2000", { selector: "p" })).toBeInTheDocument()
+
+    verifyInitialInput(screen.getByRole("textbox", { name: /your email address/i }))
+
+    const passwordInput = screen.getByLabelText(/^password/i, { selector: "input" })
+    verifyInitialInput(passwordInput)
+    expect(passwordInput).toHaveAttribute("type", "password")
+    expect(
+      screen.getByText(
+        "Must be at least 12 characters and include at least one lowercase letter, one uppercase letter, one number, and one special character (#?!@$%^&*-)."
+      )
+    ).toBeInTheDocument()
+    const passwordConfirmInput = screen.getByLabelText(/re-enter your password/i, {
+      selector: "input",
+    })
+    verifyInitialInput(passwordConfirmInput)
+    expect(passwordConfirmInput).toHaveAttribute("type", "password")
+
+    const createAccountButton = screen.getByRole("button", { name: /create account/i })
+    expect(createAccountButton).toBeInTheDocument()
+    expect(createAccountButton).toBeEnabled()
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: /already have an account\?/i })
+    ).toBeInTheDocument()
+
+    const signInLink = screen.getByText(/sign in/i, { selector: "a" })
+    expect(signInLink).toBeInTheDocument()
+    expect(signInLink).toHaveAttribute("href", "/sign-in")
+  })
+
+  describe("Field validation errors", () => {
+    it("should show no alerts on initial load", () => {
+      render(<CreateAccount />)
+
+      expect(screen.queryByText("Please enter a First Name")).not.toBeInTheDocument()
+      expect(screen.queryByText("Must not be more than 64 characters.")).not.toBeInTheDocument()
+      expect(screen.queryByText("Please enter a Last Name")).not.toBeInTheDocument()
+      expect(
+        screen.queryByText("Please enter a valid Date of Birth, must be 18 or older")
+      ).not.toBeInTheDocument()
+      expect(screen.queryByText("Please enter a valid email address")).not.toBeInTheDocument()
+      expect(screen.queryByText("Please enter a valid password")).not.toBeInTheDocument()
+      expect(screen.queryByText("The passwords do not match")).not.toBeInTheDocument()
+    })
+
+    it("show alerts on 'Create Account' click without filling any fields", async () => {
+      render(<CreateAccount />)
+
+      const createAccountButton = screen.getByRole("button", { name: /create account/i })
+      expect(createAccountButton).toBeInTheDocument()
+      await act(() => userEvent.click(createAccountButton))
+
+      expect(screen.getByRole("textbox", { name: /first or given name/i })).toBeInvalid()
+      expect(screen.getByText("Please enter a First Name")).toBeInTheDocument()
+
+      expect(screen.getByRole("textbox", { name: /last or family name/i })).toBeInvalid()
+      expect(screen.getByText("Please enter a Last Name")).toBeInTheDocument()
+
+      expect(screen.getByRole("textbox", { name: /month/i })).toBeInvalid()
+      expect(screen.getByRole("textbox", { name: /day/i })).toBeInvalid()
+      expect(screen.getByRole("textbox", { name: /year/i })).toBeInvalid()
+      expect(
+        screen.getByText("Please enter a valid Date of Birth, must be 18 or older")
+      ).toBeInTheDocument()
+
+      expect(screen.getByRole("textbox", { name: /your email address/i })).toBeInvalid()
+      expect(screen.getByText("Please enter a valid email address")).toBeInTheDocument()
+
+      expect(screen.getByLabelText(/^password/i, { selector: "input" })).toBeInvalid()
+      expect(screen.getByText("Please enter a valid password")).toBeInTheDocument()
+
+      expect(screen.queryByText("Must not be more than 64 characters.")).not.toBeInTheDocument()
+      expect(screen.queryByText("The passwords do not match")).not.toBeInTheDocument()
+    })
+
+    it("show max character limit error for string fields", async () => {
+      render(<CreateAccount />)
+
+      const createAccountButton = screen.getByRole("button", { name: /create account/i })
+      const firstNameField = screen.getByRole("textbox", { name: /first or given name/i })
+      const middleNameField = screen.getByRole("textbox", { name: /middle name \(optional\)/i })
+      const lastNameField = screen.getByRole("textbox", { name: /last or family name/i })
+      expect(firstNameField).toBeInTheDocument()
+      expect(middleNameField).toBeInTheDocument()
+      expect(lastNameField).toBeInTheDocument()
+      expect(createAccountButton).toBeInTheDocument()
+      await userEvent.type(firstNameField, Array(65).fill("a").join(""))
+      await userEvent.type(middleNameField, Array(65).fill("a").join(""))
+      await userEvent.type(lastNameField, Array(65).fill("a").join(""))
+      fireEvent.click(createAccountButton)
+      expect(await screen.findAllByText("Must not be more than 64 characters.")).toHaveLength(3)
+      expect(firstNameField).toBeInvalid()
+      expect(middleNameField).toBeInvalid()
+      expect(lastNameField).toBeInvalid()
+      expect(screen.queryByText("Please enter a First Name")).not.toBeInTheDocument()
+      expect(screen.queryByText("Please enter a Last Name")).not.toBeInTheDocument()
+    })
+
+    describe("show password error on invalid passwords", () => {
+      const TEST_PASSWORDS = [
+        {
+          password: "P@ssw0rd#123",
+          description: "Valid password with all requirements met",
+          valid: true,
+        },
+        {
+          password: "Secure!Pa$$123",
+          description: "Valid password with multiple special characters",
+          valid: true,
+        },
+        {
+          password: "AbCdEfG1!2@3#",
+          description: "Valid password with alternating character types",
+          valid: true,
+        },
+        {
+          password: "ThisIs@Valid1",
+          description: "Valid password with exactly 12 characters",
+          valid: true,
+        },
+        {
+          password: "L0ng&C0mpl3xP@ssw0rd",
+          description: "Valid longer password (20 characters)",
+          valid: true,
+        },
+        {
+          password: "Sh0rt!",
+          description: "Too short (only 6 characters)",
+          valid: false,
+          reason: "Does not meet minimum length of 12 characters",
+        },
+        {
+          password: "Almost@12ch",
+          description: "Almost long enough (11 characters)",
+          valid: false,
+          reason: "Does not meet minimum length of 12 characters",
+        },
+        {
+          password: "NO_LOWERCASE1!",
+          description: "Missing lowercase letter",
+          valid: false,
+          reason: "Does not contain at least one lowercase letter",
+        },
+        {
+          password: "no_uppercase1!",
+          description: "Missing uppercase letter",
+          valid: false,
+          reason: "Does not contain at least one uppercase letter",
+        },
+        {
+          password: "NoNumbers!@ABC",
+          description: "Missing number",
+          valid: false,
+          reason: "Does not contain at least one number",
+        },
+        {
+          password: "NoSpecialChar12",
+          description: "Missing special character",
+          valid: false,
+          reason: "Does not contain at least one special character (#?!@$%^&*-)",
+        },
+        {
+          password: "WrongSpecial_12",
+          description: "Contains special character not in the allowed set",
+          valid: false,
+          reason: "Special character used is not in the allowed set (#?!@$%^&*-)",
+        },
+        {
+          password: "NOLOWERNONUMBER!",
+          description: "Missing lowercase letter and number",
+          valid: false,
+          reason: "Does not contain lowercase letter and number",
+        },
+        {
+          password: "nouppernospecial123",
+          description: "Missing uppercase letter and special character",
+          valid: false,
+          reason: "Does not contain uppercase letter and special character",
+        },
+        {
+          password: "          12A!",
+          description: "Mostly whitespace with minimal valid characters",
+          valid: false,
+          reason:
+            "Although it contains all required character types, the spaces don't count towards the 12 character minimum",
+        },
+        {
+          password: "Password123",
+          description: "Common password format missing special character",
+          valid: false,
+          reason: "Does not contain special character",
+        },
+      ].map((entry) =>
+        Object.assign(entry, {
+          toString: function () {
+            return this.description
+          },
+        })
+      )
+
+      it.each(TEST_PASSWORDS)("%s", async (entry) => {
+        const { password, valid } = entry
+
+        act(() => {
+          render(<CreateAccount />)
+        })
+
+        const createAccountButton = screen.getByRole("button", { name: /create account/i })
+        const passwordInput = screen.getByLabelText(/^password/i, { selector: "input" })
+        expect(passwordInput).toBeInTheDocument()
+        expect(createAccountButton).toBeInTheDocument()
+
+        await act(() => userEvent.type(passwordInput, password))
+        await act(() => userEvent.click(createAccountButton))
+
+        if (valid) {
+          await waitFor(() => {
+            expect(screen.queryByText("Please enter a valid password")).not.toBeInTheDocument()
+          })
+          expect(passwordInput).toBeValid()
+        } else {
+          expect(await screen.findByText("Please enter a valid password")).toBeInTheDocument()
+          expect(passwordInput).toBeInvalid()
+        }
+      })
+    })
+
+    it("show error on password on missmatching passwords", async () => {
+      render(<CreateAccount />)
+
+      const createAccountButton = screen.getByRole("button", { name: /create account/i })
+      const passwordInput = screen.getByLabelText(/^password/i, { selector: "input" })
+      const passwordConfirmInput = screen.getByLabelText(/re-enter your password/i, {
+        selector: "input",
+      })
+
+      expect(passwordInput).toBeInTheDocument()
+      expect(passwordConfirmInput).toBeInTheDocument()
+      expect(createAccountButton).toBeInTheDocument()
+
+      await act(() => userEvent.type(passwordInput, "P@ssw0rd#123"))
+      await act(() => userEvent.type(passwordConfirmInput, "Test"))
+      await act(() => userEvent.click(createAccountButton))
+
+      expect(passwordInput).toBeValid()
+      expect(passwordConfirmInput).toBeInvalid()
+      expect(screen.queryByText("Please enter a valid password")).not.toBeInTheDocument()
+      expect(await screen.findByText("The passwords do not match")).toBeInTheDocument()
+    })
+  })
+
+  describe("shoud show proper API call error responses", () => {
+    const ERROR_RESPONSES = [
+      {
+        title: "Account confirmed",
+        status: 400,
+        message: "accountConfirmed",
+        value: "Your account is already confirmed.",
+      },
+      {
+        title: "Not matching email",
+        status: 400,
+        message: "emailMismatch",
+        value: "The emails do not match",
+      },
+      {
+        title: "Email not found",
+        status: 400,
+        message: "emailNotFound",
+        value: "Email not found. Please register first.",
+      },
+      {
+        title: "Internal",
+        status: 400,
+        message: "errorSaving",
+        value:
+          /Oops! Looks like something went wrong. Please try again. Contact your housing department if you're still experiencing issues./i,
+      },
+      {
+        title: "Password mismatch",
+        status: 400,
+        message: "passwordMismatch",
+        value: "The passwords do not match",
+      },
+      {
+        title: "To weak password",
+        status: 400,
+        message: "passwordTooWeak",
+        value:
+          "Password is too weak. Must be at least 12 characters and include at least one lowercase letter, one uppercase letter, one number, and one special character (#?!@$%^&*-).",
+      },
+      {
+        title: "Expired token",
+        status: 400,
+        message: "tokenExpired",
+        value: "Your link has expired.",
+      },
+      {
+        title: "Email in use 409",
+        status: 409,
+        value: "Email is already in use",
+      },
+      {
+        title: "Generic",
+        status: 401, // Used 401 code here to mock a unhandled status code.
+        value:
+          /Something went wrong while creating your account. Please try again. Contact your housing department if you're still experiencing issues./i,
+      },
+    ].map((entry) =>
+      Object.assign(entry, {
+        toString: function () {
+          return this.title
+        },
+      })
+    )
+
+    it.each(ERROR_RESPONSES)("show the %s error response message", async (response) => {
+      const { message, value, status } = response
+      server.use(
+        rest.post("http://localhost/api/adapter/user", (_req, res, ctx) => {
+          if (message) {
+            return res(
+              ctx.status(status),
+              ctx.json({
+                message: message,
+              })
+            )
+          } else {
+            return res(ctx.status(status))
+          }
+        })
+      )
+      render(<CreateAccount />)
+
+      expect(screen.getByRole("heading", { name: /create account/i, level: 1 })).toBeInTheDocument()
+
+      await act(async () => {
+        await userEvent.type(screen.getByRole("textbox", { name: /first or given name/i }), "John")
+        await userEvent.type(screen.getByRole("textbox", { name: /middle name/i }), "Admin")
+        await userEvent.type(screen.getByRole("textbox", { name: /last or family name/i }), "Doe")
+        await userEvent.type(screen.getByRole("textbox", { name: /month/i }), "2")
+        await userEvent.type(screen.getByRole("textbox", { name: /day/i }), "4")
+        await userEvent.type(screen.getByRole("textbox", { name: /year/i }), "2000")
+        await userEvent.type(
+          screen.getByRole("textbox", { name: /your email address/i }),
+          "johndoe@example.com"
+        )
+        await userEvent.type(
+          screen.getByLabelText(/^password/i, { selector: "input" }),
+          "P@ssw0rd#123"
+        )
+        await userEvent.type(
+          screen.getByLabelText(/re-enter your password/i, {
+            selector: "input",
+          }),
+          "P@ssw0rd#123"
+        )
+      })
+
+      const createAccountButton = screen.getByRole("button", { name: /create account/i })
+      expect(createAccountButton).toBeInTheDocument()
+      await act(() => userEvent.click(createAccountButton))
+
+      expect(await screen.findByText(value)).toBeInTheDocument()
+    })
+  })
+
+  it("should navigate to confirmation modal on success", async () => {
+    process.env.showPwdless = "TRUE"
+    const { pushMock } = mockNextRouter()
+    server.use(
+      rest.post("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(ctx.json(user))
+      })
+    )
+    render(<CreateAccount />)
+
+    expect(screen.getByRole("heading", { name: /create account/i, level: 1 })).toBeInTheDocument()
+
+    await act(async () => {
+      await userEvent.type(screen.getByRole("textbox", { name: /first or given name/i }), "John")
+      await userEvent.type(screen.getByRole("textbox", { name: /middle name/i }), "Admin")
+      await userEvent.type(screen.getByRole("textbox", { name: /last or family name/i }), "Doe")
+      await userEvent.type(screen.getByRole("textbox", { name: /month/i }), "2")
+      await userEvent.type(screen.getByRole("textbox", { name: /day/i }), "4")
+      await userEvent.type(screen.getByRole("textbox", { name: /year/i }), "2000")
+      await userEvent.type(
+        screen.getByRole("textbox", { name: /your email address/i }),
+        "johndoe@example.com"
+      )
+      await userEvent.type(
+        screen.getByLabelText(/^password/i, { selector: "input" }),
+        "P@ssw0rd#123"
+      )
+      await userEvent.type(
+        screen.getByLabelText(/re-enter your password/i, {
+          selector: "input",
+        }),
+        "P@ssw0rd#123"
+      )
+    })
+
+    const createAccountButton = screen.getByRole("button", { name: /create account/i })
+    expect(createAccountButton).toBeInTheDocument()
+    await act(() => userEvent.click(createAccountButton))
+
+    expect(screen.queryByText("Please enter a First Name")).not.toBeInTheDocument()
+    expect(screen.queryByText("Must not be more than 64 characters.")).not.toBeInTheDocument()
+    expect(screen.queryByText("Please enter a Last Name")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("Please enter a valid Date of Birth, must be 18 or older")
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Please enter a valid email address")).not.toBeInTheDocument()
+    expect(screen.queryByText("Please enter a valid password")).not.toBeInTheDocument()
+    expect(screen.queryByText("The passwords do not match")).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(pushMock).toBeCalledWith({
+        pathname: "/verify",
+        query: { email: "johndoe@example.com", flowType: "create" },
+      })
+    })
+  })
+})

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -63,6 +63,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.0.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/markdown-to-jsx": "^6.11.2",
     "@types/node": "^12.12.67",
     "@types/react": "^18.0.33",

--- a/sites/public/src/pages/create-account.tsx
+++ b/sites/public/src/pages/create-account.tsx
@@ -23,7 +23,7 @@ import signUpBenefitsStyles from "../../styles/sign-up-benefits.module.scss"
 import SignUpBenefits from "../components/account/SignUpBenefits"
 import SignUpBenefitsHeadingGroup from "../components/account/SignUpBenefitsHeadingGroup"
 
-export default () => {
+const CreateAccount = () => {
   const { createUser, resendConfirmation } = useContext(AuthContext)
   const [confirmationResent, setConfirmationResent] = useState<boolean>(false)
   const signUpCopy = process.env.showMandatedAccounts
@@ -96,18 +96,18 @@ export default () => {
   }
 
   return (
-    <FormsLayout className={signUpCopy && "sm:max-w-lg md:max-w-full"}>
-      <div className={signUpCopy && signUpBenefitsStyles["benefits-container"]}>
+    <FormsLayout className={signUpCopy ? "sm:max-w-lg md:max-w-full" : undefined}>
+      <div className={signUpCopy ? signUpBenefitsStyles["benefits-container"] : undefined}>
         {signUpCopy && (
           <div className={signUpBenefitsStyles["benefits-display-hide"]}>
             <SignUpBenefitsHeadingGroup mobileView={true} />
           </div>
         )}
-        <div className={signUpCopy && signUpBenefitsStyles["benefits-form-container"]}>
+        <div className={signUpCopy ? signUpBenefitsStyles["benefits-form-container"] : undefined}>
           <BloomCard iconSymbol="profile" title={t("account.createAccount")} headingPriority={1}>
             <>
               {requestError && (
-                <AlertBox className="" onClose={() => setRequestError(undefined)} type="alert">
+                <AlertBox onClose={() => setRequestError(undefined)} type="alert">
                   {requestError}
                 </AlertBox>
               )}
@@ -116,53 +116,55 @@ export default () => {
                   divider={"inset"}
                   className={accountCardStyles["account-card-settings-section"]}
                 >
-                  <label className={styles["create-account-header"]} htmlFor="firstName">
-                    {t("application.name.yourName")}
-                  </label>
+                  <fieldset id="userName">
+                    <legend className={styles["create-account-header"]}>
+                      {t("application.name.yourName")}
+                    </legend>
 
-                  <label className={styles["create-account-field"]} htmlFor="firstName">
-                    {t("application.name.firstOrGivenName")}
-                  </label>
-                  <Field
-                    controlClassName={styles["create-account-input"]}
-                    name="firstName"
-                    validation={{ required: true, maxLength: 64 }}
-                    error={errors.givenName}
-                    errorMessage={
-                      errors.givenName?.type === "maxLength"
-                        ? t("errors.maxLength", { length: 64 })
-                        : t("errors.firstNameError")
-                    }
-                    register={register}
-                  />
+                    <label className={styles["create-account-field"]} htmlFor="firstName">
+                      {t("application.name.firstOrGivenName")}
+                    </label>
+                    <Field
+                      controlClassName={styles["create-account-input"]}
+                      name="firstName"
+                      validation={{ required: true, maxLength: 64 }}
+                      error={errors.firstName}
+                      errorMessage={
+                        errors.firstName?.type === "maxLength"
+                          ? t("errors.maxLength", { length: 64 })
+                          : t("errors.firstNameError")
+                      }
+                      register={register}
+                    />
 
-                  <label className={styles["create-account-field"]} htmlFor="middleName">
-                    {t("application.name.middleNameOptional")}
-                  </label>
-                  <Field
-                    name="middleName"
-                    register={register}
-                    error={errors.middleName}
-                    validation={{ maxLength: 64 }}
-                    errorMessage={t("errors.maxLength", { length: 64 })}
-                    controlClassName={styles["create-account-input"]}
-                  />
+                    <label className={styles["create-account-field"]} htmlFor="middleName">
+                      {t("application.name.middleNameOptional")}
+                    </label>
+                    <Field
+                      name="middleName"
+                      register={register}
+                      error={errors.middleName}
+                      validation={{ maxLength: 64 }}
+                      errorMessage={t("errors.maxLength", { length: 64 })}
+                      controlClassName={styles["create-account-input"]}
+                    />
 
-                  <label className={styles["create-account-field"]} htmlFor="lastName">
-                    {t("application.name.lastOrFamilyName")}
-                  </label>
-                  <Field
-                    name="lastName"
-                    validation={{ required: true, maxLength: 64 }}
-                    error={errors.lastName}
-                    register={register}
-                    errorMessage={
-                      errors.lastName?.type === "maxLength"
-                        ? t("errors.maxLength", { length: 64 })
-                        : t("errors.lastNameError")
-                    }
-                    controlClassName={styles["create-account-input"]}
-                  />
+                    <label className={styles["create-account-field"]} htmlFor="lastName">
+                      {t("application.name.lastOrFamilyName")}
+                    </label>
+                    <Field
+                      name="lastName"
+                      validation={{ required: true, maxLength: 64 }}
+                      error={errors.lastName}
+                      register={register}
+                      errorMessage={
+                        errors.lastName?.type === "maxLength"
+                          ? t("errors.maxLength", { length: 64 })
+                          : t("errors.lastNameError")
+                      }
+                      controlClassName={styles["create-account-input"]}
+                    />
+                  </fieldset>
                 </CardSection>
                 <CardSection
                   divider={"inset"}
@@ -337,3 +339,5 @@ export default () => {
     </FormsLayout>
   )
 }
+
+export default CreateAccount

--- a/sites/public/tsconfig.json
+++ b/sites/public/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "jsx": "preserve",
     "allowJs": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3496,6 +3496,11 @@
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.2.tgz#db7257d727c891905947bd1c1a99da20e03c2ebd"
   integrity sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==
 
+"@testing-library/user-event@^14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"


### PR DESCRIPTION
This PR addresses #4553

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Add the event testing library package to the public sites module
* Add `es2020` target to public module TS configuration
* Implement password reset page integration tests following best practices

## How Can This Be Tested/Reviewed?

Run the command below in the main repo directory or run general tests using CircleCI:
```bash
cd sites/public && yarn jest -w --verbose -t "Create Account Page"
```

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
