### PR TITLE
fix: re-add the Alameda transition banner

### DIFF
--- a/api/prisma/seed-helpers/reserved-community-type-factory.ts
+++ b/api/prisma/seed-helpers/reserved-community-type-factory.ts
@@ -38,7 +38,7 @@ export const reservedCommunityTypeFactoryAll = async (
 
 export const reservedCommunityTypeFactoryGet = async (
   prismaClient: PrismaClient,
-  jurisdictionId: string,
+  jurisdictionId?: string,
   name?: string,
 ): Promise<ReservedCommunityTypes> => {
   // if name is not given pick one randomly from the above list
@@ -73,12 +73,11 @@ export const reservedCommunityTypesFindOrCreate = async (
 ): Promise<ReservedCommunityTypes> => {
   const reservedCommunityType = await reservedCommunityTypeFactoryGet(
     prismaClient,
-    jurisdictionId,
   );
   if (reservedCommunityType) {
-    return await reservedCommunityTypeFactoryGet(prismaClient, jurisdictionId);
+    return reservedCommunityType;
   }
 
   await reservedCommunityTypeFactoryAll(jurisdictionId, prismaClient);
-  return await reservedCommunityTypeFactoryGet(prismaClient, jurisdictionId);
+  return await reservedCommunityTypeFactoryGet(prismaClient);
 };

--- a/sites/public/cypress/e2e/account/account.spec.ts
+++ b/sites/public/cypress/e2e/account/account.spec.ts
@@ -19,7 +19,7 @@ describe("User accounts", () => {
     // Change the name fields
     cy.getByTestId("account-first-name").clear().type(updatedPublicUser.firstName)
     cy.getByTestId("account-middle-name").clear().type(updatedPublicUser.middleName)
-    cy.getByTestId("account-last-name").clear().type(updatedPublicUser.lastName)
+    cy.getByTestId("account-last-name").clear({ force: true }).type(updatedPublicUser.lastName)
     cy.getByID("account-submit-name").click()
     cy.getByTestId("alert-box").contains("Name update successful")
     cy.get("[aria-label='close alert']").click()

--- a/sites/public/src/layouts/application.tsx
+++ b/sites/public/src/layouts/application.tsx
@@ -8,7 +8,6 @@ import { JurisdictionFooterSection as SanMateoFooter } from "../page_content/jur
 import { JurisdictionFooterSection as SanJoseFooter } from "../page_content/jurisdiction_overrides/san_jose/JurisdictionFooterSection"
 import { JurisdictionFooterSection as AlamedaFooter } from "../page_content/jurisdiction_overrides/alameda/JurisdictionFooterSection"
 import { JursidictionSiteNotice as SanJoseNotice } from "../page_content/jurisdiction_overrides/san_jose/jurisdiction-site-notice"
-import { JursidictionSiteNotice as AlamedaNotice } from "../page_content/jurisdiction_overrides/alameda/jurisdiction-site-notice"
 import { Message, Toast, Icon } from "@bloom-housing/ui-seeds"
 import { MenuLink, t, SiteHeader as UICSiteHeader } from "@bloom-housing/ui-components"
 import { AuthContext, MessageContext } from "@bloom-housing/shared-helpers"
@@ -92,7 +91,7 @@ const getSiteHeaderDeprecated = (
   let siteNotice = <div></div>
   let transitionMessage = null
   if (process.env.jurisdictionName === "Alameda") {
-    siteNotice = <AlamedaNotice />
+    transitionMessage = t("alert.transitionv3")
   }
   if (process.env.jurisdictionName === "San Jose") {
     siteNotice = <SanJoseNotice />


### PR DESCRIPTION
This PR addresses [issue with release](https://exygy.slack.com/archives/C01Q4QG5R8Q/p1745330669188909)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

With the recent release there was an accidental removal of the Alameda banner. The maintenance banner is showing where the transition banner should. This is because when the Alameda transition banner was added it was added in place of the maintenance banner and a `MAINTENANCE_WINDOW` env variable was set. So when merge conflicts happened it was not noticed that the translation in that spot was incorrect.

![image (10)](https://github.com/user-attachments/assets/4f1b3983-6130-459b-9349-119dcc58a786)

This change keeps the maintenance banner the same and instead places the transition banner where it is supposed to be for Alameda 

## How Can This Be Tested/Reviewed?

* Locally set the jurisdiction to be `Alamaeda`
* Remove the `MAINTENANCE_WINDOW` env variable 

You should see the correct transition banner

You can also see the deploy preview: https://deploy-preview-868--housing-acgov-org.netlify.app/

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
