### PR TITLE
feat: public user dashboard integration tests 

### DIFF
--- a/sites/public/__tests__/pages/account/dashboard.test.tsx
+++ b/sites/public/__tests__/pages/account/dashboard.test.tsx
@@ -1,0 +1,135 @@
+import React from "react"
+import { render, screen, within } from "@testing-library/react"
+import { setupServer } from "msw/lib/node"
+import Dashboard from "../../../src/pages/account/dashboard"
+import { jurisdiction, user } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import { mockNextRouter } from "../../testUtils"
+import { AuthContext } from "@bloom-housing/shared-helpers"
+import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe("<Dashboard>", () => {
+  mockNextRouter()
+  it("should render dashboard card without favorites", () => {
+    render(
+      <AuthContext.Provider
+        value={{
+          profile: {
+            ...user,
+            listings: [],
+            jurisdictions: [],
+          },
+        }}
+      >
+        <Dashboard jurisdiction={jurisdiction} />
+      </AuthContext.Provider>
+    )
+
+    const dashboardCards = screen.getAllByRole("gridcell")
+    expect(dashboardCards).toHaveLength(2)
+
+    const [myApplicationsCard, accountSettingsCard] = dashboardCards
+
+    // My Applications Card
+    expect(
+      within(myApplicationsCard).getByRole("heading", { level: 2, name: /my applications/i })
+    ).toBeInTheDocument()
+    expect(
+      within(myApplicationsCard).getByText(
+        "See lottery dates and listings for properties for which you've applied"
+      )
+    ).toBeInTheDocument()
+
+    const viewApplicationButton = within(myApplicationsCard).getByRole("link", {
+      name: /view applications/i,
+    })
+    expect(viewApplicationButton).toBeInTheDocument()
+    expect(viewApplicationButton).toHaveAttribute("href", "/account/applications")
+
+    //Account settings card
+    expect(
+      within(accountSettingsCard).getByRole("heading", { level: 2, name: /account settings/i })
+    ).toBeInTheDocument()
+    expect(
+      within(accountSettingsCard).getByText("Account Settings, email and password")
+    ).toBeInTheDocument()
+
+    const updateAccountSettingsButton = within(accountSettingsCard).getByRole("link", {
+      name: /update account settings/i,
+    })
+    expect(updateAccountSettingsButton).toBeInTheDocument()
+    expect(updateAccountSettingsButton).toHaveAttribute("href", "/account/edit")
+
+    // My Favorites Card - should not ring-accent-cool-darker
+    expect(
+      screen.queryByRole("heading", { level: 2, name: /my favorites/i })
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Save listings and check back for updates")).not.toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: /view favorites/i })).not.toBeInTheDocument()
+  })
+
+  it("should render the favorites dashboard card when flag enabled", () => {
+    render(
+      <AuthContext.Provider
+        value={{
+          profile: {
+            ...user,
+            listings: [],
+            jurisdictions: [],
+          },
+        }}
+      >
+        <Dashboard
+          jurisdiction={{
+            ...jurisdiction,
+            featureFlags: [
+              ...jurisdiction.featureFlags,
+              {
+                name: FeatureFlagEnum.enableListingFavoriting,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                id: "2ac85a8b-c319-4257-bedb-2db95133fab3",
+                description:
+                  "When true, a Favorite button is shown for public listings and users can view their favorited listings ",
+                active: true,
+                jurisdictions: [],
+              },
+            ],
+          }}
+        />
+      </AuthContext.Provider>
+    )
+
+    const dashboardCards = screen.getAllByRole("gridcell")
+    expect(dashboardCards).toHaveLength(3)
+
+    const myFavoritesCard = dashboardCards.pop()
+
+    //Favorites card
+    expect(
+      within(myFavoritesCard).getByRole("heading", { level: 2, name: /my favorites/i })
+    ).toBeInTheDocument()
+    expect(
+      within(myFavoritesCard).getByText("Save listings and check back for updates")
+    ).toBeInTheDocument()
+
+    const viewFavoritesButton = within(myFavoritesCard).getByRole("link", {
+      name: /view favorites/i,
+    })
+    expect(viewFavoritesButton).toBeInTheDocument()
+    expect(viewFavoritesButton).toHaveAttribute("href", "/account/favorites")
+  })
+})

--- a/sites/public/src/pages/account/dashboard.tsx
+++ b/sites/public/src/pages/account/dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useContext } from "react"
 import Head from "next/head"
-import { NextRouter, withRouter } from "next/router"
+import { useRouter } from "next/router"
 import {
   FeatureFlagEnum,
   Jurisdiction,
@@ -24,13 +24,13 @@ import { fetchJurisdictionByName } from "../../lib/hooks"
 import styles from "./account.module.scss"
 
 interface DashboardProps {
-  router: NextRouter
   jurisdiction: Jurisdiction
 }
 
 function Dashboard(props: DashboardProps) {
   const { profile } = useContext(AuthContext)
   const [alertMessage, setAlertMessage] = useState<string | null>(null)
+  const router = useRouter()
 
   useEffect(() => {
     if (profile) {
@@ -40,10 +40,8 @@ function Dashboard(props: DashboardProps) {
         status: UserStatus.LoggedIn,
       })
     }
-    if (props.router.query?.alert) {
-      const alert = Array.isArray(props.router.query.alert)
-        ? props.router.query.alert[0]
-        : props.router.query.alert
+    if (router.query?.alert) {
+      const alert = Array.isArray(router.query.alert) ? router.query.alert[0] : router.query.alert
       setAlertMessage(alert)
     }
 
@@ -53,10 +51,10 @@ function Dashboard(props: DashboardProps) {
         isFeatureFlagOn(props.jurisdiction, FeatureFlagEnum.enableListingFavoriting) === true
       ).toString()
     )
-  }, [props.router, props.jurisdiction, profile])
+  }, [router, props.jurisdiction, profile])
 
   const closeAlert = () => {
-    void props.router.push("/account/dashboard", undefined, { shallow: true })
+    void router.push("/account/dashboard", undefined, { shallow: true })
     setAlertMessage(null)
   }
 
@@ -153,7 +151,7 @@ function Dashboard(props: DashboardProps) {
   )
 }
 
-export default withRouter(Dashboard)
+export default Dashboard
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function getStaticProps() {


### PR DESCRIPTION
This PR addresses #4548

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Update the public site account dashboard component to use router hook pattern instead of HOC pattern 
* Add integration tests for the dashboard page content

## How Can This Be Tested/Reviewed?

Run the following command in the main directory
```
cd sites/public && yarn jest -w --verbose -t "<Dashboard>"
```

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
