### PR TITLE
4572/listings application add integration tests 

### DIFF
--- a/sites/partners/__tests__/components/applications/sections/FormAlternateContact.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormAlternateContact.test.tsx
@@ -1,0 +1,51 @@
+import { act, render, screen } from "@testing-library/react"
+import React from "react"
+import { FormProviderWrapper } from "./helpers"
+import { FormAlternateContact } from "../../../../src/components/applications/PaperApplicationForm/sections/FormAlternateContact"
+import userEvent from "@testing-library/user-event"
+
+describe("<FormAlternateContact>", () => {
+  it("renders the form with alternate contact fields", () => {
+    render(
+      <FormProviderWrapper>
+        <FormAlternateContact />
+      </FormProviderWrapper>
+    )
+
+    expect(screen.getByRole("heading", { level: 2, name: /alternate contact/i }))
+    expect(screen.getByLabelText(/first name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/last name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/agency if applicable/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument()
+    expect(screen.getByText(/phone/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/relationship/i)).toBeInTheDocument()
+
+    expect(screen.getByText(/mailing address/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/street address/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/apt or unit #/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/city/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/state/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/zip code/i)).toBeInTheDocument()
+
+    expect(screen.queryByLabelText(/other relationship/i)).not.toBeInTheDocument()
+  })
+
+  it("renders other relationship input field when the 'other' option is selected", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormAlternateContact />
+      </FormProviderWrapper>
+    )
+
+    const relationshipSelect = screen.getByLabelText(/relationship/i)
+    expect(relationshipSelect).toBeInTheDocument()
+
+    expect(screen.queryByLabelText(/other relationship/i)).not.toBeInTheDocument()
+    await act(() => userEvent.selectOptions(relationshipSelect, "friend"))
+    expect(relationshipSelect).toHaveValue("friend")
+    expect(screen.queryByLabelText(/other relationship/i)).not.toBeInTheDocument()
+    await act(() => userEvent.selectOptions(relationshipSelect, "other"))
+    expect(relationshipSelect).toHaveValue("other")
+    expect(await screen.findByLabelText(/other relationship/i)).toBeInTheDocument()
+  })
+})

--- a/sites/partners/__tests__/components/applications/sections/FormApplicationData.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormApplicationData.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import React from "react"
+import userEvent from "@testing-library/user-event"
+import { act } from "react-dom/test-utils"
+import { LanguagesEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { FormProviderWrapper } from "./helpers"
+import { FormApplicationData } from "../../../../src/components/applications/PaperApplicationForm/sections/FormApplicationData"
+
+describe("<FormApplicationData>", () => {
+  it("renders the form with application data fields", () => {
+    render(
+      <FormProviderWrapper>
+        <FormApplicationData />
+      </FormProviderWrapper>
+    )
+    expect(screen.getByRole("heading", { level: 2, name: /application data/i })).toBeInTheDocument()
+
+    expect(screen.getByText(/date submitted/i)).toBeInTheDocument()
+    expect(screen.getByTestId("dateSubmitted-month")).toBeInTheDocument()
+    expect(screen.getByTestId("dateSubmitted-day")).toBeInTheDocument()
+    expect(screen.getByTestId("dateSubmitted-year")).toBeInTheDocument()
+
+    expect(screen.getByText(/time submitted/i)).toBeInTheDocument()
+    expect(screen.getByTestId("timeSubmitted-hours")).toBeInTheDocument()
+    expect(screen.getByTestId("timeSubmitted-minutes")).toBeInTheDocument()
+    expect(screen.getByTestId("timeSubmitted-period")).toBeInTheDocument()
+
+    expect(screen.getByLabelText(/language submitted in/i)).toBeInTheDocument()
+  })
+
+  it("time fields are disabled when date is not fully entered", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormApplicationData />
+      </FormProviderWrapper>
+    )
+
+    const timeHours = screen.getByTestId("timeSubmitted-hours")
+    const timeMinutes = screen.getByTestId("timeSubmitted-minutes")
+    const timePeriod = screen.getByTestId("timeSubmitted-period")
+
+    expect(timeHours).toBeDisabled()
+    expect(timeMinutes).toBeDisabled()
+    expect(timePeriod).toBeDisabled()
+
+    const monthInput = screen.getByTestId("dateSubmitted-month")
+    const dayInput = screen.getByTestId("dateSubmitted-day")
+    const yearInput = screen.getByTestId("dateSubmitted-year")
+
+    await act(async () => {
+      await userEvent.type(monthInput, "2")
+      await userEvent.type(dayInput, "10")
+      await userEvent.type(yearInput, "2025")
+    })
+
+    await waitFor(() => {
+      expect(timeHours).not.toBeDisabled()
+      expect(timeMinutes).not.toBeDisabled()
+      expect(timePeriod).not.toBeDisabled()
+    })
+  })
+
+  it("language selection works correctly", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormApplicationData />
+      </FormProviderWrapper>
+    )
+
+    const languageSelect = screen.getByLabelText(/language submitted in/i)
+    await userEvent.selectOptions(languageSelect, LanguagesEnum.en)
+
+    expect((languageSelect as HTMLSelectElement).value).toBe(LanguagesEnum.en)
+  })
+
+  it("clearing date fields resets time fields", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormApplicationData />
+      </FormProviderWrapper>
+    )
+
+    const timeHours = screen.getByTestId("timeSubmitted-hours")
+    const timeMinutes = screen.getByTestId("timeSubmitted-minutes")
+    const timePeriod = screen.getByTestId("timeSubmitted-period")
+    const monthInput = screen.getByTestId("dateSubmitted-month")
+    const dayInput = screen.getByTestId("dateSubmitted-day")
+    const yearInput = screen.getByTestId("dateSubmitted-year")
+
+    await act(async () => {
+      await userEvent.type(monthInput, "2")
+      await userEvent.type(dayInput, "10")
+      await userEvent.type(yearInput, "2025")
+    })
+
+    await act(async () => {
+      await userEvent.type(timeHours, "12")
+      await userEvent.type(timeMinutes, "30")
+      await userEvent.selectOptions(timePeriod, "pm")
+    })
+
+    expect((timeHours as HTMLInputElement).value).toBe("12")
+    expect((timeMinutes as HTMLInputElement).value).toBe("30")
+    expect((timePeriod as HTMLSelectElement).value).toBe("pm")
+
+    await act(async () => {
+      await userEvent.clear(monthInput)
+      await userEvent.clear(dayInput)
+      await userEvent.clear(yearInput)
+    })
+
+    expect(timeHours).toBeDisabled()
+    expect(timeMinutes).toBeDisabled()
+    expect(timePeriod).toBeDisabled()
+    expect((timeHours as HTMLInputElement).value).toBe("")
+    expect((timeMinutes as HTMLInputElement).value).toBe("")
+    expect((timePeriod as HTMLSelectElement).value).toBe("pm")
+  })
+})

--- a/sites/partners/__tests__/components/applications/sections/FormDemographics.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormDemographics.test.tsx
@@ -1,0 +1,102 @@
+import { act } from "react-dom/test-utils"
+import { FormDemographics } from "../../../../src/components/applications/PaperApplicationForm/sections/FormDemographics"
+import { mockNextRouter, render, screen } from "../../../testUtils"
+import { FormProviderWrapper } from "./helpers"
+import React from "react"
+import userEvent from "@testing-library/user-event"
+
+beforeAll(() => {
+  mockNextRouter()
+})
+
+describe("<FormDemographics>", () => {
+  it("renders the form with demographic information fields", () => {
+    render(
+      <FormProviderWrapper>
+        <FormDemographics
+          formValues={{
+            id: "id",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            race: [],
+            howDidYouHear: [],
+          }}
+        />
+      </FormProviderWrapper>
+    )
+
+    expect(screen.getByText(/race/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/american indian \/ alaskan native/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/asian/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/black \/ african american/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/native hawaiian \/ other pacific islander/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/white/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/other \/ multiracial/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/decline to respond/i)).toBeInTheDocument()
+
+    expect(screen.queryByLabelText(/Asian Indian/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Chinese/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Filipino/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Japanese/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Korean/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Vietnamese/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Other Asian/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/^Native Hawaiian$/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Guamanian or Chamorro/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/Samoan/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/^Other Pacific Islander$/i)).not.toBeInTheDocument()
+
+    expect(screen.getByLabelText(/ethnicity/i)).toBeInTheDocument()
+
+    expect(screen.getByText(/how did you hear about us/i))
+    expect(screen.getByLabelText(/bus ad/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/developer website/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/email alert/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/flyer/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/friend/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/housing counselor/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^other$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/radio ad/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/alameda county hcd website/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/government website/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/property website/i)).not.toBeInTheDocument()
+  })
+
+  it("should expand suboptions when main key is checked", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormDemographics
+          formValues={{
+            id: "id",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            race: [],
+            howDidYouHear: [],
+          }}
+        />
+      </FormProviderWrapper>
+    )
+
+    const asianCheckbox = screen.getByLabelText(/asian/i)
+    const hawaiianPacificCheckbox = screen.getByLabelText(
+      /native hawaiian \/ other pacific islander/i
+    )
+
+    await act(async () => {
+      await userEvent.click(asianCheckbox)
+      await userEvent.click(hawaiianPacificCheckbox)
+    })
+
+    expect(screen.getByLabelText(/Asian Indian/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Chinese/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Filipino/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Japanese/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Korean/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Vietnamese/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Other Asian/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^Native Hawaiian$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Guamanian or Chamorro/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Samoan/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^Other Pacific Islander$/i)).toBeInTheDocument()
+  })
+})

--- a/sites/partners/__tests__/components/applications/sections/FormHouseholdDetails.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormHouseholdDetails.test.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import { mockNextRouter, render, screen } from "../../../testUtils"
+import { FormProviderWrapper } from "./helpers"
+import { FormHouseholdDetails } from "../../../../src/components/applications/PaperApplicationForm/sections/FormHouseholdDetails"
+import { UnitTypeEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { unit } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+
+beforeAll(() => {
+  mockNextRouter()
+})
+
+describe("<FormHouseholdDetails>", () => {
+  it("renders the form with household details fields", () => {
+    render(
+      <FormProviderWrapper>
+        <FormHouseholdDetails
+          listingUnits={Object.values(UnitTypeEnum).map((item, index) => ({
+            ...unit,
+            unitTypes: {
+              id: `id_${index}`,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              numBedrooms: index,
+              name: item,
+            },
+          }))}
+          applicationUnitTypes={[]}
+          applicationAccessibilityFeatures={{
+            id: "id",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            mobility: true,
+            vision: true,
+            hearing: true,
+          }}
+        />
+      </FormProviderWrapper>
+    )
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: /household details/i })
+    ).toBeInTheDocument()
+
+    expect(screen.getByText(/preferred unit sizes/i)).toBeInTheDocument()
+    expect(screen.getByLabelText("5 Bedroom")).toBeInTheDocument()
+    expect(screen.getByLabelText("4 Bedroom")).toBeInTheDocument()
+    expect(screen.getByLabelText("3 Bedroom")).toBeInTheDocument()
+    expect(screen.getByLabelText("2 Bedroom")).toBeInTheDocument()
+    expect(screen.getByLabelText("1 Bedroom")).toBeInTheDocument()
+    expect(screen.getByLabelText("SRO")).toBeInTheDocument()
+    expect(screen.getByLabelText("Studio")).toBeInTheDocument()
+
+    expect(screen.getByText(/ada priorities selected/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/mobility impairments/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/vision impairments/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/hearing impairments/i)).toBeInTheDocument()
+
+    expect(screen.getByText(/expecting household changes/i)).toBeInTheDocument()
+    expect(screen.getByText(/household includes student or member nearing 18/i)).toBeInTheDocument()
+    expect(screen.getAllByLabelText(/yes/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/no/i)).toHaveLength(2)
+  })
+})

--- a/sites/partners/__tests__/components/applications/sections/FormHouseholdIncome.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormHouseholdIncome.test.tsx
@@ -1,0 +1,54 @@
+import React from "react"
+import { FormHouseholdIncome } from "../../../../src/components/applications/PaperApplicationForm/sections/FormHouseholdIncome"
+import { act, mockNextRouter, render, screen } from "../../../testUtils"
+import { FormProviderWrapper } from "./helpers"
+import userEvent from "@testing-library/user-event"
+
+beforeAll(() => {
+  mockNextRouter()
+})
+
+describe("<FormHouseholdIncome>", () => {
+  it("renders the form with household income fields", () => {
+    render(
+      <FormProviderWrapper>
+        <FormHouseholdIncome />
+      </FormProviderWrapper>
+    )
+
+    expect(screen.getByRole("heading", { level: 2, name: /declared household income/i }))
+    expect(screen.getByText(/income period/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/per year/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/per month/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/annual income/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/monthly income/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/housing voucher or subsidy/i)).toBeInTheDocument()
+  })
+
+  it("should disable income value fields until income period is selected", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormHouseholdIncome />
+      </FormProviderWrapper>
+    )
+
+    const annualIncomeInput = screen.getByLabelText(/annual income/i)
+    const monthlyIncomeInput = screen.getByLabelText(/monthly income/i)
+
+    expect(annualIncomeInput).toBeDisabled()
+    expect(monthlyIncomeInput).toBeDisabled()
+
+    const perYearOption = screen.getByLabelText(/per year/i)
+    const perMonthOption = screen.getByLabelText(/per month/i)
+
+    await act(() => userEvent.click(perYearOption))
+
+    expect(annualIncomeInput).toBeEnabled()
+    expect(monthlyIncomeInput).toBeDisabled()
+
+    await act(() => userEvent.click(perMonthOption))
+
+    expect(annualIncomeInput).toBeDisabled()
+    expect(monthlyIncomeInput).toBeEnabled()
+  })
+})

--- a/sites/partners/__tests__/components/applications/sections/FormHouseholdMembers.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormHouseholdMembers.test.tsx
@@ -1,0 +1,302 @@
+import React from "react"
+import { FormProviderWrapper } from "./helpers"
+import { FormHouseholdMembers } from "../../../../src/components/applications/PaperApplicationForm/sections/FormHouseholdMembers"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { act } from "react-dom/test-utils"
+import {
+  HouseholdMemberRelationship,
+  YesNoEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+
+const mockHouseholdMember = {
+  id: "member_1_id",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  firstName: "John",
+  middleName: "Mark",
+  lastName: "Smith",
+  relationship: HouseholdMemberRelationship.cousin,
+  birthYear: "1998",
+  birthMonth: "3",
+  birthDay: "28",
+  workInRegion: YesNoEnum.yes,
+  sameAddress: YesNoEnum.no,
+  householdMemberAddress: {
+    id: "address_1_id",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    city: "New London",
+    state: "",
+    zipCode: "",
+    street: "",
+  },
+}
+
+describe("<FormHouseholdMembers>", () => {
+  it("should render the add household member button and drawer", async () => {
+    render(
+      <FormProviderWrapper>
+        {/* eslint-disable-next-line @typescript-eslint/no-empty-function */}
+        <FormHouseholdMembers householdMembers={[]} setHouseholdMembers={() => {}} />
+      </FormProviderWrapper>
+    )
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: /household members/i })
+    ).toBeInTheDocument()
+
+    const addMemberButton = screen.getByRole("button", { name: /add household member/i })
+    expect(addMemberButton).toBeInTheDocument()
+    expect(screen.queryByRole("table")).not.toBeInTheDocument()
+
+    await act(() => userEvent.click(addMemberButton))
+
+    const drawerTitle = screen.getByRole("heading", { level: 1, name: /^household member$/i })
+    expect(drawerTitle).toBeInTheDocument()
+
+    const drawerContainer = drawerTitle.parentElement.parentElement
+    expect(
+      within(drawerContainer).getByRole("heading", { level: 2, name: /household details/i })
+    ).toBeInTheDocument()
+    expect(within(drawerContainer).getByLabelText(/first name/i)).toBeInTheDocument()
+    expect(within(drawerContainer).getByLabelText(/middle name \(optional\)/i)).toBeInTheDocument()
+    expect(within(drawerContainer).getByLabelText(/last name/i)).toBeInTheDocument()
+    expect(within(drawerContainer).getByText(/date of birth/i)).toBeInTheDocument()
+    expect(within(drawerContainer).getByLabelText(/month/i)).toBeInTheDocument()
+    expect(within(drawerContainer).getByLabelText(/day/i)).toBeInTheDocument()
+    expect(within(drawerContainer).getByLabelText(/year/i)).toBeInTheDocument()
+    expect(within(drawerContainer).getByLabelText(/relationship/i)).toBeInTheDocument()
+    expect(within(drawerContainer).getByText(/same address as primary/i)).toBeInTheDocument()
+    expect(within(drawerContainer).getByText(/work in region/i)).toBeInTheDocument()
+
+    expect(within(drawerContainer).getByRole("button", { name: /submit/i }))
+    expect(within(drawerContainer).getByRole("button", { name: /cancel/i }))
+
+    expect(within(drawerContainer).queryByText(/residence address/i)).not.toBeInTheDocument()
+    expect(within(drawerContainer).queryByText(/work address/i)).not.toBeInTheDocument()
+    expect(screen.queryAllByLabelText(/street address/i)).toHaveLength(0)
+    expect(screen.queryAllByLabelText(/apt or unit #/i)).toHaveLength(0)
+    expect(screen.queryAllByLabelText(/city/i)).toHaveLength(0)
+    expect(screen.queryAllByLabelText(/state/i)).toHaveLength(0)
+    expect(screen.queryAllByLabelText(/zip code/i)).toHaveLength(0)
+  })
+
+  it("show residance address fields when same address as primary is set to no", async () => {
+    render(
+      <FormProviderWrapper>
+        {/* eslint-disable-next-line @typescript-eslint/no-empty-function */}
+        <FormHouseholdMembers householdMembers={[]} setHouseholdMembers={() => {}} />
+      </FormProviderWrapper>
+    )
+
+    const addMemberButton = screen.getByRole("button", { name: /add household member/i })
+    expect(addMemberButton).toBeInTheDocument()
+
+    await act(() => userEvent.click(addMemberButton))
+
+    const drawerTitle = screen.getByRole("heading", { level: 1, name: /^household member$/i })
+    expect(drawerTitle).toBeInTheDocument()
+
+    const drawerContainer = drawerTitle.parentElement.parentElement
+    const noRadioButton = within(
+      within(drawerContainer).getByText(/same address as primary/i).parentElement
+    ).getByLabelText(/no/i)
+
+    expect(noRadioButton).toBeInTheDocument()
+    await act(() => userEvent.click(noRadioButton))
+
+    expect(screen.getByText(/residence address/i)).toBeInTheDocument()
+    expect(screen.getAllByLabelText(/street address/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/apt or unit #/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/city/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/state/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/zip code/i)).toHaveLength(1)
+  })
+
+  it("show word address fields when does not work in the region", async () => {
+    render(
+      <FormProviderWrapper>
+        {/* eslint-disable-next-line @typescript-eslint/no-empty-function */}
+        <FormHouseholdMembers householdMembers={[]} setHouseholdMembers={() => {}} />
+      </FormProviderWrapper>
+    )
+
+    const addMemberButton = screen.getByRole("button", { name: /add household member/i })
+    expect(addMemberButton).toBeInTheDocument()
+
+    await act(() => userEvent.click(addMemberButton))
+
+    const drawerTitle = screen.getByRole("heading", { level: 1, name: /^household member$/i })
+    expect(drawerTitle).toBeInTheDocument()
+
+    const drawerContainer = drawerTitle.parentElement.parentElement
+    const yesRadioButton = within(
+      within(drawerContainer).getByText(/work in region/i).parentElement
+    ).getByLabelText(/yes/i)
+
+    expect(yesRadioButton).toBeInTheDocument()
+    await act(() => userEvent.click(yesRadioButton))
+
+    expect(screen.getByText(/work address/i)).toBeInTheDocument()
+    expect(screen.getAllByLabelText(/street address/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/apt or unit #/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/city/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/state/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/zip code/i)).toHaveLength(1)
+  })
+
+  it("should show both address section if required", async () => {
+    render(
+      <FormProviderWrapper>
+        {/* eslint-disable-next-line @typescript-eslint/no-empty-function */}
+        <FormHouseholdMembers householdMembers={[]} setHouseholdMembers={() => {}} />
+      </FormProviderWrapper>
+    )
+
+    const addMemberButton = screen.getByRole("button", { name: /add household member/i })
+    expect(addMemberButton).toBeInTheDocument()
+
+    await act(() => userEvent.click(addMemberButton))
+
+    const drawerTitle = screen.getByRole("heading", { level: 1, name: /^household member$/i })
+    expect(drawerTitle).toBeInTheDocument()
+
+    const drawerContainer = drawerTitle.parentElement.parentElement
+
+    const yesRadioButton = within(
+      within(drawerContainer).getByText(/work in region/i).parentElement
+    ).getByLabelText(/yes/i)
+    const noRadioButton = within(
+      within(drawerContainer).getByText(/same address as primary/i).parentElement
+    ).getByLabelText(/no/i)
+
+    expect(yesRadioButton).toBeInTheDocument()
+    expect(noRadioButton).toBeInTheDocument()
+
+    await act(async () => {
+      await userEvent.click(yesRadioButton)
+      await userEvent.click(noRadioButton)
+    })
+
+    expect(screen.getByText(/residence address/i)).toBeInTheDocument()
+    expect(screen.getByText(/work address/i)).toBeInTheDocument()
+    expect(screen.getAllByLabelText(/street address/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/apt or unit #/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/city/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/state/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/zip code/i)).toHaveLength(2)
+  })
+
+  it("should render hosuehold members table", () => {
+    render(
+      <FormProviderWrapper>
+        <FormHouseholdMembers
+          householdMembers={[mockHouseholdMember]}
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          setHouseholdMembers={() => {}}
+        />
+      </FormProviderWrapper>
+    )
+
+    const membersTable = screen.getByRole("table")
+    expect(membersTable).toBeInTheDocument()
+
+    const headAndBody = within(membersTable).getAllByRole("rowgroup")
+    expect(headAndBody).toHaveLength(2)
+
+    const [head, body] = headAndBody
+
+    const tableHeaders = within(head).getAllByRole("columnheader")
+    expect(tableHeaders).toHaveLength(6)
+    const [name, relationship, dob, residence, work, action] = tableHeaders
+    expect(name).toHaveTextContent(/name/i)
+    expect(relationship).toHaveTextContent(/relationship/i)
+    expect(dob).toHaveTextContent(/date of birth/i)
+    expect(residence).toHaveTextContent(/same residence/i)
+    expect(work).toHaveTextContent(/work in region/i)
+    expect(action).toHaveTextContent(/actions/i)
+
+    const tableBodyRows = within(body).getAllByRole("row")
+    expect(tableBodyRows).toHaveLength(1)
+    const [nameVal, relationshipVal, dobVal, residenceVal, workVal, actionVal] = within(
+      tableBodyRows[0]
+    ).getAllByRole("cell")
+    expect(nameVal).toHaveTextContent("John Smith")
+    expect(relationshipVal).toHaveTextContent("Cousin")
+    expect(dobVal).toHaveTextContent("3/28/1998")
+    expect(residenceVal).toHaveTextContent("No")
+    expect(workVal).toHaveTextContent("Yes")
+    expect(within(actionVal).getByRole("button", { name: /edit/i }))
+    expect(within(actionVal).getByRole("button", { name: /delete/i }))
+  })
+
+  it("should open delete modal on delete household member click", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormHouseholdMembers
+          householdMembers={[mockHouseholdMember]}
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          setHouseholdMembers={() => {}}
+        />
+      </FormProviderWrapper>
+    )
+
+    const deleteButton = screen.getByRole("button", { name: /delete/i })
+    expect(deleteButton).toBeInTheDocument()
+
+    await act(() => userEvent.click(deleteButton))
+
+    const popupTitle = await screen.findByRole("heading", {
+      level: 1,
+      name: /delete this member\?/i,
+    })
+
+    const popupContainer = popupTitle.parentElement.parentElement
+    expect(within(popupContainer).getByText(/do you really want to delete this member\?/i))
+    expect(within(popupContainer).getByRole("button", { name: /cancel/i }))
+    expect(within(popupContainer).getByRole("button", { name: /delete/i }))
+  })
+
+  it("should open filled-out drawer on edit member click", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormHouseholdMembers
+          householdMembers={[
+            {
+              ...mockHouseholdMember,
+              householdMemberWorkAddress: mockHouseholdMember.householdMemberAddress,
+            },
+          ]}
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          setHouseholdMembers={() => {}}
+        />
+      </FormProviderWrapper>
+    )
+
+    const editButton = screen.getByRole("button", { name: /edit/i })
+    expect(editButton).toBeInTheDocument()
+
+    await act(() => userEvent.click(editButton))
+
+    const drawerTitle = screen.getByRole("heading", { level: 1, name: /^household member$/i })
+    expect(drawerTitle).toBeInTheDocument()
+
+    const drawerContainer = drawerTitle.parentElement.parentElement
+    expect(within(drawerContainer).getByLabelText(/first name/i)).toHaveValue("John")
+    expect(within(drawerContainer).getByLabelText(/middle name \(optional\)/i)).toHaveValue("Mark")
+    expect(within(drawerContainer).getByLabelText(/last name/i)).toHaveValue("Smith")
+    expect(within(drawerContainer).getByLabelText(/month/i)).toHaveValue("3")
+    expect(within(drawerContainer).getByLabelText(/day/i)).toHaveValue("28")
+    expect(within(drawerContainer).getByLabelText(/year/i)).toHaveValue("1998")
+    expect(within(drawerContainer).getByLabelText(/relationship/i)).toHaveValue("cousin")
+
+    const workAddress = within(drawerContainer).getByText(/work in region/i)
+    const primaryAdress = within(drawerContainer).getByText(/same address as primary/i)
+
+    expect(within(workAddress.parentElement).getByLabelText(/yes/i)).toBeChecked()
+    expect(within(workAddress.parentElement).getByLabelText(/no/i)).not.toBeChecked()
+    expect(within(primaryAdress.parentElement).getByLabelText(/yes/i)).not.toBeChecked()
+    expect(within(primaryAdress.parentElement).getByLabelText(/no/i)).toBeChecked()
+  })
+})

--- a/sites/partners/__tests__/components/applications/sections/FormMultiselectQuestions.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormMultiselectQuestions.test.tsx
@@ -1,0 +1,278 @@
+import React from "react"
+import { FormMultiselectQuestions } from "../../../../src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions"
+import { FormProviderWrapper } from "./helpers"
+import { MultiselectQuestionsApplicationSectionEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { act, mockNextRouter, render, screen } from "../../../testUtils"
+import { multiselectQuestionPreference } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import userEvent from "@testing-library/user-event"
+
+beforeAll(() => {
+  mockNextRouter()
+})
+
+describe("<FormMultiselectQuestions>", () => {
+  it("should render nothing when no questions are provided", () => {
+    const { container } = render(
+      <FormProviderWrapper>
+        <FormMultiselectQuestions
+          sectionTitle="Test Section Title"
+          questions={[]}
+          applicationSection={MultiselectQuestionsApplicationSectionEnum.preferences}
+        />
+      </FormProviderWrapper>
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("should render checkbox type options without subsection fields", () => {
+    render(
+      <FormProviderWrapper>
+        <FormMultiselectQuestions
+          sectionTitle="Test Section Title"
+          questions={[
+            {
+              multiselectQuestions: {
+                ...multiselectQuestionPreference,
+                options: [
+                  {
+                    text: "Live in County",
+                    ordinal: 1,
+                  },
+                  {
+                    text: "Work in County",
+                    ordinal: 2,
+                  },
+                ],
+                optOutText: "No preference",
+              },
+            },
+          ]}
+          applicationSection={MultiselectQuestionsApplicationSectionEnum.preferences}
+        />
+      </FormProviderWrapper>
+    )
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: /test section title/i })
+    ).toBeInTheDocument()
+
+    expect(screen.getByRole("checkbox", { name: /live in county/i })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: /work in county/i })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: /no preference/i })).toBeInTheDocument()
+
+    expect(screen.queryByLabelText(/full name of address holder/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/relationship to address holder/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/street address/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/apt or unit #/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/city/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/state/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/zip code/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/map preview/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/map pin position/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/automatic/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Map pin position is based on the address provided/i)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/custom/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Drag the pin to update the marker location/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it("should render radio type options without subsection fields", () => {
+    render(
+      <FormProviderWrapper>
+        <FormMultiselectQuestions
+          sectionTitle="Test Section Title"
+          questions={[
+            {
+              multiselectQuestions: {
+                ...multiselectQuestionPreference,
+                options: [
+                  {
+                    text: "Live in County",
+                    ordinal: 1,
+                    exclusive: true,
+                  },
+                  {
+                    text: "Work in County",
+                    ordinal: 2,
+                    exclusive: true,
+                  },
+                ],
+                optOutText: "No preference",
+              },
+            },
+          ]}
+          applicationSection={MultiselectQuestionsApplicationSectionEnum.preferences}
+        />
+      </FormProviderWrapper>
+    )
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: /test section title/i })
+    ).toBeInTheDocument()
+
+    expect(screen.getByText(/Live\/Work in County/i)).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: /live in county/i })).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: /work in county/i })).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: /no preference/i })).toBeInTheDocument()
+
+    expect(screen.queryByLabelText(/full name of address holder/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/relationship to address holder/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/street address/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/apt or unit #/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/city/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/state/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/zip code/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/map preview/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/map pin position/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/automatic/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Map pin position is based on the address provided/i)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/custom/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Drag the pin to update the marker location/i)
+    ).not.toBeInTheDocument()
+  })
+
+  it("should render the additional address holder name field when option is checked", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormMultiselectQuestions
+          sectionTitle="Test Section Title"
+          questions={[
+            {
+              multiselectQuestions: {
+                ...multiselectQuestionPreference,
+                options: [
+                  {
+                    text: "Live in County",
+                    ordinal: 1,
+                    collectName: true,
+                  },
+                ],
+                optOutText: "",
+              },
+            },
+          ]}
+          applicationSection={MultiselectQuestionsApplicationSectionEnum.preferences}
+        />
+      </FormProviderWrapper>
+    )
+    expect(
+      screen.getByRole("heading", { level: 2, name: /test section title/i })
+    ).toBeInTheDocument()
+
+    const checkbox = screen.getByRole("checkbox", { name: /live in county/i })
+    expect(checkbox).toBeInTheDocument()
+
+    expect(screen.queryByLabelText(/full name of address holder/i)).not.toBeInTheDocument()
+    await act(() => userEvent.click(checkbox))
+    expect(await screen.findByText(/full name of address holder/i)).toBeInTheDocument()
+  })
+
+  it("should render the additional address holder relationship field when option is checked", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormMultiselectQuestions
+          sectionTitle="Test Section Title"
+          questions={[
+            {
+              multiselectQuestions: {
+                ...multiselectQuestionPreference,
+                options: [
+                  {
+                    text: "Live in County",
+                    ordinal: 1,
+                    collectRelationship: true,
+                  },
+                ],
+                optOutText: "",
+              },
+            },
+          ]}
+          applicationSection={MultiselectQuestionsApplicationSectionEnum.preferences}
+        />
+      </FormProviderWrapper>
+    )
+    expect(
+      screen.getByRole("heading", { level: 2, name: /test section title/i })
+    ).toBeInTheDocument()
+
+    const checkbox = screen.getByRole("checkbox", { name: /live in county/i })
+    expect(checkbox).toBeInTheDocument()
+
+    expect(screen.queryByLabelText(/relationship to address holder/i)).not.toBeInTheDocument()
+    await act(() => userEvent.click(checkbox))
+    expect(await screen.findByText(/relationship to address holder/i)).toBeInTheDocument()
+  })
+
+  it("should render the qualifying address field when option is checked", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormMultiselectQuestions
+          sectionTitle="Test Section Title"
+          questions={[
+            {
+              multiselectQuestions: {
+                ...multiselectQuestionPreference,
+                options: [
+                  {
+                    text: "Live in County",
+                    ordinal: 1,
+                    collectAddress: true,
+                  },
+                ],
+                optOutText: "",
+              },
+            },
+          ]}
+          applicationSection={MultiselectQuestionsApplicationSectionEnum.preferences}
+        />
+      </FormProviderWrapper>
+    )
+    expect(
+      screen.getByRole("heading", { level: 2, name: /test section title/i })
+    ).toBeInTheDocument()
+
+    const checkbox = screen.getByRole("checkbox", { name: /live in county/i })
+    expect(checkbox).toBeInTheDocument()
+
+    expect(screen.queryByText(/qualifying address/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/street address/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/apt or unit #/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/city/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/state/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/zip code/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/map preview/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/map pin position/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/automatic/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Map pin position is based on the address provided/i)
+    ).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/custom/i)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/Drag the pin to update the marker location/i)
+    ).not.toBeInTheDocument()
+
+    await act(() => userEvent.click(checkbox))
+
+    expect(screen.getByText(/qualifying address/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/street address/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/apt or unit #/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/city/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/state/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/zip code/i)).toBeInTheDocument()
+    expect(screen.getByText(/map preview/i)).toBeInTheDocument()
+    expect(screen.getByText(/^map pin position$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/automatic/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/Map pin position is based on the address provided/i)
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText(/custom/i)).toBeInTheDocument()
+    expect(screen.getByText(/Drag the pin to update the marker location/i)).toBeInTheDocument()
+  })
+})

--- a/sites/partners/__tests__/components/applications/sections/FormPrimaryApplicant.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormPrimaryApplicant.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor, within } from "@testing-library/react"
+import React from "react"
+import { FormPrimaryApplicant } from "../../../../src/components/applications/PaperApplicationForm/sections/FormPrimaryApplicant"
+import { FormProviderWrapper } from "./helpers"
+import userEvent from "@testing-library/user-event"
+import { act } from "react-dom/test-utils"
+
+describe("<FormPrimaryApplicant>", () => {
+  it("renders the form with primary applicant fields", () => {
+    render(
+      <FormProviderWrapper>
+        <FormPrimaryApplicant />
+      </FormProviderWrapper>
+    )
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: /primary applicant/i })
+    ).toBeInTheDocument()
+
+    expect(screen.getByLabelText(/first name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/middle name \(optional\)/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/last name/i)).toBeInTheDocument()
+
+    const dobTitle = screen.getByText(/date of birth/i)
+    expect(dobTitle).toBeInTheDocument()
+    const dobSection = dobTitle.parentElement
+    expect(within(dobSection).getByLabelText(/month/i)).toBeInTheDocument()
+    expect(within(dobSection).getByLabelText(/day/i)).toBeInTheDocument()
+    expect(within(dobSection).getByLabelText(/year/i)).toBeInTheDocument()
+    expect(screen.getAllByLabelText(/email/i)).toHaveLength(2)
+    expect(screen.getAllByText(/^phone$/i)).toHaveLength(2)
+
+    expect(screen.getByLabelText(/what type of number is this\?/i)).toBeInTheDocument()
+    expect(screen.getByText(/^additional phone$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/additional phone type/i)).toBeInTheDocument()
+
+    expect(screen.getByText(/preferred contact type/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/letter/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/text/i)).toBeInTheDocument()
+    expect(screen.getByText(/work in the region\?/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/yes/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/no/i)).toBeInTheDocument()
+
+    expect(screen.getByText(/residence address/i)).toBeInTheDocument()
+    expect(screen.getAllByLabelText(/street address/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/apt or unit #/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/city/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/state/i)).toHaveLength(1)
+    expect(screen.getAllByLabelText(/zip code/i)).toHaveLength(1)
+
+    expect(screen.getByLabelText(/send my mail to a different address/i))
+
+    expect(screen.queryByText(/mailing address/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/work address/i)).not.toBeInTheDocument()
+  })
+
+  it("enables number type select when phone number is given", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormPrimaryApplicant />
+      </FormProviderWrapper>
+    )
+
+    const phoneTypeSelect = screen.getByLabelText(/what type of number is this\?/i)
+    expect(phoneTypeSelect).toBeInTheDocument()
+    expect(phoneTypeSelect).toBeDisabled()
+
+    const phoneInput = within(screen.getByTestId("phoneNumber")).getByRole("textbox")
+
+    expect(phoneInput).toBeInTheDocument()
+
+    await act(async () => {
+      await userEvent.type(phoneInput, "(424) 242-4242")
+    })
+
+    expect(phoneTypeSelect).toBeEnabled()
+  })
+
+  it("enables additional phone type selection when additional phone type is filled", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormPrimaryApplicant />
+      </FormProviderWrapper>
+    )
+
+    const additionalPhoneTypeSelect = screen.getByLabelText(/additional phone type/i)
+    expect(additionalPhoneTypeSelect).toBeInTheDocument()
+    expect(additionalPhoneTypeSelect).toBeDisabled()
+
+    const additonalPhoneInput = within(
+      screen.getByTestId("additionalPhoneNumber").parentElement
+    ).getByRole("textbox")
+
+    expect(additonalPhoneInput).toBeInTheDocument()
+
+    await act(async () => {
+      await userEvent.type(additonalPhoneInput, "(424) 242-4242")
+    })
+
+    expect(additionalPhoneTypeSelect).toBeEnabled()
+  })
+
+  it("show work address fields an work in the region is checked", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormPrimaryApplicant />
+      </FormProviderWrapper>
+    )
+
+    const workInTheRegionButton = screen.getByLabelText("Yes")
+
+    await act(() => userEvent.click(workInTheRegionButton))
+
+    await waitFor(() => {
+      expect(workInTheRegionButton).toBeChecked()
+    })
+
+    expect(screen.getByText(/work address/i)).toBeInTheDocument()
+    expect(screen.getAllByLabelText(/street address/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/apt or unit #/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/city/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/state/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/zip code/i)).toHaveLength(2)
+  })
+
+  it("show mailing address fields an send my mail to a different address is checked", async () => {
+    render(
+      <FormProviderWrapper>
+        <FormPrimaryApplicant />
+      </FormProviderWrapper>
+    )
+
+    const sendMailToAddress = screen.getByLabelText(/send my mail to a different address/i)
+
+    await act(() => userEvent.click(sendMailToAddress))
+
+    await waitFor(() => {
+      expect(sendMailToAddress).toBeChecked()
+    })
+
+    expect(screen.getByText(/mailing address/i)).toBeInTheDocument()
+    expect(screen.getAllByLabelText(/street address/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/apt or unit #/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/city/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/state/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/zip code/i)).toHaveLength(2)
+  })
+})

--- a/sites/partners/__tests__/components/applications/sections/FormTerms.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormTerms.test.tsx
@@ -1,0 +1,23 @@
+import { FormTerms } from "../../../../src/components/applications/PaperApplicationForm/sections/FormTerms"
+import { mockNextRouter, render, screen } from "../../../testUtils"
+import { FormProviderWrapper } from "./helpers"
+import React from "react"
+
+beforeAll(() => {
+  mockNextRouter()
+})
+
+describe("<FormTerms>", () => {
+  it("renders the form with terms fields", () => {
+    render(
+      <FormProviderWrapper>
+        <FormTerms />
+      </FormProviderWrapper>
+    )
+
+    expect(screen.getByRole("heading", { level: 2, name: /terms/i })).toBeInTheDocument()
+    expect(screen.getByText(/signature on terms of agreement/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/yes/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/no/i)).toBeInTheDocument()
+  })
+})

--- a/sites/partners/__tests__/components/applications/sections/helpers.tsx
+++ b/sites/partners/__tests__/components/applications/sections/helpers.tsx
@@ -1,0 +1,8 @@
+import { FormProvider, useForm } from "react-hook-form"
+import { FormTypes } from "../../../../src/lib/applications/FormTypes"
+import React from "react"
+
+export const FormProviderWrapper = ({ children }: React.PropsWithChildren) => {
+  const formMethods = useForm<FormTypes>({})
+  return <FormProvider {...formMethods}>{children}</FormProvider>
+}

--- a/sites/partners/__tests__/pages/listings/[id]/applications/add.test.tsx
+++ b/sites/partners/__tests__/pages/listings/[id]/applications/add.test.tsx
@@ -1,0 +1,116 @@
+import React from "react"
+import NewApplication from "../../../../../src/pages/listings/[id]/applications/add"
+import { mockNextRouter, render, screen, waitFor } from "../../../../testUtils"
+import { setupServer } from "msw/lib/node"
+import { rest } from "msw"
+import { application, listing } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import userEvent from "@testing-library/user-event"
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+})
+
+afterAll(() => {
+  server.close()
+})
+
+describe("listing applications add page", () => {
+  it("should render all application form sections and controll buttons", () => {
+    mockNextRouter({ id: "test_listing_id" })
+    server.use(
+      rest.get("http://localhost:3100/listings/test_listing_id", (_req, res, ctx) => {
+        return res(ctx.json(listing))
+      })
+    )
+    render(<NewApplication />)
+
+    expect(screen.getByRole("heading", { level: 1, name: /new application/i })).toBeInTheDocument()
+    expect(screen.getByText(/draft/i)).toBeInTheDocument()
+
+    //Aapplication form buttons side section
+    expect(screen.getByRole("button", { name: /^submit$/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /submit & new/i })).toBeInTheDocument()
+    const cancelButton = screen.getByRole("link", { name: /cancel/i })
+    expect(cancelButton).toBeInTheDocument()
+    expect(cancelButton).toHaveAttribute("href", "/listings/test_listing_id/applications")
+
+    // Check only for sections titles as the components themselves have separate test files
+    expect(screen.getByRole("heading", { level: 2, name: /application data/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { level: 2, name: /primary applicant/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { level: 2, name: /alternate contact/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { level: 2, name: /household members/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { level: 2, name: /household details/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { level: 2, name: /application programs/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { level: 2, name: /declared household income/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { level: 2, name: /application preferences/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { level: 2, name: /demographic information/i })
+    ).toBeInTheDocument()
+    expect(screen.getByRole("heading", { level: 2, name: /terms/i })).toBeInTheDocument()
+  })
+
+  it("should navigate to preview on submit click", async () => {
+    const { pushMock } = mockNextRouter({ id: "test_id" })
+    server.use(
+      rest.get("http://localhost:3100/listings/test_id", (_req, res, ctx) => {
+        return res(ctx.json({ ...listing, listingMultiselectQuestions: [] }))
+      }),
+      rest.post("http://localhost/api/adapter/applications", (_req, res, ctx) => {
+        return res(
+          ctx.json({ ...application, programs: [], preferences: [], id: "application_id" })
+        )
+      })
+    )
+    render(<NewApplication />)
+
+    const submitButton = screen.getByRole("button", { name: /^submit$/i })
+    expect(submitButton).toBeInTheDocument()
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/application/application_id")
+    })
+  })
+
+  it("should navigate to new form on submit & new click", async () => {
+    const { pushMock } = mockNextRouter({ id: "test_id" })
+    server.use(
+      rest.get("http://localhost:3100/listings/test_id", (_req, res, ctx) => {
+        return res(ctx.json({ ...listing, listingMultiselectQuestions: [] }))
+      }),
+      rest.post("http://localhost/api/adapter/applications", (_req, res, ctx) => {
+        return res(
+          ctx.json({ ...application, programs: [], preferences: [], id: "application_id" })
+        )
+      })
+    )
+    render(<NewApplication />)
+
+    const submitButton = screen.getByRole("button", { name: /submit & new/i })
+    expect(submitButton).toBeInTheDocument()
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/listings/test_id/applications/add")
+    })
+  })
+})

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormApplicationData.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormApplicationData.tsx
@@ -41,6 +41,7 @@ const FormApplicationData = () => {
             errorMessage={t("errors.dateError")}
             required={!!isDateRequired}
             labelClass={"text__caps-spaced"}
+            dataTestId="dateSubmitted"
           />
         </Grid.Cell>
 
@@ -55,6 +56,7 @@ const FormApplicationData = () => {
             disabled={!isDateFilled}
             required={!!isDateFilled}
             labelClass={"text__caps-spaced"}
+            dataTestId="timeSubmitted"
           />
         </Grid.Cell>
 

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormPrimaryApplicant.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormPrimaryApplicant.tsx
@@ -120,6 +120,7 @@ const FormPrimaryApplicant = () => {
               errorMessage={t("errors.phoneNumberError")}
               control={control}
               controlClassName="control"
+              dataTestId="phoneNumber"
             />
           </Grid.Cell>
           <Grid.Cell>
@@ -148,6 +149,7 @@ const FormPrimaryApplicant = () => {
               errorMessage={t("errors.phoneNumberError")}
               control={control}
               controlClassName="control"
+              dataTestId="additionalPhoneNumber"
             />
           </Grid.Cell>
           <Grid.Cell>


### PR DESCRIPTION
This PR addresses #4572 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Add integration tests for application form components 
* Add integration tests for the main use cases of the add new listing application page.

## How Can This Be Tested/Reviewed?

Run the unit test suite for the patterns page 
```
npm run test:app:partners:unit
```

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
