### PR TITLE
release: always secondary sort by name (#4835)

### DIFF
--- a/api/src/utilities/build-order-by.ts
+++ b/api/src/utilities/build-order-by.ts
@@ -15,6 +15,9 @@ export const buildOrderByForListings = (
     return undefined;
   }
 
+  orderBy.push(ListingOrderByKeys.name);
+  orderDir.push(OrderByEnum.ASC);
+
   return orderBy.map((param, index) => {
     switch (param) {
       case ListingOrderByKeys.mostRecentlyUpdated:

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -702,6 +702,9 @@ describe('Testing listing service', () => {
           {
             name: 'asc',
           },
+          {
+            name: 'asc',
+          },
         ],
         where: {
           AND: [
@@ -834,6 +837,9 @@ describe('Testing listing service', () => {
         skip: 0,
         take: 30,
         orderBy: [
+          {
+            name: 'asc',
+          },
           {
             name: 'asc',
           },
@@ -1152,6 +1158,9 @@ describe('Testing listing service', () => {
         skip: 10,
         take: 10,
         orderBy: [
+          {
+            name: 'asc',
+          },
           {
             name: 'asc',
           },

--- a/api/test/unit/utilities/build-order-by.spec.ts
+++ b/api/test/unit/utilities/build-order-by.spec.ts
@@ -1,11 +1,114 @@
+import { ListingOrderByKeys } from '../../../src/enums/listings/order-by-enum';
 import { OrderByEnum } from '../../../src/enums/shared/order-by-enum';
-import { buildOrderBy } from '../../../src/utilities/build-order-by';
+import {
+  buildOrderBy,
+  buildOrderByForListings,
+} from '../../../src/utilities/build-order-by';
+
+describe('Testing buildOrderByForListings', () => {
+  it('should return applicationDueDate in array when orderBy contains applicationDueDate', () => {
+    expect(
+      buildOrderByForListings(
+        [ListingOrderByKeys.applicationDates],
+        [OrderByEnum.ASC],
+      ),
+    ).toEqual([{ applicationDueDate: 'asc' }, { name: 'asc' }]);
+  });
+
+  it('should return marketingType in array when orderBy contains marketingType', () => {
+    expect(
+      buildOrderByForListings(
+        [ListingOrderByKeys.marketingType],
+        [OrderByEnum.ASC],
+      ),
+    ).toEqual([{ marketingType: 'asc' }, { name: 'asc' }]);
+  });
+
+  it('should return closedAt in array when orderBy contains mostRecentlyClosed', () => {
+    expect(
+      buildOrderByForListings(
+        [ListingOrderByKeys.mostRecentlyClosed],
+        [OrderByEnum.ASC],
+      ),
+    ).toEqual([{ closedAt: 'asc' }, { name: 'asc' }]);
+  });
+
+  it('should return publishedAt in array when orderBy contains mostRecentlyPublished', () => {
+    expect(
+      buildOrderByForListings(
+        [ListingOrderByKeys.mostRecentlyPublished],
+        [OrderByEnum.ASC],
+      ),
+    ).toEqual([{ publishedAt: 'asc' }, { name: 'asc' }]);
+  });
+
+  it('should return updatedAt in array when orderBy contains mostRecentlyUpdated', () => {
+    expect(
+      buildOrderByForListings(
+        [ListingOrderByKeys.mostRecentlyUpdated],
+        [OrderByEnum.ASC],
+      ),
+    ).toEqual([{ updatedAt: 'asc' }, { name: 'asc' }]);
+  });
+
+  it('should return name in array when orderBy contains name', () => {
+    expect(
+      buildOrderByForListings([ListingOrderByKeys.name], [OrderByEnum.ASC]),
+    ).toEqual([{ name: 'asc' }, { name: 'asc' }]);
+  });
+
+  it('should return marketingType in array when orderBy contains status', () => {
+    expect(
+      buildOrderByForListings([ListingOrderByKeys.status], [OrderByEnum.ASC]),
+    ).toEqual([{ status: 'asc' }, { name: 'asc' }]);
+  });
+
+  it('should return unitsAvailable in array when orderBy contains unitsAvailable', () => {
+    expect(
+      buildOrderByForListings(
+        [ListingOrderByKeys.unitsAvailable],
+        [OrderByEnum.ASC],
+      ),
+    ).toEqual([{ unitsAvailable: 'asc' }, { name: 'asc' }]);
+  });
+
+  it('should return isWaitlistOpen in array when orderBy contains waitlistOpen', () => {
+    expect(
+      buildOrderByForListings(
+        [ListingOrderByKeys.waitlistOpen],
+        [OrderByEnum.ASC],
+      ),
+    ).toEqual([{ isWaitlistOpen: 'asc' }, { name: 'asc' }]);
+  });
+
+  it('should return undefined when orderBy contains a value that is not an enum', () => {
+    expect(buildOrderByForListings(['order1'], [OrderByEnum.ASC])).toEqual([
+      undefined,
+      { name: 'asc' },
+    ]);
+  });
+
+  it('should return undefined when arrays are of unequal length', () => {
+    expect(
+      buildOrderByForListings(
+        [ListingOrderByKeys.name],
+        [OrderByEnum.ASC, OrderByEnum.ASC],
+      ),
+    ).toEqual(undefined);
+  });
+
+  it('should return undefined when both arrays are empty', () => {
+    expect(buildOrderByForListings([], [])).toEqual(undefined);
+  });
+});
+
 describe('Testing buildOrderBy', () => {
-  it('should return correctly mapped array when both arrays have length', () => {
+  it('should return correctly mapped array when both arrays have the same length', () => {
     expect(
       buildOrderBy(['order1', 'order2'], [OrderByEnum.ASC, OrderByEnum.DESC]),
     ).toEqual([{ order1: 'asc' }, { order2: 'desc' }]);
   });
+
   it('should return empty array when both arrays are empty', () => {
     expect(buildOrderBy([], [])).toEqual(undefined);
   });


### PR DESCRIPTION
This PR addresses [#(4817)](https://github.com/bloom-housing/bloom/issues/4817)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Releases: https://github.com/bloom-housing/bloom/pull/4835

When sorting and paginating on listings with OrderBy set to `status`, Prisma may return repeats on different pages since `status` is not unique and can include a large number of listings, causing some listings not to appear at all.

The solution is to include a secondary sort by name. This way it will sort by status and then subsort by name.

## How Can This Be Tested/Reviewed?

Play around with sorting on the partners listing view. Have more than 8 listings with a single status to make sure issue is resolved.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
