### PR TITLE
fix: customized site message

### DIFF
--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -828,6 +828,7 @@
   "seasons.spring": "Primavera",
   "seasons.summer": "Verano",
   "seasons.winter": "Invierno",
+  "siteMessage.generic": "Este es un mensaje genérico del sitio para informar a los usuarios sobre información importante que deben tener en cuenta al buscar vivienda asequible y recursos de apoyo. Para más información, consulte este <a className='lined' href='https://www.example.com/' target='_blank'>sitio de ejemplo</a>.",
   "states.AK": "Alaska",
   "states.AL": "Alabama",
   "states.AR": "Arkansas",

--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -84,6 +84,7 @@
   "alert.maintenance": "Este sitio está en mantenimiento programado. Nos disculpamos por cualquier inconveniente.",
   "alert.transition": "Se realizará la transición de este sitio al Doorway Housing Portal y se redirigirá a <a className='lined' href='https://www.housingbayarea.org/es' target='_blank'>housingbayarea.org</a>.",
   "alert.transitionv3": "Este sitio se integrará al portal de viviendas Doorway. Visite <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a> para encontrar nuevas oportunidades de viviendas asequibles a partir del 12 de mayo.",
+  "alert.transitionv4": "Este sitio se trasladará al Portal de Vivienda Doorway, en <a className='lined' href='https://housingbayarea.org/es' target='_blank'>housingbayarea.org</a>, a partir del 12 de mayo. Para obtener más información sobre los cambios, visite: <a className='lined' href='https://mtc.ca.gov/achp-to-doorway' target='_blank'>https://mtc.ca.gov/achp-to-doorway</a>.",
   "application.ada.hearing": "Para dificultades auditivas",
   "application.ada.label": "Viviendas accesibles de conformidad con ADA",
   "application.ada.mobility": "Para dificultades en la movilidad",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -832,6 +832,7 @@
   "seasons.spring": "Spring",
   "seasons.summer": "Summer",
   "seasons.winter": "Winter",
+  "siteMessage.generic": "This is a generic site message to inform users of important information to consider as they search for affordable housing and supportive resources. For more information, check out this <a className='lined' href='https://www.example.com/' target='_blank'>example site</a>.",
   "states.AL": "Alabama",
   "states.AK": "Alaska",
   "states.AR": "Arkansas",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -84,6 +84,7 @@
   "alert.transition": "This site will be transitioning into the Doorway Housing Portal and will redirect to <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a>.",
   "alert.transitionv2": "This site is transitioning to the <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>Doorway Housing Portal</a>. If you have questions about your account or applications, please contact Doorway@smchousing.org.",
   "alert.transitionv3": "This site will be folding into the Doorway Housing Portal. Please visit <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a> to find new affordable housing opportunities starting May 12th.",
+  "alert.transitionv4": "This site will be moving to the Doorway Housing Portal, at<a className='lined' href='https://housingbayarea.org' target='_blank'>housingbayarea.org</a>, starting on May 12th. To learn more about the changes, please visit:<a className='lined' href='https://mtc.ca.gov/achp-to-doorway' target='_blank'>https://mtc.ca.gov/achp-to-doorway</a>.",
   "application.ada.hearing": "For Hearing Impairments",
   "application.ada.label": "ADA Accessible Units",
   "application.ada.mobility": "For Mobility Impairments",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -84,6 +84,7 @@
   "alert.maintenance": "Ang site na ito ay sumasailalim sa naka-iskedyul na pagpapanatili. Humihingi kami ng paumanhin para sa anumang abala.",
   "alert.transition": "Ang site na ito ay magiging Doorway Housing Portal at magre-redirect sa <a className='lined' href='https://www.housingbayarea.org/tl' target='_blank'>housingbayarea.org</a>.",
   "alert.transitionv3": "Ang site na ito ay matitiklop sa Doorway Housing Portal. Pakibisita ang <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a> upang makahanap ng mga bagong pagkakataon sa abot-kayang pabahay simula ika-12 ng Mayo.",
+  "alert.transitionv4": "Ang site na ito ay lilipat sa Doorway Housing Portal, sa<a className='lined' href='https://housingbayarea.org/tl' target='_blank'>housingbayarea.org</a>, simula sa ika-12 ng Mayo. Upang matuto nang higit pa tungkol sa mga pagbabago, pakibisita ang:<a className='lined' href='https://mtc.ca.gov/achp-to-doorway' target='_blank'>https://mtc.ca.gov/achp-to-doorway</a>.",
   "application.ada.hearing": "Para Sa Mga Kapansanan Sa Pandinig",
   "application.ada.label": "Mga Accessible Unit ng ADA",
   "application.ada.mobility": "Para Sa Mga Kapansanan Sa Pagkilos",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -816,6 +816,7 @@
   "progressNav.notCompleted": "hindi natapos",
   "progressNav.srHeading": "Pag-unlad",
   "region.name": "Lokal na rehiyon",
+  "siteMessage.generic": "Ito ay isang generic na mensahe ng site upang ipaalam sa mga user ang mahalagang impormasyon na dapat isaalang-alang habang naghahanap sila ng abot-kayang pabahay at mga mapagkukunang pansuporta. Para sa higit pang impormasyon, tingnan itong <a className='lined' href='https://www.example.com/' target='_blank'>halimbawang site</a>.",
   "states.AK": "Alaska",
   "states.AL": "Alabama",
   "states.AR": "Arkansas",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -817,6 +817,7 @@
   "progressNav.notCompleted": "chưa hoàn thành",
   "progressNav.srHeading": "Tiến trình",
   "region.name": "Địa phương",
+  "siteMessage.generic": "Đây là thông báo trang web chung để thông báo cho người dùng những thông tin quan trọng cần cân nhắc khi họ tìm kiếm nhà ở giá rẻ và các nguồn hỗ trợ. Để biết thêm thông tin, hãy xem <a className='lined' href='https://www.example.com/' target='_blank'>trang web mẫu</a> này.",
   "states.AK": "Alaska",
   "states.AL": "Alabama",
   "states.AR": "Arkansas",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -84,6 +84,7 @@
   "alert.maintenance": "Trang web này đang được bảo trì theo lịch trình. Chúng tôi xin lỗi vì bất cứ sự bất tiện nào.",
   "alert.transition": "Trang web này sẽ chuyển sang Doorway Housing Portal và sẽ chuyển hướng đến <a className='lined' href='https://www.housingbayarea.org/vi' target='_blank'>housingbayarea.org</a>.",
   "alert.transitionv3": "Trang web này sẽ được đưa vào Cổng thông tin nhà ở Doorway. Vui lòng truy cập <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a> để tìm các cơ hội nhà ở giá rẻ mới bắt đầu từ ngày 12 tháng 5.",
+  "alert.transitionv4": "Trang web này sẽ được chuyển đến Cổng thông tin nhà ở Doorway, tại <a className='lined' href='https://housingbayarea.org/vi' target='_blank'>housingbayarea.org</a>, bắt đầu từ ngày 12 tháng 5. Để tìm hiểu thêm về những thay đổi, vui lòng truy cập: <a className='lined' href='https://mtc.ca.gov/achp-to-doorway' target='_blank'>https://mtc.ca.gov/achp-to-doorway</a>.",
   "application.ada.hearing": "Dành cho các cư dân bị Suy giảm Thính lực",
   "application.ada.label": "Các Căn nhà Dễ tiếp cập của ADA",
   "application.ada.mobility": "Dành cho các cư dân Vận động Khó khăn",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -817,6 +817,7 @@
   "progressNav.notCompleted": "没完成",
   "progressNav.srHeading": "进度",
   "region.name": "當地地區",
+  "siteMessage.generic": "這是一條通用的網站消息，旨在告知用戶在搜索經濟適用房和支持資源時需要考慮的重要信息。更多信息，請查看此<a className='lined' href='https://www.example.com/' target='_blank'>示例網站</a>。",
   "states.AK": "Alaska（阿拉斯加州）",
   "states.AL": "Alabama（阿拉巴馬州）",
   "states.AR": "Arkansas（阿肯色州）",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -84,6 +84,7 @@
   "alert.maintenance": "该网站正在进行定期维护。很抱歉给您带来不便。",
   "alert.transition": "此网站将转换为住房门户网站/ Doorway Housing Portal 并且其网址 将更新到 <a className='lined' href='https://www.housingbayarea.org/zh' target='_blank'>housingbayarea.org</a>.",
   "alert.transitionv3": "該網站將折疊到門口住房門戶網站中。從 5 月 12 日起，請造訪 <a className='lined' href='https://www.housingbayarea.org/' target='_blank'>housingbayarea.org</a> 尋找新的經濟適用房機會。",
+  "alert.transitionv4": "本網站將於 5 月 12 日起遷移至 Doorway 住房門戶網站，網址為 <a className='lined' href='https://housingbayarea.org/zh' target='_blank'>housingbayarea.org</a>。如需了解更多變更信息，請訪問：<a className='lined' href='https://mtc.ca.gov/achp-to-doorway' target='_blank'>https://mtc.ca.gov/achp-to-doorway</a>。",
   "application.ada.hearing": "聽障",
   "application.ada.label": "《美國殘疾人法案》(ADA) 規定的無障礙單位",
   "application.ada.mobility": "行動不便",

--- a/sites/public/.env.template
+++ b/sites/public/.env.template
@@ -25,6 +25,7 @@ DOORWAY_URL=https://dev.doorway.housingbayarea.org
 # YYYY-MM-DD HH:mm Z,YYYY-MM-DD HH:mm Z
 # 2024-02-05 18:00 -08:00,2024-02-05 18:55 -08:00
 MAINTENANCE_WINDOW=
+SITE_MESSAGE_WINDOW=
 
 # feature toggles
 SHOW_PUBLIC_LOTTERY=TRUE

--- a/sites/public/next.config.js
+++ b/sites/public/next.config.js
@@ -47,6 +47,7 @@ module.exports = withBundleAnalyzer({
     showMandatedAccounts: process.env.SHOW_MANDATED_ACCOUNTS === "TRUE",
     showPwdless: process.env.SHOW_PWDLESS === "TRUE",
     maintenanceWindow: process.env.MAINTENANCE_WINDOW,
+    siteMessageWindow: process.env.SITE_MESSAGE_WINDOW,
     reCaptchaKey: process.env.RECAPTCHA_KEY,
     maxClosedListings: process.env.MAX_CLOSED_LISTINGS,
     maxOpenListings: process.env.MAX_OPEN_LISTINGS,

--- a/sites/public/src/layouts/application.module.scss
+++ b/sites/public/src/layouts/application.module.scss
@@ -1,9 +1,16 @@
-.site-alert-banner-container {
-  background-color: var(--seeds-color-primary-light);
+.site-banner-container {
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.site-banner-alert-bg {
+  background-color: var(--seeds-color-alert-light);
+}
+
+.site-banner-primary-bg {
+  background-color: var(--seeds-color-primary-light);
 }
 
 .site-alert-banner-content {


### PR DESCRIPTION
This PR releases #4846 with custom copy

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR builds off of the maintenance banner pattern to include a generic site message. This way we can turn on the site message and maintenance banner simultaneously or toggle them more quickly with the env variables.

**Most importantly, this adds the updated AC transition banner copy**

## How Can This Be Tested/Reviewed?

Update the MAINTENANCE_WINDOW and SITE_MESSAGE_WINDOW env variables and rebuild to see the view when one, both, or neither are showing. NOTE: This functionality is not part of the seeds SiteHeader so seeds must be turned off

**Set your jurisdiction env var to Alameda to see the following updated copy** "This site will be moving to the Doorway Housing Portal, at [housingbayarea.org](http://housingbayarea.org/), starting on May 12th. To learn more about the changes, please visit: https://mtc.ca.gov/achp-to-doorway."


## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
