### PR TITLE
release: FE - public unit groups (#4752)

### DIFF
--- a/api/src/dtos/unit-groups/unit-group-summary.dto.ts
+++ b/api/src/dtos/unit-groups/unit-group-summary.dto.ts
@@ -10,12 +10,13 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
 import { MinMaxCurrency } from '../shared/min-max-currency.dto';
 import { MinMax } from '../shared/min-max.dto';
+import { UnitType } from '../unit-types/unit-type.dto';
 
 export class UnitGroupSummary {
   @Expose()
   @IsString({ groups: [ValidationsGroupsEnum.default], each: true })
-  @ApiPropertyOptional({ type: [String] })
-  unitTypes?: string[] | null;
+  @ApiPropertyOptional({ type: [UnitType] })
+  unitTypes?: UnitType[] | null;
 
   @Expose()
   @ValidateNested({ groups: [ValidationsGroupsEnum.default] })

--- a/api/src/utilities/unit-groups-transformations.ts
+++ b/api/src/utilities/unit-groups-transformations.ts
@@ -56,9 +56,9 @@ export const getUnitGroupSummary = (
       amiPercentageRange = setMinMax(amiPercentageRange, level.amiPercentage);
     });
     const groupSummary: UnitGroupSummary = {
-      unitTypes: group.unitTypes
-        .sort((a, b) => (a.numBedrooms < b.numBedrooms ? -1 : 1))
-        .map((type) => type.name),
+      unitTypes: group.unitTypes.sort((a, b) =>
+        a.numBedrooms < b.numBedrooms ? -1 : 1,
+      ),
       rentAsPercentIncomeRange,
       rentRange: rentRange && {
         min: rentRange.min ? `$${rentRange.min}` : '',

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -2574,7 +2574,15 @@ describe('Testing listing service', () => {
 
       expect(listing.unitGroups).toEqual(mockedListing.unitGroups);
       expect(listing.unitGroupsSummarized.unitGroupSummary[0]).toEqual({
-        unitTypes: [UnitTypeEnum.SRO],
+        unitTypes: [
+          {
+            id: 'unitType 0',
+            createdAt: date,
+            updatedAt: date,
+            name: 'SRO',
+            numBedrooms: 0,
+          },
+        ],
         rentAsPercentIncomeRange: {
           min: 0,
           max: 30,
@@ -2599,7 +2607,15 @@ describe('Testing listing service', () => {
         },
       });
       expect(listing.unitGroupsSummarized.unitGroupSummary[2]).toEqual({
-        unitTypes: [UnitTypeEnum.oneBdrm],
+        unitTypes: [
+          {
+            id: 'unitType 2',
+            createdAt: date,
+            updatedAt: date,
+            name: 'oneBdrm',
+            numBedrooms: 2,
+          },
+        ],
         rentAsPercentIncomeRange: {
           min: 20,
           max: 50,

--- a/api/test/unit/utilities/unit-group-transformations.spec.ts
+++ b/api/test/unit/utilities/unit-group-transformations.spec.ts
@@ -83,7 +83,15 @@ describe('Unit Group Transformations', () => {
       const result = getUnitGroupSummary(unitGroups);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
-        unitTypes: [UnitTypeEnum.studio],
+        unitTypes: [
+          {
+            id: 'type1',
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+            name: UnitTypeEnum.studio,
+            numBedrooms: 0,
+          },
+        ],
         rentAsPercentIncomeRange: undefined,
         rentRange: {
           min: '$1000',
@@ -147,7 +155,15 @@ describe('Unit Group Transformations', () => {
       const result = getUnitGroupSummary(unitGroups);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
-        unitTypes: [UnitTypeEnum.oneBdrm],
+        unitTypes: [
+          {
+            id: 'type1',
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+            name: UnitTypeEnum.oneBdrm,
+            numBedrooms: 1,
+          },
+        ],
         rentAsPercentIncomeRange: {
           min: 30,
           max: 30,
@@ -247,36 +263,57 @@ describe('Unit Group Transformations', () => {
       ];
 
       const result = getUnitGroupSummary(unitGroups);
+
       expect(result).toHaveLength(2);
-      expect(result[0].unitTypes).toEqual([UnitTypeEnum.studio]);
-      expect(result[1].unitTypes).toEqual([UnitTypeEnum.oneBdrm]);
-      expect(result[1]).toEqual({
-        unitTypes: [UnitTypeEnum.oneBdrm],
-        rentAsPercentIncomeRange: {
+      expect(result[0].unitTypes).toEqual([
+        {
+          id: 'type1',
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+          name: UnitTypeEnum.studio,
+          numBedrooms: 0,
+        },
+      ]);
+      expect(result[1].unitTypes).toEqual([
+        {
+          id: 'type2',
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+          name: UnitTypeEnum.oneBdrm,
+          numBedrooms: 1,
+        },
+      ]);
+      expect(result[0]).toEqual({
+        unitTypes: [
+          {
+            id: 'type1',
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+            name: UnitTypeEnum.studio,
+            numBedrooms: 0,
+          },
+        ],
+        rentRange: {
+          min: '$1000',
+          max: '$1000',
+        },
+        amiPercentageRange: {
           min: 30,
           max: 30,
         },
-        rentRange: {
-          min: '$1500',
-          max: '$1500',
-        },
-        amiPercentageRange: {
-          min: 50,
-          max: 80,
-        },
-        openWaitlist: false,
-        unitVacancies: 3,
+        openWaitlist: true,
+        unitVacancies: 5,
         bathroomRange: {
           min: 1,
-          max: 2,
+          max: 1,
         },
         floorRange: {
-          min: 2,
-          max: 4,
+          min: 1,
+          max: 1,
         },
         sqFeetRange: {
-          min: 700,
-          max: 900,
+          min: 500,
+          max: 500,
         },
       });
     });
@@ -823,7 +860,13 @@ describe('Unit Group Transformations', () => {
       // Check unit group summary
       expect(result.unitGroupSummary).toHaveLength(1);
       expect(result.unitGroupSummary[0].unitTypes).toEqual([
-        UnitTypeEnum.studio,
+        {
+          id: 'type1',
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+          name: UnitTypeEnum.studio,
+          numBedrooms: 0,
+        },
       ]);
 
       // Check household max income summary

--- a/shared-helpers/__tests__/views/summaryTables.test.ts
+++ b/shared-helpers/__tests__/views/summaryTables.test.ts
@@ -1,6 +1,11 @@
 import { cleanup } from "@testing-library/react"
-import { UnitSummary, UnitTypeEnum } from "../../src/types/backend-swagger"
-import { mergeSummaryRows, stackedUnitSummariesTable } from "../../src/views/summaryTables"
+import { UnitSummary, UnitTypeEnum, UnitGroupSummary } from "../../src/types/backend-swagger"
+import {
+  mergeSummaryRows,
+  stackedUnitSummariesTable,
+  mergeGroupSummaryRows,
+  stackedUnitGroupsSummariesTable,
+} from "../../src/views/summaryTables"
 
 afterEach(cleanup)
 
@@ -21,6 +26,15 @@ const defaultUnitSummary = {
   totalAvailable: null as unknown,
   areaRange: { min: null as unknown, max: null as unknown },
 } as UnitSummary
+
+const defaultUnitGroupSummary = {
+  unitTypes: [],
+  rentRange: { min: null as unknown, max: null as unknown },
+  rentAsPercentIncomeRange: { min: null as unknown, max: null as unknown },
+  unitVacancies: 0,
+  openWaitlist: false,
+  amiPercentageRange: { min: null as unknown, max: null as unknown },
+} as UnitGroupSummary
 
 const rentNoRanges = [
   {
@@ -176,6 +190,196 @@ const noRentData = [
   },
 ]
 
+// Test data for unit groups
+const groupRentNoRanges = [
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+    rentRange: { min: "1200", max: "1200" },
+  },
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+    rentRange: { min: "1200", max: "1200" },
+  },
+]
+
+const groupRentRanges = [
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+    rentRange: { min: "1400", max: "1500" },
+  },
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+    rentRange: { min: "1200", max: "1300" },
+  },
+]
+
+const groupPercentageRentNoRanges = [
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+    rentAsPercentIncomeRange: { min: 30, max: 30 },
+  },
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+    rentAsPercentIncomeRange: { min: 30, max: 30 },
+  },
+]
+
+const groupPercentageRent = [
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+    rentAsPercentIncomeRange: { min: 5, max: 10 },
+  },
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+    rentAsPercentIncomeRange: { min: 15, max: 20 },
+  },
+]
+
+const groupMixedRentUnits = [
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+    rentAsPercentIncomeRange: { min: 20, max: 30 },
+  },
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 3,
+        name: UnitTypeEnum.threeBdrm,
+      },
+    ],
+    rentAsPercentIncomeRange: { min: 10, max: 15 },
+  },
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+    rentRange: { min: "450", max: "750" },
+  },
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 2,
+        name: UnitTypeEnum.twoBdrm,
+      },
+    ],
+    rentRange: { min: "400", max: "700" },
+  },
+]
+
+const groupNoRentData = [
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+  },
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+    ],
+  },
+]
+
+const groupMultipleUnitTypes = [
+  {
+    ...defaultUnitGroupSummary,
+    unitTypes: [
+      {
+        ...defaultUnit,
+        numBedrooms: 1,
+        name: UnitTypeEnum.oneBdrm,
+      },
+      {
+        ...defaultUnit,
+        numBedrooms: 2,
+        name: UnitTypeEnum.twoBdrm,
+      },
+    ],
+    rentRange: { min: "1200", max: "1500" },
+  },
+]
+
 describe("mergeSummaryRows", () => {
   it("should merge units with just $ rent and no ranges", () => {
     expect(mergeSummaryRows(rentNoRanges)).toEqual({
@@ -315,6 +519,226 @@ describe("stackedUnitSummariesTable", () => {
         minimumIncome: { cellSubText: "", cellText: "n/a" },
         rent: { cellSubText: "", cellText: "n/a" },
         unitType: { cellSubText: "", cellText: "1 BR" },
+      },
+    ])
+  })
+})
+
+describe("mergeGroupSummaryRows", () => {
+  it("should merge unit groups with just $ rent and no ranges", () => {
+    expect(mergeGroupSummaryRows(groupRentNoRanges)).toEqual({
+      maxDollarRent: 1200,
+      maxPercentageRent: null,
+      maxUnitName: "oneBdrm",
+      maxUnitType: 1,
+      minDollarRent: 1200,
+      minPercentageRent: null,
+      minUnitName: "oneBdrm",
+      minUnitType: 1,
+    })
+  })
+  it("should merge unit groups with just $ rent and ranges", () => {
+    expect(mergeGroupSummaryRows(groupRentRanges)).toEqual({
+      maxDollarRent: 1500,
+      maxPercentageRent: null,
+      maxUnitName: "oneBdrm",
+      maxUnitType: 1,
+      minDollarRent: 1200,
+      minPercentageRent: null,
+      minUnitName: "oneBdrm",
+      minUnitType: 1,
+    })
+  })
+  it("should merge unit groups with just % rent and no ranges", () => {
+    expect(mergeGroupSummaryRows(groupPercentageRentNoRanges)).toEqual({
+      maxDollarRent: null,
+      maxPercentageRent: 30,
+      maxUnitName: "oneBdrm",
+      maxUnitType: 1,
+      minDollarRent: null,
+      minPercentageRent: 30,
+      minUnitName: "oneBdrm",
+      minUnitType: 1,
+    })
+  })
+  it("should merge unit groups with just % rent and ranges", () => {
+    expect(mergeGroupSummaryRows(groupPercentageRent)).toEqual({
+      maxDollarRent: null,
+      maxPercentageRent: 20,
+      maxUnitName: "oneBdrm",
+      maxUnitType: 1,
+      minDollarRent: null,
+      minPercentageRent: 5,
+      minUnitName: "oneBdrm",
+      minUnitType: 1,
+    })
+  })
+  it("should merge unit groups with both $ and % units", () => {
+    expect(mergeGroupSummaryRows(groupMixedRentUnits)).toEqual({
+      maxDollarRent: 750,
+      maxPercentageRent: 30,
+      maxUnitName: "threeBdrm",
+      maxUnitType: 3,
+      minDollarRent: 400,
+      minPercentageRent: 10,
+      minUnitName: "oneBdrm",
+      minUnitType: 1,
+    })
+  })
+  it("should merge unit groups with no rent data", () => {
+    expect(mergeGroupSummaryRows(groupNoRentData)).toEqual({
+      maxDollarRent: null,
+      maxPercentageRent: null,
+      maxUnitName: "oneBdrm",
+      maxUnitType: 1,
+      minDollarRent: null,
+      minPercentageRent: null,
+      minUnitName: "oneBdrm",
+      minUnitType: 1,
+    })
+  })
+  it("should properly use first and last unit type from the array", () => {
+    expect(mergeGroupSummaryRows(groupMultipleUnitTypes)).toEqual({
+      maxDollarRent: 1500,
+      maxPercentageRent: null,
+      maxUnitName: "twoBdrm",
+      maxUnitType: 2,
+      minDollarRent: 1200,
+      minPercentageRent: null,
+      minUnitName: "oneBdrm",
+      minUnitType: 1,
+    })
+  })
+})
+
+describe("stackedUnitGroupsSummariesTable", () => {
+  it("should merge unit groups with just $ rent and no ranges", () => {
+    expect(stackedUnitGroupsSummariesTable(groupRentNoRanges)).toEqual([
+      {
+        rent: { cellSubText: "per month", cellText: "$1,200" },
+        unitType: { cellSubText: "", cellText: "1 BR" },
+        availability: { cellText: "Not available" },
+      },
+    ])
+  })
+  it("should merge unit groups with just $ rent and ranges", () => {
+    expect(stackedUnitGroupsSummariesTable(groupRentRanges)).toEqual([
+      {
+        rent: { cellSubText: "per month", cellText: "$1,200 to $1,500" },
+        unitType: { cellSubText: "", cellText: "1 BR" },
+        availability: { cellText: "Not available" },
+      },
+    ])
+  })
+  it("should merge unit groups with just % rent and no ranges", () => {
+    expect(stackedUnitGroupsSummariesTable(groupPercentageRentNoRanges)).toEqual([
+      {
+        rent: { cellSubText: "per month", cellText: "30% of income" },
+        unitType: { cellSubText: "", cellText: "1 BR" },
+        availability: { cellText: "Not available" },
+      },
+    ])
+  })
+  it("should merge unit groups with just % rent and ranges", () => {
+    expect(stackedUnitGroupsSummariesTable(groupPercentageRent)).toEqual([
+      {
+        rent: { cellSubText: "per month", cellText: "5% to 20% of income" },
+        unitType: { cellSubText: "", cellText: "1 BR" },
+        availability: { cellText: "Not available" },
+      },
+    ])
+  })
+  it("should merge unit groups with both $ and % units", () => {
+    expect(stackedUnitGroupsSummariesTable(groupMixedRentUnits)).toEqual([
+      {
+        rent: { cellSubText: "per month", cellText: "% of income, or up to $750" },
+        unitType: { cellSubText: "", cellText: "1 BR - 3 BR" },
+        availability: { cellText: "Not available" },
+      },
+    ])
+  })
+  it("should merge unit groups with no rent data", () => {
+    expect(stackedUnitGroupsSummariesTable(groupNoRentData)).toEqual([
+      {
+        rent: { cellSubText: "", cellText: "n/a" },
+        unitType: { cellSubText: "", cellText: "1 BR" },
+        availability: { cellText: "Not available" },
+      },
+    ])
+  })
+  it("should handle multiple unit types in a single group", () => {
+    expect(stackedUnitGroupsSummariesTable(groupMultipleUnitTypes)).toEqual([
+      {
+        rent: { cellSubText: "per month", cellText: "$1,200 to $1,500" },
+        unitType: { cellSubText: "", cellText: "1 BR - 2 BR" },
+        availability: { cellText: "Not available" },
+      },
+    ])
+  })
+  it("should show availability text for open waitlist", () => {
+    const openWaitlistGroup = [
+      {
+        ...defaultUnitGroupSummary,
+        unitTypes: [
+          {
+            ...defaultUnit,
+            numBedrooms: 1,
+            name: UnitTypeEnum.oneBdrm,
+          },
+        ],
+        openWaitlist: true,
+      },
+    ]
+    expect(stackedUnitGroupsSummariesTable(openWaitlistGroup)).toEqual([
+      {
+        rent: { cellSubText: "", cellText: "n/a" },
+        unitType: { cellSubText: "", cellText: "1 BR" },
+        availability: { cellText: "Open Waitlist" },
+      },
+    ])
+  })
+  it("should show availability text for vacant units", () => {
+    const vacantUnitsGroup = [
+      {
+        ...defaultUnitGroupSummary,
+        unitTypes: [
+          {
+            ...defaultUnit,
+            numBedrooms: 1,
+            name: UnitTypeEnum.oneBdrm,
+          },
+        ],
+        unitVacancies: 3,
+      },
+    ]
+    expect(stackedUnitGroupsSummariesTable(vacantUnitsGroup)).toEqual([
+      {
+        rent: { cellSubText: "", cellText: "n/a" },
+        unitType: { cellSubText: "", cellText: "1 BR" },
+        availability: {
+          cellText: "3 Vacant Units",
+        },
+      },
+    ])
+  })
+  it("should show coming soon text when isComingSoon is true", () => {
+    const comingSoonGroup = [
+      {
+        ...defaultUnitGroupSummary,
+        unitTypes: [
+          {
+            ...defaultUnit,
+            numBedrooms: 1,
+            name: UnitTypeEnum.oneBdrm,
+          },
+        ],
+      },
+    ]
+    expect(stackedUnitGroupsSummariesTable(comingSoonGroup, true)).toEqual([
+      {
+        rent: { cellSubText: "", cellText: "n/a" },
+        unitType: { cellSubText: "", cellText: "1 BR" },
+        availability: { cellText: "Under Construction" },
       },
     ])
   })

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -761,6 +761,7 @@
   "listings.underConstruction": "Under Construction",
   "listings.unitsAreFor": "These units are for %{type}.",
   "listings.unitsHaveAccessibilityFeaturesFor": "These units have accessibility features for people with %{type}.",
+  "listings.unitsSummary.notAvailable": "Not available",
   "listings.unitTypes.fiveBdrm": "5 BR",
   "listings.unitTypes.fourBdrm": "4 BR",
   "listings.unitTypes.oneBdrm": "1 BR",

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -3563,7 +3563,7 @@ export interface UnitsSummarized {
 
 export interface UnitGroupSummary {
   /**  */
-  unitTypes?: string[]
+  unitTypes?: UnitType[]
 
   /**  */
   rentAsPercentIncomeRange?: MinMax

--- a/shared-helpers/src/views/summaryTables.tsx
+++ b/shared-helpers/src/views/summaryTables.tsx
@@ -7,7 +7,15 @@ import {
   getTranslationWithArguments,
   StackedTableRow,
 } from "@bloom-housing/ui-components"
-import { MinMax, ReviewOrderTypeEnum, Unit, UnitSummary } from "../types/backend-swagger"
+import {
+  MarketingTypeEnum,
+  MinMax,
+  ReviewOrderTypeEnum,
+  Unit,
+  UnitGroupSummary,
+  UnitSummary,
+  Listing,
+} from "../types/backend-swagger"
 import { numberOrdinal } from "../utilities/numberOrdinal"
 
 const getTranslationFromCurrencyString = (value: string) => {
@@ -43,7 +51,6 @@ export const unitSummariesTable = (
           {` ${t("t.perMonth")}`}
         </>
       )
-
     const getRent = (rentMin: string, rentMax: string, percent = false) => {
       const unit = percent ? `% ${t("t.income")}` : ` ${t("t.perMonth")}`
       return rentMin == rentMax ? (
@@ -189,6 +196,17 @@ type StackedSummary = {
   maxUnitName: string | null
 }
 
+type StackedGroupSummary = {
+  minDollarRent: number | null
+  maxDollarRent: number | null
+  minPercentageRent: number | null
+  maxPercentageRent: number | null
+  minUnitType: number | null
+  maxUnitType: number | null
+  minUnitName?: string | null
+  maxUnitName?: string | null
+}
+
 // Replace an old value with a new one if the new one exceeds the defined limit (either less or more) and is valid
 export const replaceIfExceeds = (less: boolean, current: number | null, updated: number | null) => {
   const isValid = (test: number | null) => {
@@ -282,6 +300,74 @@ export const mergeSummaryRows = (summaries: UnitSummary[]): StackedSummary => {
     )
 }
 
+// Massage the data in an array of unit group summaries to calculate the min and max values of each data point across the full set
+// This is essentially a new type of unit summary. We should move this to the backend when we rewrite summaries.
+export const mergeGroupSummaryRows = (summaries: UnitGroupSummary[]): StackedGroupSummary => {
+  return summaries.reduce(
+    (acc, curr) => {
+      const updatedMinUnitType = replaceIfExceeds(
+        true,
+        acc.minUnitType,
+        curr.unitTypes?.[0]?.numBedrooms ?? null
+      )
+      const updatedMaxUnitType = replaceIfExceeds(
+        false,
+        acc.maxUnitType,
+        curr.unitTypes?.[curr.unitTypes.length - 1]?.numBedrooms ?? null
+      )
+
+      return {
+        minDollarRent: replaceIfExceeds(
+          true,
+          acc.minDollarRent,
+          curr.rentRange?.min ? parseInt(curr.rentRange.min.replace(/[$,]+/g, "")) : null
+        ),
+        maxDollarRent: replaceIfExceeds(
+          false,
+          acc.maxDollarRent,
+          curr.rentRange?.max ? parseInt(curr.rentRange.max.replace(/[$,]+/g, "")) : null
+        ),
+        minPercentageRent: replaceIfExceeds(
+          true,
+          acc.minPercentageRent,
+          curr.rentAsPercentIncomeRange?.min ?? null
+        ),
+        maxPercentageRent: replaceIfExceeds(
+          false,
+          acc.maxPercentageRent,
+          curr.rentAsPercentIncomeRange?.max ?? null
+        ),
+        minUnitType: replaceIfExceeds(
+          true,
+          acc.minUnitType,
+          curr.unitTypes?.[0]?.numBedrooms ?? null
+        ),
+        maxUnitType: replaceIfExceeds(
+          false,
+          acc.maxUnitType,
+          curr.unitTypes?.[curr.unitTypes.length - 1]?.numBedrooms ?? null
+        ),
+        minUnitName:
+          updatedMinUnitType !== acc.minUnitType ? curr.unitTypes?.[0].name : acc.minUnitName,
+        maxUnitName:
+          updatedMaxUnitType !== acc.maxUnitType
+            ? curr.unitTypes?.[curr.unitTypes.length - 1].name
+            : acc.maxUnitName,
+      }
+    },
+    {
+      minDollarRent: null,
+      maxDollarRent: null,
+      minPercentageRent: null,
+      maxPercentageRent: null,
+      minUnitType: null,
+      maxUnitType: null,
+      minUnitName: null,
+      maxUnitName: null,
+    }
+  )
+}
+
 export const stackedUnitSummariesTable = (
   summaries: UnitSummary[]
 ): Record<string, StackedTableRow>[] => {
@@ -355,6 +441,172 @@ export const stackedUnitSummariesTable = (
   return [rowData]
 }
 
+export const getAvailabilityText = (
+  group: UnitGroupSummary,
+  isComingSoon?: boolean
+): { text: string } => {
+  if (isComingSoon) {
+    return {
+      text: t("listings.underConstruction"),
+    }
+  }
+  const hasVacantUnits = group.unitVacancies > 0
+  const waitlistStatus = group.openWaitlist
+    ? t("listings.waitlist.open")
+    : t("listings.waitlist.closed")
+
+  // Create an array of status elements to combine
+  const statusElements = []
+
+  if (hasVacantUnits) {
+    statusElements.push(
+      `${group.unitVacancies} ${
+        group.unitVacancies === 1 ? t("listings.vacantUnit") : t("listings.vacantUnits")
+      }`
+    )
+  }
+
+  if (group.openWaitlist) {
+    statusElements.push(waitlistStatus)
+  }
+
+  // Combine statuses with proper formatting
+  let availability = null
+  if (statusElements.length > 0) {
+    if (statusElements.length >= 3) {
+      const lastElement = statusElements.pop()
+      availability = `${statusElements.join(", ")} & ${lastElement}`
+    } else {
+      availability = statusElements.join(" & ")
+    }
+  }
+
+  const text = availability ?? t("listings.unitsSummary.notAvailable")
+
+  return { text }
+}
+
+export const getAvailabilityTextForGroup = (
+  groups: UnitGroupSummary[],
+  isComingSoon?: boolean
+): { text: string } => {
+  // Add coming soon status if needed
+  if (isComingSoon) {
+    return {
+      text: t("listings.underConstruction"),
+    }
+  }
+  // Track all statuses across groups
+  const statusSet = new Set<string>()
+  let totalVacantUnits = 0
+
+  // Collect information from all groups
+  groups.forEach((group) => {
+    if (group.openWaitlist) {
+      statusSet.add(t("listings.waitlist.open"))
+    }
+
+    if (group.unitVacancies > 0) {
+      totalVacantUnits += group.unitVacancies
+    }
+  })
+
+  const statusElements = Array.from(statusSet)
+  if (totalVacantUnits > 0) {
+    statusElements.unshift(
+      `${totalVacantUnits} ${
+        totalVacantUnits === 1 ? t("listings.vacantUnit") : t("listings.vacantUnits")
+      }`
+    )
+  }
+
+  // Combine statuses with proper formatting
+  let availability = null
+  if (statusElements.length > 0) {
+    if (statusElements.length >= 3) {
+      const lastElement = statusElements.pop()
+      availability = `${statusElements.join(", ")} & ${lastElement}`
+    } else {
+      availability = statusElements.join(" & ")
+    }
+  }
+
+  const text = availability ?? t("listings.unitsSummary.notAvailable")
+
+  return { text }
+}
+
+export const stackedUnitGroupsSummariesTable = (
+  summaries: UnitGroupSummary[],
+  isComingSoon?: boolean
+): Record<string, StackedTableRow>[] => {
+  const ranges = mergeGroupSummaryRows(summaries)
+
+  const getUnitText = (ranges: StackedGroupSummary) => {
+    if (ranges.minUnitType === ranges.maxUnitType)
+      return t(`listings.unitTypes.${ranges.minUnitName}`)
+    return `${t(`listings.unitTypes.${ranges.minUnitName}`)} - ${t(
+      `listings.unitTypes.${ranges.maxUnitName}`
+    )}`
+  }
+  const getRentText = (ranges: StackedGroupSummary) => {
+    const hasPercentUnits = ranges.minPercentageRent !== null && ranges.maxPercentageRent !== null
+    const hasCurrencyUnits = ranges.minDollarRent !== null && ranges.maxDollarRent !== null
+
+    // If a listing has mixed rent type units, show more generic information
+    if (hasPercentUnits && hasCurrencyUnits) {
+      return `${t("t.ofIncome")}, ${t("t.orUpTo")} $${ranges.maxDollarRent?.toLocaleString()}`
+    }
+
+    // Otherwise show more specific ranges
+    if (hasPercentUnits && !hasCurrencyUnits) {
+      if (ranges.minPercentageRent === ranges.maxPercentageRent) {
+        return t("t.numOfIncome", { num: ranges.minPercentageRent })
+      } else {
+        return t("t.rangeOfIncome", {
+          min: ranges.minPercentageRent,
+          max: ranges.maxPercentageRent,
+        })
+      }
+    }
+
+    if (!hasPercentUnits && hasCurrencyUnits) {
+      if (ranges.minDollarRent !== null && ranges.maxDollarRent !== null) {
+        if (ranges.minDollarRent === ranges.maxDollarRent) {
+          return `$${ranges.minDollarRent.toLocaleString()}`
+        } else {
+          return `$${ranges.minDollarRent.toLocaleString()} ${t(
+            "t.to"
+          )} $${ranges.maxDollarRent.toLocaleString()}`
+        }
+      }
+    }
+
+    return t("t.n/a")
+  }
+
+  const availability =
+    summaries.length > 0
+      ? getAvailabilityTextForGroup(summaries, isComingSoon)
+      : { text: t("t.n/a"), subText: "" }
+
+  const rowData = {
+    unitType: {
+      cellText: getUnitText(ranges),
+      cellSubText: "",
+    },
+    rent: {
+      cellText: getRentText(ranges),
+      cellSubText: getRentText(ranges) !== t("t.n/a") ? t("t.perMonth") : "",
+    },
+    availability: {
+      cellText: availability.text,
+    },
+  }
+
+  return [rowData]
+}
+
 export const getSummariesTable = (
   summaries: UnitSummary[],
   listingReviewOrder: ReviewOrderTypeEnum
@@ -374,6 +626,18 @@ export const getStackedSummariesTable = (
 
   if (summaries?.length > 0) {
     unitSummaries = stackedUnitSummariesTable(summaries)
+  }
+  return unitSummaries
+}
+
+export const getStackedGroupSummariesTable = (
+  summaries: UnitGroupSummary[],
+  isComingSoon?: boolean
+): Record<string, StackedTableRow>[] => {
+  let unitSummaries: Record<string, StackedTableRow>[] = []
+
+  if (summaries?.length > 0) {
+    unitSummaries = stackedUnitGroupsSummariesTable(summaries, isComingSoon)
   }
   return unitSummaries
 }
@@ -546,4 +810,85 @@ export const UnitTables = (props: UnitTablesProps) => {
       })}
     </>
   )
+}
+
+export const getUnitGroupSummariesTable = (listing: Listing) => {
+  const unitGroupsSummariesHeaders = {
+    unitType: t("t.unitType"),
+    rent: t("t.rent"),
+    availability: t("t.availability"),
+    ami: "ami",
+  }
+  let groupedUnitData = null
+
+  // unit group summary
+  groupedUnitData = listing?.unitGroupsSummarized?.unitGroupSummary.map((group) => {
+    const isComingSoon =
+      listing.marketingType && listing.marketingType === MarketingTypeEnum.comingSoon
+
+    let rentRange = null
+    let rentAsPercentIncomeRange = null
+    if (group.rentRange && group.rentRange.min === group.rentRange.max) {
+      rentRange = group.rentRange.min
+    } else if (group.rentRange) {
+      rentRange = `${group.rentRange.min} - ${group.rentRange.max}`
+    }
+
+    if (
+      group.rentAsPercentIncomeRange &&
+      group.rentAsPercentIncomeRange.min === group.rentAsPercentIncomeRange.max
+    ) {
+      rentAsPercentIncomeRange = group.rentAsPercentIncomeRange.min
+    } else if (group.rentAsPercentIncomeRange) {
+      rentAsPercentIncomeRange = `${group.rentAsPercentIncomeRange.min} - ${group.rentAsPercentIncomeRange.max}`
+    }
+
+    if (rentAsPercentIncomeRange) {
+      rentAsPercentIncomeRange = `${rentAsPercentIncomeRange}% ${t("t.income")}`
+    }
+
+    let rent = null
+
+    if (rentRange && rentAsPercentIncomeRange) {
+      rent = `${rentRange}, ${rentAsPercentIncomeRange}`
+    } else if (rentRange) {
+      rent = rentRange
+    } else if (rentAsPercentIncomeRange) {
+      rent = rentAsPercentIncomeRange
+    }
+
+    let ami = null
+
+    if (
+      group.amiPercentageRange?.min &&
+      group.amiPercentageRange.min === group.amiPercentageRange.max
+    ) {
+      ami = `${group.amiPercentageRange.min}%`
+    } else if (group.amiPercentageRange?.min && group.amiPercentageRange?.max) {
+      ami = `${group.amiPercentageRange.min} - ${group.amiPercentageRange.max}%`
+    }
+
+    const availability = getAvailabilityText(group, isComingSoon)
+
+    return {
+      unitType: {
+        cellText: group.unitTypes?.map((type) => t(`listings.unitTypes.${type.name}`)).join(", "),
+      },
+      rent: {
+        cellText: rent ?? t("listings.unitsSummary.notAvailable"),
+        cellSubText: rent ? t("t.perMonth") : "",
+      },
+      availability: {
+        cellText: availability.text,
+      },
+      ami: {
+        cellText: ami ?? t("listings.unitsSummary.notAvailable"),
+      },
+    }
+  })
+
+  return {
+    headers: unitGroupsSummariesHeaders,
+    data: groupedUnitData,
+  }
 }

--- a/sites/public/src/components/browse/ListingCard.tsx
+++ b/sites/public/src/components/browse/ListingCard.tsx
@@ -1,10 +1,15 @@
 import React from "react"
-import { Jurisdiction, Listing } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import {
+  Jurisdiction,
+  Listing,
+  MarketingTypeEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { imageUrlFromListing, oneLineAddress, ClickableCard } from "@bloom-housing/shared-helpers"
 import { StackedTable, t } from "@bloom-housing/ui-components"
 import { Card, Heading, Link, Tag } from "@bloom-housing/ui-seeds"
 import {
   getListingApplicationStatus,
+  getListingStackedGroupTableData,
   getListingStackedTableData,
   getListingStatusMessage,
 } from "../../lib/helpers"
@@ -81,14 +86,28 @@ export const ListingCard = ({
                 </div>
               )}
               <div className={`${styles["unit-table"]} styled-stacked-table`}>
-                <StackedTable
-                  headers={{
-                    unitType: "t.unitType",
-                    minimumIncome: "t.minimumIncome",
-                    rent: "t.rent",
-                  }}
-                  stackedData={getListingStackedTableData(listing.unitsSummarized)}
-                />
+                {listing.unitGroups?.length > 0 ? (
+                  <StackedTable
+                    headers={{
+                      unitType: "t.unitType",
+                      rent: "t.rent",
+                      availability: "t.availability",
+                    }}
+                    stackedData={getListingStackedGroupTableData(
+                      listing.unitGroupsSummarized,
+                      listing.marketingType === MarketingTypeEnum.comingSoon
+                    )}
+                  />
+                ) : (
+                  <StackedTable
+                    headers={{
+                      unitType: "t.unitType",
+                      minimumIncome: "t.minimumIncome",
+                      rent: "t.rent",
+                    }}
+                    stackedData={getListingStackedTableData(listing.unitsSummarized)}
+                  />
+                )}
               </div>
 
               {actions.length > 0 && (

--- a/sites/public/src/components/listing/ListingViewSeeds.tsx
+++ b/sites/public/src/components/listing/ListingViewSeeds.tsx
@@ -211,6 +211,7 @@ export const ListingViewSeeds = ({ listing, jurisdiction, profile, preview }: Li
             reviewOrderType={listing.reviewOrderType}
             unitsSummarized={listing.unitsSummarized}
             section8Acceptance={listing.section8Acceptance}
+            listing={listing}
           />
           <div className={styles["main-content"]}>
             <div className={styles["hide-desktop"]}>{ApplyBar}</div>

--- a/sites/public/src/components/listing/listing_sections/RentSummary.tsx
+++ b/sites/public/src/components/listing/listing_sections/RentSummary.tsx
@@ -2,10 +2,14 @@ import * as React from "react"
 import { Heading } from "@bloom-housing/ui-seeds"
 import { StackedTable, t } from "@bloom-housing/ui-components"
 import {
+  Listing,
   ReviewOrderTypeEnum,
   UnitsSummarized,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { getStackedUnitSummaryDetailsTable } from "@bloom-housing/shared-helpers"
+import {
+  getStackedUnitSummaryDetailsTable,
+  getUnitGroupSummariesTable,
+} from "@bloom-housing/shared-helpers"
 import styles from "./RentSummary.module.scss"
 import Markdown from "markdown-to-jsx"
 
@@ -14,6 +18,7 @@ type RentSummaryProps = {
   reviewOrderType: ReviewOrderTypeEnum
   unitsSummarized: UnitsSummarized
   section8Acceptance: boolean
+  listing: Listing
 }
 
 export const RentSummary = ({
@@ -21,6 +26,7 @@ export const RentSummary = ({
   reviewOrderType,
   unitsSummarized,
   section8Acceptance,
+  listing,
 }: RentSummaryProps) => {
   const unitSummariesHeaders = {
     unitType: "t.unitType",
@@ -28,6 +34,8 @@ export const RentSummary = ({
     rent: "t.rent",
     availability: "t.availability",
   }
+
+  const { headers, data: unitGroupSummariesData } = getUnitGroupSummariesTable(listing)
 
   return (
     <div className={styles["rent-summary"]}>
@@ -55,6 +63,10 @@ export const RentSummary = ({
             </React.Fragment>
           )
         })}
+      {unitGroupSummariesData && (
+        <StackedTable headers={headers} stackedData={unitGroupSummariesData} />
+      )}
+
       {amiValues.length === 1 && (
         <StackedTable
           headers={unitSummariesHeaders}

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -15,6 +15,7 @@ import {
   cleanMultiselectString,
   getStackedSummariesTable,
   ResponseException,
+  getStackedGroupSummariesTable,
 } from "@bloom-housing/shared-helpers"
 import {
   Address,
@@ -26,6 +27,7 @@ import {
   MarketingTypeEnum,
   ModificationEnum,
   ReviewOrderTypeEnum,
+  UnitGroupsSummarized,
   UnitsSummarized,
   UserService,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
@@ -77,6 +79,15 @@ export const getListingTableData = (
 export const getListingStackedTableData = (unitsSummarized: UnitsSummarized) => {
   return unitsSummarized !== undefined
     ? getStackedSummariesTable(unitsSummarized.byUnitTypeAndRent)
+    : []
+}
+
+export const getListingStackedGroupTableData = (
+  unitGroupsSummarized: UnitGroupsSummarized,
+  isComingSoon?: boolean
+) => {
+  return unitGroupsSummarized !== undefined
+    ? getStackedGroupSummariesTable(unitGroupsSummarized.unitGroupSummary, isComingSoon)
     : []
 }
 


### PR DESCRIPTION
This PR addresses #4670 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Releases: https://github.com/bloom-housing/bloom/pull/4752

Adds table for unit groups for listing list, and for listing view.

## How Can This Be Tested/Reviewed?

To add unit groups use code from [this PR](https://github.com/bloom-housing/bloom/pull/4676) (just change `id`'s. and maybe add some more `unitGroupAmiLevels`)
on public site `/listings` It should summarize all unit groups to one row.
For listing view it should show it separate for each unit group

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
