### PR TITLE
release: add filters for unitGroups (#4799)

### DIFF
--- a/api/prisma/seed-helpers/unit-group-factory.ts
+++ b/api/prisma/seed-helpers/unit-group-factory.ts
@@ -18,6 +18,7 @@ export const unitGroupFactorySingle = (
     amiChart?: AmiChart;
     openWaitlist?: boolean;
     otherFields?: Prisma.UnitGroupCreateWithoutListingsInput;
+    unitGroupAmiLevelsFlatRentValue?: number;
   },
 ): Prisma.UnitGroupCreateWithoutListingsInput => {
   const bedrooms = unitType.numBedrooms || randomInt(6);
@@ -42,8 +43,14 @@ export const unitGroupFactorySingle = (
         {
           amiPercentage: 10,
           monthlyRentDeterminationType:
-            MonthlyRentDeterminationTypeEnum.percentageOfIncome,
-          percentageOfIncomeValue: 10,
+            optionalParams?.unitGroupAmiLevelsFlatRentValue
+              ? MonthlyRentDeterminationTypeEnum.flatRent
+              : MonthlyRentDeterminationTypeEnum.percentageOfIncome,
+          percentageOfIncomeValue:
+            optionalParams?.unitGroupAmiLevelsFlatRentValue ? undefined : 10,
+          flatRentValue: optionalParams?.unitGroupAmiLevelsFlatRentValue
+            ? optionalParams.unitGroupAmiLevelsFlatRentValue
+            : undefined,
           amiChart: optionalParams?.amiChart
             ? { connect: { id: optionalParams.amiChart.id } }
             : undefined,

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -402,6 +402,50 @@ export class ListingService implements OnModuleInit {
       caseSensitive: true,
     });
 
+    // detect combined >=/<= monthlyRent filters and add one range filter
+    const rentParams =
+      params?.filter((f) => f[ListingFilterKeys.monthlyRent] !== undefined) ||
+      [];
+    const minRent = rentParams.find((f) => f.$comparison === Compare['>=']);
+    const maxRent = rentParams.find((f) => f.$comparison === Compare['<=']);
+    if (minRent && maxRent) {
+      const min = minRent[ListingFilterKeys.monthlyRent];
+      const max = maxRent[ListingFilterKeys.monthlyRent];
+      filters.push({
+        OR: [
+          {
+            units: {
+              some: {
+                AND: [
+                  { monthlyRent: { gte: min } },
+                  { monthlyRent: { lte: max } },
+                ],
+              },
+            },
+          },
+          {
+            unitGroups: {
+              some: {
+                unitGroupAmiLevels: {
+                  some: {
+                    OR: [
+                      {
+                        AND: [
+                          { flatRentValue: { gte: min } },
+                          { flatRentValue: { lte: max } },
+                        ],
+                      },
+                      { percentageOfIncomeValue: { not: null } },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+    }
+
     if (params?.length) {
       params.forEach((filter) => {
         if (
@@ -509,8 +553,7 @@ export class ListingService implements OnModuleInit {
             })),
           });
         }
-        // TODO: Handle bathrooms for unit groups
-        if (filter[ListingFilterKeys.bathrooms]) {
+        if (filter[ListingFilterKeys.bathrooms] !== undefined) {
           const builtFilter = buildFilter({
             $comparison: filter.$comparison,
             $include_nulls: false,
@@ -528,8 +571,7 @@ export class ListingService implements OnModuleInit {
             })),
           });
         }
-        // TODO: Handle bedrooms for unit groups
-        if (filter[ListingFilterKeys.bedrooms]) {
+        if (filter[ListingFilterKeys.bedrooms] !== undefined) {
           const builtFilter = buildFilter({
             $comparison: filter.$comparison,
             $include_nulls: false,
@@ -538,13 +580,26 @@ export class ListingService implements OnModuleInit {
             caseSensitive: true,
           });
           filters.push({
-            OR: builtFilter.map((filt) => ({
-              units: {
-                some: {
-                  numBedrooms: filt,
+            OR: [
+              ...builtFilter.map((filt) => ({
+                units: {
+                  some: {
+                    numBedrooms: filt,
+                  },
                 },
-              },
-            })),
+              })),
+              ...builtFilter.map((filt) => ({
+                unitGroups: {
+                  some: {
+                    unitTypes: {
+                      some: {
+                        numBedrooms: filt,
+                      },
+                    },
+                  },
+                },
+              })),
+            ],
           });
         }
         if (filter[ListingFilterKeys.city]) {
@@ -660,8 +715,8 @@ export class ListingService implements OnModuleInit {
             })),
           });
         }
-        // TODO: Handle monthly rent for unit groups
         if (filter[ListingFilterKeys.monthlyRent]) {
+          if (minRent && maxRent) return;
           const builtFilter = buildFilter({
             $comparison: filter.$comparison,
             $include_nulls: false,
@@ -670,13 +725,29 @@ export class ListingService implements OnModuleInit {
             caseSensitive: true,
           });
           filters.push({
-            OR: builtFilter.map((filt) => ({
-              units: {
-                some: {
-                  [ListingFilterKeys.monthlyRent]: filt,
+            OR: [
+              ...builtFilter.map((filt) => ({
+                units: {
+                  some: {
+                    [ListingFilterKeys.monthlyRent]: filt,
+                  },
                 },
-              },
-            })),
+              })),
+              ...builtFilter.map((filt) => ({
+                unitGroups: {
+                  some: {
+                    unitGroupAmiLevels: {
+                      some: {
+                        OR: [
+                          { flatRentValue: filt },
+                          { percentageOfIncomeValue: { not: null } },
+                        ],
+                      },
+                    },
+                  },
+                },
+              })),
+            ],
           });
         }
         if (filter[ListingFilterKeys.name]) {

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -660,8 +660,9 @@ describe('Listing Controller Tests', () => {
             marketingType: MarketingTypeEnum.comingSoon,
           } as Prisma.ListingsCreateInput,
           unitGroups: [
-            unitGroupFactorySingle(unitTypeThreeBed, {
+            unitGroupFactorySingle(unitTypeOneBed, {
               openWaitlist: undefined,
+              unitGroupAmiLevelsFlatRentValue: 1000,
             }),
           ],
         },
@@ -887,7 +888,6 @@ describe('Listing Controller Tests', () => {
       expect(ids).toContain(listing1WithUnits.id);
       expect(ids).toContain(listing2WithUnits.id);
     });
-    it.todo('should return a listing based on filter bathrooms - unitGroups');
     it('should return a listing based on filter bathrooms - units', async () => {
       const query: ListingsQueryBody = {
         page: 1,
@@ -917,7 +917,34 @@ describe('Listing Controller Tests', () => {
       );
       expect(foundId).toEqual(true);
     });
-    it.todo('should return a listing based on filter bedrooms - unitGroups');
+    it('should return a listing based on filter bedrooms - unitGroups', async () => {
+      const query: ListingsQueryBody = {
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare['='],
+            bedrooms: 3,
+          },
+          {
+            $comparison: Compare['='],
+            jurisdiction: jurisdictionDWithUnitGroups.id,
+          },
+        ],
+      };
+
+      const res = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(query)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(res.body.items.length).toEqual(2);
+
+      const ids = res.body.items.map((listing) => listing.id);
+      expect(ids).toContain(listing4WithUnitGroups.id);
+      expect(ids).toContain(listing5WithUnitGroups.id);
+    });
     it('should return a listing based on filter bedrooms - units', async () => {
       const query: ListingsQueryBody = {
         page: 1,
@@ -1200,7 +1227,63 @@ describe('Listing Controller Tests', () => {
       );
       expect(foundId).toEqual(true);
     });
-    it.todo('should return a listing based on filter monthlyRent - unitGroups');
+    it('should return all listings with percentageOfIncome based on filter monthlyRent - unitGroups ', async () => {
+      const query: ListingsQueryBody = {
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare['='],
+            monthlyRent: '3000',
+          },
+          {
+            $comparison: Compare['='],
+            jurisdiction: jurisdictionDWithUnitGroups.id,
+          },
+        ],
+      };
+
+      const res = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(query)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(res.body.items.length).toEqual(2);
+
+      const ids = res.body.items.map((listing) => listing.id);
+      expect(ids).toContain(listing4WithUnitGroups.id);
+      expect(ids).toContain(listing5WithUnitGroups.id);
+    });
+    it('should return all listings with percentageOfIncome and flatRent based on filter monthlyRent - unitGroups', async () => {
+      const query: ListingsQueryBody = {
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare['='],
+            monthlyRent: '1000',
+          },
+          {
+            $comparison: Compare['='],
+            jurisdiction: jurisdictionDWithUnitGroups.id,
+          },
+        ],
+      };
+
+      const res = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(query)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(res.body.items.length).toEqual(3);
+
+      const ids = res.body.items.map((listing) => listing.id);
+      expect(ids).toContain(listing4WithUnitGroups.id);
+      expect(ids).toContain(listing5WithUnitGroups.id);
+      expect(ids).toContain(listing6WithUnitGroups.id);
+    });
     it('should return a listing based on filter monthlyRent - units', async () => {
       const query: ListingsQueryBody = {
         page: 1,

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -729,6 +729,19 @@ describe('Testing listing service', () => {
                     },
                   },
                 },
+                {
+                  unitGroups: {
+                    some: {
+                      unitTypes: {
+                        some: {
+                          numBedrooms: {
+                            gte: 2,
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
               ],
             },
             {
@@ -799,6 +812,19 @@ describe('Testing listing service', () => {
                     some: {
                       numBedrooms: {
                         gte: 2,
+                      },
+                    },
+                  },
+                },
+                {
+                  unitGroups: {
+                    some: {
+                      unitTypes: {
+                        some: {
+                          numBedrooms: {
+                            gte: 2,
+                          },
+                        },
                       },
                     },
                   },
@@ -929,6 +955,19 @@ describe('Testing listing service', () => {
                   },
                 },
               },
+              {
+                unitGroups: {
+                  some: {
+                    unitTypes: {
+                      some: {
+                        numBedrooms: {
+                          gte: 2,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
             ],
           },
         ],
@@ -979,6 +1018,15 @@ describe('Testing listing service', () => {
                   some: {
                     numBedrooms: {
                       gte: 2,
+                    },
+                  },
+                },
+              },
+              {
+                unitGroups: {
+                  some: {
+                    unitTypes: {
+                      some: { numBedrooms: { gte: 2 } },
                     },
                   },
                 },
@@ -1188,6 +1236,13 @@ describe('Testing listing service', () => {
                     },
                   },
                 },
+                {
+                  unitGroups: {
+                    some: {
+                      unitTypes: { some: { numBedrooms: { gte: 2 } } },
+                    },
+                  },
+                },
               ],
             },
             {
@@ -1259,6 +1314,13 @@ describe('Testing listing service', () => {
                       numBedrooms: {
                         gte: 2,
                       },
+                    },
+                  },
+                },
+                {
+                  unitGroups: {
+                    some: {
+                      unitTypes: { some: { numBedrooms: { gte: 2 } } },
                     },
                   },
                 },
@@ -1454,6 +1516,13 @@ describe('Testing listing service', () => {
                     numBedrooms: {
                       equals: 2,
                     },
+                  },
+                },
+              },
+              {
+                unitGroups: {
+                  some: {
+                    unitTypes: { some: { numBedrooms: { equals: 2 } } },
                   },
                 },
               },
@@ -1690,6 +1759,24 @@ describe('Testing listing service', () => {
                   some: {
                     monthlyRent: {
                       equals: monthlyRent,
+                    },
+                  },
+                },
+              },
+              {
+                unitGroups: {
+                  some: {
+                    unitGroupAmiLevels: {
+                      some: {
+                        OR: [
+                          {
+                            flatRentValue: {
+                              equals: monthlyRent,
+                            },
+                          },
+                          { percentageOfIncomeValue: { not: null } },
+                        ],
+                      },
                     },
                   },
                 },


### PR DESCRIPTION
This PR addresses #4761 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Releases: https://github.com/bloom-housing/bloom/pull/4799

Adds missing filters for unit groups related fields. It doesn't include number of bathroom, as it's not present in detroit (and it's not really applicable).
For monthly rent it should work fine for single filters, but if it got double filters like greater than 2400 and less than 2600 it will return all listings. Not sure if we got any ways of handling that so i left it for now.
Also `monthlyRent` for `units` seem to be comparing strings not numbers so for example `9` is bigger than `1000`, again not sure if i'm missing something so left it.

## How Can This Be Tested/Reviewed?
seed data with unitGroups (it takes bedrooms from unitTypes, and monthlyRent from unitGroupAmiLevels.flatRentValue, also it will return that listing when percentageOfIncomeValue is not null)
I used request body in swagger UI like this (not all at once usually)

```
{
  "page": 1,
  "limit": 10,
  "filter": [
    {
      "$comparison": ">=",
      "monthlyRent": "2498"
    },
   {
      "$comparison": "<=",
      "monthlyRent": "2499"
    },
   {
      "$comparison": "=",
      "bedrooms": "5"
    }
  ],
  "view": "fundamentals"
}
```

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
