### PR TITLE
fix: open + closed listings tab fix 

### DIFF
--- a/sites/public/.env.template
+++ b/sites/public/.env.template
@@ -39,8 +39,7 @@ SHOW_NEW_SEEDS_DESIGNS=FALSE
 API_PASS_KEY="some-key-here"
 
 # the max number of closed listings to be displayed in the closed listing list
-MAX_CLOSED_LISTINGS="20"
-MAX_OPEN_LISTINGS="25"
+MAX_BROWSE_LISTINGS=10
 
 # DataDog environment name
 DD_ENV=

--- a/sites/public/next.config.js
+++ b/sites/public/next.config.js
@@ -49,8 +49,7 @@ module.exports = withBundleAnalyzer({
     maintenanceWindow: process.env.MAINTENANCE_WINDOW,
     siteMessageWindow: process.env.SITE_MESSAGE_WINDOW,
     reCaptchaKey: process.env.RECAPTCHA_KEY,
-    maxClosedListings: process.env.MAX_CLOSED_LISTINGS,
-    maxOpenListings: process.env.MAX_OPEN_LISTINGS,
+    maxBrowseListings: process.env.MAX_BROWSE_LISTINGS,
     rtlLanguages: process.env.RTL_LANGUAGES || "ar",
   },
   i18n: {

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -180,7 +180,7 @@ export async function fetchOpenListings(req: any, page: number) {
       ],
       orderBy: [ListingOrderByKeys.mostRecentlyPublished],
       orderDir: [OrderByEnum.desc],
-      limit: process.env.maxOpenListings,
+      limit: process.env.maxBrowseListings,
     },
     req
   )
@@ -199,7 +199,7 @@ export async function fetchClosedListings(req: any, page: number) {
       ],
       orderBy: [ListingOrderByKeys.mostRecentlyClosed],
       orderDir: [OrderByEnum.desc],
-      limit: process.env.maxClosedListings,
+      limit: process.env.maxBrowseListings,
     },
     req
   )


### PR DESCRIPTION
This PR addresses #4834 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Remove separate environmental variables for max open and closed listings 
* Add a new generic listing browse environmental variable to maintain consistency between tabs
* Update listings fetcher hooks to use the new env variable

## How Can This Be Tested/Reviewed?

* Seed the application with a different number of closed and open applications 
* Turn on the Listings Pagination feature flag
* Visit the listings browser on public sites
* Adjust the new event variable to test the consistency of currently displayed listings in both `closed` and `open` paths

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [x] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
