### PR TITLE
fix: refactor listingFormActions (#4805)

### DIFF
--- a/sites/partners/__tests__/components/listings/ListingFormActions.test.tsx
+++ b/sites/partners/__tests__/components/listings/ListingFormActions.test.tsx
@@ -14,6 +14,7 @@ import {
   ListingsStatusEnum,
   User,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import userEvent from "@testing-library/user-event"
 
 afterEach(cleanup)
 
@@ -99,11 +100,13 @@ const ListingFormActionsComponent = ({
   listingStatus,
   formActionType,
   lotteryOptIn,
+  submitFormWithStatus,
 }: {
   user: User
   listingStatus: ListingsStatusEnum
   formActionType: ListingFormActionsType
   lotteryOptIn?: boolean
+  submitFormWithStatus?: () => void
 }) => {
   return (
     <AuthContext.Provider
@@ -115,7 +118,7 @@ const ListingFormActionsComponent = ({
       <ListingContext.Provider
         value={{ ...listing, status: listingStatus, lotteryOptIn: lotteryOptIn, listingEvents: [] }}
       >
-        <ListingFormActions type={formActionType} />
+        <ListingFormActions type={formActionType} submitFormWithStatus={submitFormWithStatus} />
       </ListingContext.Provider>
     </AuthContext.Provider>
   )
@@ -580,6 +583,22 @@ describe("<ListingFormActions>", () => {
         expect(screen.getByRole("button", { name: "Unpublish" })).toBeInTheDocument()
         expect(screen.getByRole("button", { name: "Post Results" })).toBeInTheDocument()
         expect(screen.getByRole("button", { name: "Exit" })).toBeInTheDocument()
+      })
+
+      it("click approve and publish in edit mode", async () => {
+        const submitMock = jest.fn()
+        render(
+          <ListingFormActionsComponent
+            user={adminUser}
+            listingStatus={ListingsStatusEnum.pendingReview}
+            formActionType={ListingFormActionsType.edit}
+            submitFormWithStatus={submitMock}
+          />
+        )
+
+        await userEvent.click(screen.getByRole("button", { name: "Approve & Publish" }))
+        expect(submitMock).toBeCalledWith("redirect", ListingsStatusEnum.active)
+        screen.debug()
       })
     })
     describe("as a jurisdictional admin", () => {
@@ -1734,16 +1753,11 @@ describe("<ListingFormActions>", () => {
       })
       it("renders correct buttons in a closed detail state", () => {
         render(
-          <AuthContext.Provider
-            value={{
-              profile: jurisdictionAdminUser,
-              doJurisdictionsHaveFeatureFlagOn,
-            }}
-          >
-            <ListingContext.Provider value={{ ...listing, status: ListingsStatusEnum.closed }}>
-              <ListingFormActions type={ListingFormActionsType.details} />
-            </ListingContext.Provider>
-          </AuthContext.Provider>
+          <ListingFormActionsComponent
+            user={jurisdictionAdminUser}
+            listingStatus={ListingsStatusEnum.closed}
+            formActionType={ListingFormActionsType.details}
+          />
         )
         expect(screen.queryByText("Edit")).toBeFalsy()
         expect(screen.getByRole("link", { name: "Preview" })).toBeInTheDocument()
@@ -1800,19 +1814,45 @@ describe("<ListingFormActions>", () => {
     })
   })
 
-  describe("as admin with hideCloseListingButton flag enabled", () => {
+  describe("with hideCloseListingButton flag enabled", () => {
     beforeAll(() => {
       doJurisdictionsHaveFeatureFlagOn = () => true
     })
-    it("should not render the close button", () => {
-      render(
-        <ListingFormActionsComponent
-          user={adminUser}
-          listingStatus={ListingsStatusEnum.active}
-          formActionType={ListingFormActionsType.edit}
-        />
-      )
-      expect(screen.queryByText("Close")).toBeFalsy()
+    describe("as admin", () => {
+      it("should not render the close button", () => {
+        render(
+          <ListingFormActionsComponent
+            user={adminUser}
+            listingStatus={ListingsStatusEnum.active}
+            formActionType={ListingFormActionsType.edit}
+          />
+        )
+        expect(screen.queryByText("Close")).toBeFalsy()
+      })
+    })
+    describe("as partner", () => {
+      it("should not render the close button", () => {
+        render(
+          <ListingFormActionsComponent
+            user={partnerUser}
+            listingStatus={ListingsStatusEnum.active}
+            formActionType={ListingFormActionsType.edit}
+          />
+        )
+        expect(screen.queryByText("Close")).toBeFalsy()
+      })
+    })
+    describe("as jurisdiction admin", () => {
+      it("should not render the close button", () => {
+        render(
+          <ListingFormActionsComponent
+            user={jurisdictionAdminUser}
+            listingStatus={ListingsStatusEnum.active}
+            formActionType={ListingFormActionsType.edit}
+          />
+        )
+        expect(screen.queryByText("Close")).toBeFalsy()
+      })
     })
   })
 })

--- a/sites/partners/__tests__/components/listings/PaperListingForm/index.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/index.test.tsx
@@ -1,0 +1,75 @@
+import React from "react"
+import { screen } from "@testing-library/react"
+import { setupServer } from "msw/lib/node"
+import { mockNextRouter, render } from "../../../testUtils"
+import { rest } from "msw"
+import ListingForm from "../../../../src/components/listings/PaperListingForm"
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+  mockNextRouter()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  window.sessionStorage.clear()
+})
+
+afterAll(() => server.close())
+
+describe("add listing", () => {
+  it("should render the add listing page", () => {
+    window.URL.createObjectURL = jest.fn()
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(
+          ctx.json({ id: "user1", userRoles: { id: "user1", isAdmin: true, isPartner: false } })
+        )
+      }),
+      rest.get("http://localhost:3100/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json([]))
+      }),
+      rest.get("http://localhost:3100/multiselectQuestions", (_req, res, ctx) => {
+        return res(ctx.json([]))
+      })
+    )
+    render(<ListingForm />)
+
+    // Listing Details Tab
+    expect(screen.getByRole("button", { name: "Listing Details" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Listing Intro" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Listing Photo" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Building Details" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Listing Units" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Housing Preferences" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Housing Programs" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Additional Fees" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Building Features" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Additional Eligibility Rules" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Additional Details" }))
+
+    // Application Process tab
+    expect(screen.getByRole("button", { name: "Application Process" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Rankings & Results" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Leasing Agent" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Application Types" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Application Address" }))
+    expect(screen.getByRole("heading", { level: 2, name: "Application Dates" }))
+
+    // Action buttons
+    expect(screen.getByRole("button", { name: "Publish" }))
+    expect(screen.getByRole("button", { name: "Save as Draft" }))
+    expect(screen.getByRole("button", { name: "Exit" }))
+  })
+
+  it.todo("should successfully save and show correct toast")
+  it.todo("should open the save before exit dialog when exiting")
+  it.todo("should open the close listing dialog when closing listing")
+  it.todo("should open the publish listing dialog when publishing listing")
+  it.todo("should open the live confirmation dialog when listing is already active")
+  it.todo("should open the listing approval dialog when submitting for approval")
+  it.todo("should open the request changes dialog when requesting changes")
+})

--- a/sites/partners/__tests__/components/listings/PaperListingForm/sections/CommunityType.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/sections/CommunityType.test.tsx
@@ -2,10 +2,12 @@ import React from "react"
 import { rest } from "msw"
 import { setupServer } from "msw/node"
 import { FormProvider, useForm } from "react-hook-form"
-import { AuthContext } from "@bloom-housing/shared-helpers"
+import { act, screen } from "@testing-library/react"
 import CommunityType from "../../../../../src/components/listings/PaperListingForm/sections/CommunityType"
 import { formDefaults, FormListing } from "../../../../../src/lib/listings/formTypes"
 import { mockNextRouter, render } from "../../../../testUtils"
+import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import userEvent from "@testing-library/user-event"
 
 const FormComponent = ({ children, values }: { values?: FormListing; children }) => {
   const formMethods = useForm<FormListing>({
@@ -15,36 +17,24 @@ const FormComponent = ({ children, values }: { values?: FormListing; children })
   return <FormProvider {...formMethods}>{children}</FormProvider>
 }
 
-const reservedCommunityTypes = {
-  data: [
-    {
-      id: "rct1",
-
-      createdAt: new Date(),
-
-      updatedAt: new Date(),
-
-      name: "Seniors",
-
-      description: "For folks over the age of 65",
-
-      jurisdictions: "jursidictionId",
-    },
-    {
-      id: "rct2",
-
-      createdAt: new Date(),
-
-      updatedAt: new Date(),
-
-      name: "Veterans",
-
-      description: "For folks who served in the armed forces",
-
-      jurisdictions: "jursidictionId",
-    },
-  ],
-}
+const reservedCommunityTypes = [
+  {
+    id: "rct1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    name: "senior",
+    description: "For folks over the age of 65",
+    jurisdictions: "jursidictionId",
+  },
+  {
+    id: "rct2",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    name: "veteran",
+    description: "For folks who served in the armed forces",
+    jurisdictions: "jursidictionId",
+  },
+]
 
 const server = setupServer()
 
@@ -66,17 +56,27 @@ describe("CommunityType", () => {
       {
         id: "jurisdiction1",
         name: "jurisdictionWithJurisdictionAdmin",
+        featureFlags: [],
+      },
+    ],
+  }
+  const adminUserWithJurisdictionsAndFeatureFlagOn = {
+    jurisdictions: [
+      {
+        id: "jurisdiction1",
+        name: "jurisdictionWithJurisdictionAdmin",
         featureFlags: [
           {
-            name: "swapCommunityTypesWithPrograms",
+            name: FeatureFlagEnum.swapCommunityTypeWithPrograms,
             active: true,
           },
         ],
       },
     ],
   }
-  // issue with infinite useEffect re-renders
-  it.skip("should not render when swapCommunityTypesWithPrograms is true", () => {
+
+  it("should render the Community Type section", async () => {
+    document.cookie = "access-token-available=True"
     server.use(
       rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
         return res(ctx.json(adminUserWithJurisdictions))
@@ -85,23 +85,103 @@ describe("CommunityType", () => {
         return res(ctx.json(reservedCommunityTypes))
       })
     )
+
+    render(
+      <FormComponent>
+        <CommunityType />
+      </FormComponent>
+    )
+
+    // verify that the page has loaded as well as the community types
+    await screen.findByRole("heading", { level: 2, name: "Community Type" })
+    await screen.findByRole("option", { name: "Seniors" })
+
+    expect(
+      screen.getByText("Are there any requirements that applicants need to meet?")
+    ).toBeInTheDocument()
+    expect(screen.getByRole("combobox", { name: "Reserved Community Type" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Select One" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Seniors" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Veteran" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("textbox", { name: "Reserved Community Description" })
+    ).toBeInTheDocument()
+    expect(screen.getByText("Appears in listing")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Do you want to include a community type disclaimer as the first page of the application?"
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByRole("radio", { name: "Yes" })).toBeDisabled()
+    expect(screen.getByRole("radio", { name: "No" })).toBeDisabled()
+    expect(
+      screen.queryAllByRole("textbox", { name: "Reserved Community Disclaimer Title" })
+    ).toHaveLength(0)
+  })
+
+  it("should render the community disclaimer questions", async () => {
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(ctx.json(adminUserWithJurisdictions))
+      }),
+      rest.get("http://localhost:3100/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json(reservedCommunityTypes))
+      }),
+      rest.get("http://localhost/api/adapter/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json(reservedCommunityTypes))
+      })
+    )
+
+    render(
+      <FormComponent>
+        <CommunityType />
+      </FormComponent>
+    )
+
+    // verify that the page has loaded as well as the community types
+    await screen.findByRole("heading", { level: 2, name: "Community Type" })
+    await screen.findByRole("option", { name: "Seniors" })
+
+    await act(() =>
+      userEvent.selectOptions(
+        screen.getByRole("combobox", { name: "Reserved Community Type" }),
+        "Seniors"
+      )
+    )
+    expect(screen.getByRole("radio", { name: "Yes" })).not.toBeDisabled()
+    expect(screen.getByRole("radio", { name: "No" })).not.toBeDisabled()
+    await act(() => userEvent.click(screen.getByRole("radio", { name: "Yes" })))
+
+    expect(
+      screen.getByRole("textbox", { name: "Reserved Community Disclaimer Title" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("textbox", { name: "Reserved Community Disclaimer" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByText("Required to publish, appears as first page of application")
+    ).toHaveLength(2)
+  })
+
+  it("should not render when swapCommunityTypesWithPrograms is true", () => {
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(ctx.json(adminUserWithJurisdictionsAndFeatureFlagOn))
+      }),
+      rest.get("http://localhost:3100/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json(reservedCommunityTypes))
+      })
+    )
     document.cookie = "access-token-available=True"
 
     const results = render(
-      <AuthContext.Provider
-        value={{
-          doJurisdictionsHaveFeatureFlagOn: () => {
-            return true
-          },
-        }}
-      >
-        <FormComponent>
-          <CommunityType />
-        </FormComponent>
-      </AuthContext.Provider>
+      <FormComponent>
+        <CommunityType />
+      </FormComponent>
     )
 
-    expect(results.queryByText("Community")).toBeFalsy()
+    expect(results.queryAllByRole("heading", { level: 2, name: "Community Type" })).toHaveLength(0)
   })
-  it.todo("should render when swapCommunityTypesWithPrograms is true")
 })

--- a/sites/partners/src/components/listings/ListingFormActions.tsx
+++ b/sites/partners/src/components/listings/ListingFormActions.tsx
@@ -390,355 +390,140 @@ const ListingFormActions = ({
       }
     }
 
-    //admin experience
-    if (profile?.userRoles.isAdmin) {
-      // new unsaved listing
-      if (type === ListingFormActionsType.add) {
+    // new unsaved listing
+    if (type === ListingFormActionsType.add) {
+      elements.push(isListingApprover || !isListingApprovalEnabled ? publishButton : submitButton)
+      elements.push(saveDraftButton)
+      elements.push(cancelButton)
+    }
+    //draft listing, detail view
+    else if (
+      listing.status === ListingsStatusEnum.pending &&
+      type === ListingFormActionsType.details
+    ) {
+      elements.push(editFromDetailButton)
+      if (isListingCopier) elements.push(copyButton)
+      elements.push(previewButton)
+    }
+    //draft listing, edit view
+    else if (
+      listing.status === ListingsStatusEnum.pending &&
+      type === ListingFormActionsType.edit
+    ) {
+      elements.push(isListingApprover || !isListingApprovalEnabled ? publishButton : submitButton)
+      elements.push(saveContinueButton)
+      elements.push(cancelButton)
+    }
+    //pending review listing, detail view
+    else if (
+      listing.status === ListingsStatusEnum.pendingReview &&
+      type === ListingFormActionsType.details
+    ) {
+      if (isListingApprover && !profile?.userRoles.isPartner) {
+        elements.push(approveAndPublishButton)
+        elements.push(editFromDetailButton)
+      }
+      if (isListingCopier) elements.push(copyButton)
+      elements.push(previewButton)
+    }
+    //pending review listing, edit view
+    else if (
+      listing.status === ListingsStatusEnum.pendingReview &&
+      type === ListingFormActionsType.edit
+    ) {
+      if (isListingApprover && !profile?.userRoles.isPartner) {
+        elements.push(approveAndPublishButton)
+        elements.push(requestChangesButton)
+      }
+      if (profile?.userRoles.isPartner) {
         elements.push(isListingApprover || !isListingApprovalEnabled ? publishButton : submitButton)
-        elements.push(saveDraftButton)
-        elements.push(cancelButton)
       }
-      //draft listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.pending &&
-        type === ListingFormActionsType.details
-      ) {
+      elements.push(saveContinueButton)
+      elements.push(cancelButton)
+    }
+    //changes requested listing, detail view
+    else if (
+      listing.status === ListingsStatusEnum.changesRequested &&
+      type === ListingFormActionsType.details
+    ) {
+      if (isListingApprover) elements.push(approveAndPublishButton)
+      elements.push(editFromDetailButton)
+      if (isListingCopier) elements.push(copyButton)
+      elements.push(previewButton)
+    }
+    //changes requested listing, edit view
+    else if (
+      listing.status === ListingsStatusEnum.changesRequested &&
+      type === ListingFormActionsType.edit
+    ) {
+      elements.push(isListingApprover ? approveAndPublishButton : submitButton)
+      elements.push(saveContinueButton)
+      elements.push(cancelButton)
+    }
+    //open listing, detail view
+    else if (
+      listing.status === ListingsStatusEnum.active &&
+      type === ListingFormActionsType.details
+    ) {
+      elements.push(editFromDetailButton)
+      if (isListingCopier) elements.push(copyButton)
+      elements.push(previewButton)
+    }
+    //open listing, edit view
+    else if (listing.status === ListingsStatusEnum.active && type === ListingFormActionsType.edit) {
+      if (!hideCloseButton) {
+        elements.push(closeButton)
+      }
+      elements.push(unpublishButton)
+      elements.push(saveContinueButton)
+      elements.push(cancelButton)
+    }
+    //closed listing, detail view
+    else if (
+      listing.status === ListingsStatusEnum.closed &&
+      type === ListingFormActionsType.details
+    ) {
+      if (profile?.userRoles.isAdmin || !process.env.limitClosedListingActions)
         elements.push(editFromDetailButton)
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //draft listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.pending &&
-        type === ListingFormActionsType.edit
+      if (isListingCopier) elements.push(copyButton)
+      elements.push(previewButton)
+      viewlotteryResultsButton()
+    }
+    //closed listing, edit view
+    else if (listing.status === ListingsStatusEnum.closed && type === ListingFormActionsType.edit) {
+      if (
+        (isListingApprover || !isListingApprovalEnabled) &&
+        !process.env.limitClosedListingActions &&
+        !profile?.userRoles.isPartner
       ) {
-        elements.push(isListingApprover || !isListingApprovalEnabled ? publishButton : submitButton)
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
+        elements.push(reopenButton)
       }
-      //pending review listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.pendingReview &&
-        type === ListingFormActionsType.details
-      ) {
-        if (isListingApprover) {
-          elements.push(approveAndPublishButton)
-          elements.push(editFromDetailButton)
-        }
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //pending review listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.pendingReview &&
-        type === ListingFormActionsType.edit
-      ) {
-        if (isListingApprover) {
-          elements.push(approveAndPublishButton)
-          elements.push(requestChangesButton)
-        }
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-      //changes requested listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.changesRequested &&
-        type === ListingFormActionsType.details
-      ) {
-        if (isListingApprover) elements.push(approveAndPublishButton)
-        elements.push(editFromDetailButton)
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //changes requested listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.changesRequested &&
-        type === ListingFormActionsType.edit
-      ) {
-        elements.push(isListingApprover ? approveAndPublishButton : submitButton)
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-      //open listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.active &&
-        type === ListingFormActionsType.details
-      ) {
-        elements.push(editFromDetailButton)
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //open listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.active &&
-        type === ListingFormActionsType.edit
-      ) {
-        if (!hideCloseButton) {
-          elements.push(closeButton)
-        }
-        elements.push(unpublishButton)
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-      //closed listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.closed &&
-        type === ListingFormActionsType.details
-      ) {
-        elements.push(editFromDetailButton)
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-        viewlotteryResultsButton()
-      }
-      //closed listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.closed &&
-        type === ListingFormActionsType.edit
-      ) {
-        if (
-          (isListingApprover || !isListingApprovalEnabled) &&
-          !process.env.limitClosedListingActions
-        ) {
-          elements.push(reopenButton)
-        }
-        elements.push(unpublishButton)
-        updateLotteryResultsButton()
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
+      elements.push(unpublishButton)
+      updateLotteryResultsButton()
+      elements.push(saveContinueButton)
+      elements.push(cancelButton)
     }
 
-    //jurisdictional admin experience
-    else if (profile?.userRoles.isJurisdictionalAdmin) {
-      // new unsaved listing
-      if (type === ListingFormActionsType.add) {
-        elements.push(isListingApprover || !isListingApprovalEnabled ? publishButton : submitButton)
-        elements.push(saveDraftButton)
-        elements.push(cancelButton)
-      }
-      //draft listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.pending &&
-        type === ListingFormActionsType.details
-      ) {
-        elements.push(editFromDetailButton)
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //draft listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.pending &&
-        type === ListingFormActionsType.edit
-      ) {
-        elements.push(isListingApprover || !isListingApprovalEnabled ? publishButton : submitButton)
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-      //pending review listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.pendingReview &&
-        type === ListingFormActionsType.details
-      ) {
-        if (isListingApprover) {
-          elements.push(approveAndPublishButton)
-          elements.push(editFromDetailButton)
-        }
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //pending review listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.pendingReview &&
-        type === ListingFormActionsType.edit
-      ) {
-        if (isListingApprover) {
-          elements.push(approveAndPublishButton)
-          elements.push(requestChangesButton)
-        }
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-      //changes requested listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.changesRequested &&
-        type === ListingFormActionsType.details
-      ) {
-        if (isListingApprover) elements.push(approveAndPublishButton)
-        elements.push(editFromDetailButton)
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //changes requested listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.changesRequested &&
-        type === ListingFormActionsType.edit
-      ) {
-        elements.push(isListingApprover ? approveAndPublishButton : submitButton)
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-      //open listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.active &&
-        type === ListingFormActionsType.details
-      ) {
-        elements.push(editFromDetailButton)
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //open listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.active &&
-        type === ListingFormActionsType.edit
-      ) {
-        elements.push(closeButton)
-        elements.push(unpublishButton)
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-      //closed listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.closed &&
-        type === ListingFormActionsType.details
-      ) {
-        if (!process.env.limitClosedListingActions) elements.push(editFromDetailButton)
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-        viewlotteryResultsButton()
-      }
-      //closed listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.closed &&
-        type === ListingFormActionsType.edit
-      ) {
-        if (
-          (isListingApprover || !isListingApprovalEnabled) &&
-          !process.env.limitClosedListingActions
-        ) {
-          elements.push(reopenButton)
-        }
-        elements.push(unpublishButton)
-        updateLotteryResultsButton()
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-    }
-
-    //partner user experience
-    else if (profile?.userRoles.isPartner) {
-      // new unsaved listing
-      if (type === ListingFormActionsType.add) {
-        elements.push(isListingApprover || !isListingApprovalEnabled ? publishButton : submitButton)
-        elements.push(saveDraftButton)
-        elements.push(cancelButton)
-      }
-      //draft listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.pending &&
-        type === ListingFormActionsType.details
-      ) {
-        elements.push(editFromDetailButton)
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //draft listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.pending &&
-        type === ListingFormActionsType.edit
-      ) {
-        elements.push(isListingApprover || !isListingApprovalEnabled ? publishButton : submitButton)
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-      //pending review listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.pendingReview &&
-        type === ListingFormActionsType.details
-      ) {
-        //copy button?
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //pending review listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.pendingReview &&
-        type === ListingFormActionsType.edit
-      ) {
-        elements.push(isListingApprover || !isListingApprovalEnabled ? publishButton : submitButton)
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-      //changes requested listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.changesRequested &&
-        type === ListingFormActionsType.details
-      ) {
-        elements.push(editFromDetailButton)
-        //copy button?
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //changes requested listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.changesRequested &&
-        type === ListingFormActionsType.edit
-      ) {
-        elements.push(isListingApprover || !isListingApprovalEnabled ? publishButton : submitButton)
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-      //open listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.active &&
-        type === ListingFormActionsType.details
-      ) {
-        elements.push(editFromDetailButton)
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-      }
-      //open listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.active &&
-        type === ListingFormActionsType.edit
-      ) {
-        elements.push(closeButton)
-        elements.push(unpublishButton)
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-      //closed listing, detail view
-      else if (
-        listing.status === ListingsStatusEnum.closed &&
-        type === ListingFormActionsType.details
-      ) {
-        if (!process.env.limitClosedListingActions) elements.push(editFromDetailButton)
-        if (isListingCopier) elements.push(copyButton)
-        elements.push(previewButton)
-        viewlotteryResultsButton()
-      }
-      //closed listing, edit view
-      else if (
-        listing.status === ListingsStatusEnum.closed &&
-        type === ListingFormActionsType.edit
-      ) {
-        elements.push(unpublishButton)
-        updateLotteryResultsButton()
-        elements.push(saveContinueButton)
-        elements.push(cancelButton)
-      }
-    }
     return elements
   }, [
-    isListingApprover,
-    listing,
-    listingApprovalPermissions?.length,
-    listingId,
-    listingsService,
-    router,
     addToast,
+    hideCloseButton,
+    isListingApprovalEnabled,
+    isListingApprover,
+    isListingCopier,
+    listing,
+    listingId,
+    listingJurisdiction?.publicUrl,
+    listingsService,
+    profile?.userRoles.isAdmin,
+    profile?.userRoles.isPartner,
+    router,
+    setErrorAlert,
     showCloseListingModal,
+    showCopyListingDialog,
     showLotteryResultsDrawer,
     showRequestChangesModal,
+    showSaveBeforeExitDialog,
     showSubmitForApprovalModal,
     submitFormWithStatus,
     type,

--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -196,7 +196,7 @@ const ListingForm = ({ listing, editMode, setListingName }: ListingFormProps) =>
 
   // Set the active feature flags depending on if/what jurisdiction is selected
   useEffect(() => {
-    const newFeatureFlags = profile.jurisdictions?.reduce((featureFlags, juris) => {
+    const newFeatureFlags = profile?.jurisdictions?.reduce((featureFlags, juris) => {
       if (!selectedJurisdiction || selectedJurisdiction === juris.id) {
         // filter only the active feature flags
         const jurisFeatureFlags = juris.featureFlags?.filter((value) => value.active)
@@ -206,7 +206,7 @@ const ListingForm = ({ listing, editMode, setListingName }: ListingFormProps) =>
       return featureFlags
     }, [])
     setActiveFeatureFlags(newFeatureFlags)
-  }, [profile.jurisdictions, selectedJurisdiction])
+  }, [profile?.jurisdictions, selectedJurisdiction])
 
   const triggerSubmitWithStatus: SubmitFunction = (action, status, newData) => {
     if (action !== "redirect" && status === ListingsStatusEnum.active) {
@@ -362,7 +362,7 @@ const ListingForm = ({ listing, editMode, setListingName }: ListingFormProps) =>
                           <Tabs.Tab>Application Process</Tabs.Tab>
                         </Tabs.TabList>
                         <Tabs.TabPanel>
-                          <ListingIntro jurisdictions={profile.jurisdictions} />
+                          <ListingIntro jurisdictions={profile?.jurisdictions || []} />
                           <ListingPhotos />
                           <BuildingDetails
                             listing={listing}

--- a/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
@@ -28,7 +28,8 @@ const CommunityType = ({ listing }: CommunityTypeProps) => {
 
   const swapCommunityTypeWithPrograms = doJurisdictionsHaveFeatureFlagOn(
     FeatureFlagEnum.swapCommunityTypeWithPrograms,
-    jurisdiction
+    jurisdiction,
+    !jurisdiction
   )
 
   const [options, setOptions] = useState([])
@@ -36,14 +37,22 @@ const CommunityType = ({ listing }: CommunityTypeProps) => {
     listing?.reservedCommunityTypes?.id
   )
 
-  const { data: reservedCommunityTypes = [] } = useReservedCommunityTypeList()
+  const { data: reservedCommunityTypes = [], loading } = useReservedCommunityTypeList()
 
   useEffect(() => {
-    const optionsTranslated = reservedCommunityTypes.map((communityType) => {
-      return { ...communityType, name: t(`listings.reservedCommunityTypes.${communityType.name}`) }
-    })
-    setOptions(["", ...arrayToFormOptions<ReservedCommunityType>(optionsTranslated, "name", "id")])
-  }, [reservedCommunityTypes])
+    if (!options.length && !loading) {
+      const optionsTranslated = reservedCommunityTypes.map((communityType) => {
+        return {
+          ...communityType,
+          name: t(`listings.reservedCommunityTypes.${communityType.name}`),
+        }
+      })
+      setOptions([
+        "",
+        ...arrayToFormOptions<ReservedCommunityType>(optionsTranslated, "name", "id"),
+      ])
+    }
+  }, [options, reservedCommunityTypes, loading])
 
   useEffect(() => {
     setValue("reservedCommunityTypes.id", currentCommunityType)


### PR DESCRIPTION
Note: there was no changes from core

This PR addresses #4731, #4748

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

There was a lot of repeated code in ListingFormActions file. Since there wasn't that much difference between each role type in the buttons that are shown it was possible to remove the three if statements and add just a couple of extra checks to for specific actions.

I also noticed a bug where if the "hideCloseListingButton" was turned on partners could still see the close button

## How Can This Be Tested/Reviewed?
The following steps have been taken to test this refactor:
* All tests still pass
* Two new tests were added to the listingFormActions
* New integration tests were added for the PaperFormListing
* This [document](https://docs.google.com/document/d/1JR7l1v_x5p3vaAmABN30YlM3xJA8BHnlg7EFGzqOr5M/edit?usp=sharing) was written up to track what each scenario should show

In order to test this you will need to run through all scenarios for all permission levels:
* create, edit, publish, close, reopen, unpublish, copy, approve, request changes

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [x] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
