### PR TITLE
fix: jurisdiction unit groups bug fix (#4860)

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -8,12 +8,14 @@ import ChevronRightIcon from "@heroicons/react/20/solid/ChevronRightIcon"
 import { AuthContext, MessageContext, listingSectionQuestions } from "@bloom-housing/shared-helpers"
 import {
   FeatureFlag,
+  FeatureFlagEnum,
   ListingCreate,
   ListingEventsTypeEnum,
   ListingUpdate,
   ListingsStatusEnum,
   MultiselectQuestion,
   MultiselectQuestionsApplicationSectionEnum,
+  YesNoEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { useForm, FormProvider } from "react-hook-form"
 import {
@@ -145,6 +147,14 @@ const ListingForm = ({ listing, editMode, setListingName }: ListingFormProps) =>
   const [submitForApprovalDialog, setSubmitForApprovalDialog] = useState(false)
   const [requestChangesDialog, setRequestChangesDialog] = useState(false)
 
+  const enableUnitGroups =
+    activeFeatureFlags?.find((flag) => flag.name === FeatureFlagEnum.enableUnitGroups)?.active ||
+    false
+
+  const enableSection8 =
+    activeFeatureFlags?.find((flag) => flag.name === FeatureFlagEnum.enableSection8Question)
+      ?.active || false
+
   useEffect(() => {
     if (listing?.units) {
       const tempUnits = listing.units.map((unit, i) => ({
@@ -232,12 +242,16 @@ const ListingForm = ({ listing, editMode, setListingName }: ListingFormProps) =>
           clearErrors()
           const successful = await formMethods.trigger()
 
+          if (!enableSection8) {
+            formData.listingSection8Acceptance = YesNoEnum.no
+          }
+
           if (successful) {
             const dataPipeline = new ListingDataPipeline(formData, {
               preferences,
               programs,
-              units,
-              unitGroups,
+              units: !enableUnitGroups ? units : [], // Clear existing units if unit groups flag has been enabled
+              unitGroups: enableUnitGroups ? unitGroups : [], // Clear existing unit groups if the unit groups flag has been disabled
               openHouseEvents,
               profile: profile,
               latLong,
@@ -331,6 +345,7 @@ const ListingForm = ({ listing, editMode, setListingName }: ListingFormProps) =>
       setError,
       profile,
       addToast,
+      enableUnitGroups,
     ]
   )
 

--- a/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
@@ -16,7 +16,7 @@ import {
   ReviewOrderTypeEnum,
   YesNoEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { AuthContext, MessageContext } from "@bloom-housing/shared-helpers"
+import { MessageContext } from "@bloom-housing/shared-helpers"
 import UnitForm from "../UnitForm"
 import { useFormContext, useWatch } from "react-hook-form"
 import { TempUnit, TempUnitGroup } from "../../../../lib/listings/formTypes"
@@ -48,24 +48,18 @@ const FormUnits = ({
   const [defaultUnit, setDefaultUnit] = useState<TempUnit | null>(null)
   const [defaultUnitGroup, setDefaultUnitGroup] = useState<TempUnitGroup | null>(null)
   const [homeTypeEnabled, setHomeTypeEnabled] = useState(false)
-  const { doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
 
   const formMethods = useFormContext()
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, errors, clearErrors, getValues, control, setValue } = formMethods
   const listing = getValues()
 
-  const enableSection8Question = doJurisdictionsHaveFeatureFlagOn(
-    FeatureFlagEnum.enableSection8Question,
-    listing?.jurisdictions?.id,
-    !listing.jurisdictions?.id
-  )
+  const enableSection8Question =
+    featureFlags?.find((flag) => flag.name === FeatureFlagEnum.enableSection8Question)?.active ||
+    false
 
-  const enableUnitGroups = doJurisdictionsHaveFeatureFlagOn(
-    FeatureFlagEnum.enableUnitGroups,
-    listing?.jurisdictions?.id,
-    !listing.jurisdictions?.id
-  )
+  const enableUnitGroups =
+    featureFlags?.find((flag) => flag.name === FeatureFlagEnum.enableUnitGroups)?.active || false
 
   const listingAvailability = useWatch({
     control,


### PR DESCRIPTION
This PR addresses #4801 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Update the existing codebase to reduce code repetition in favor of existing props and values
* Update the partners' site listing submission to conditionally clear existing `units`/`unit groups` based on the selected jurisdiction feature flags

## Additional Notes

Clearing the fields could also be moved inside the formatted class by passing the `enableUnitGroups` feature flag as metadata. This logic has been implemented outside of the formatter for clarity, but I'm open to discussing such an approach.

## How Can This Be Tested/Reviewed?

* Seed the database
* Go to the partners' site listings view and select a listing with unit groups currently enabled (ex., _Lakeview Villa_)
* Edit the listing by changing the jurisdiction to one where the unit group flag is disabled (ex., _Bloomington_)
* Save the changes. No error should pop up, and the listing should be saved with the new changes
* (_Additionally_)  The listing can be inspected in the DB (eg, using Prisma Studio) to verify that the previously existing field has been cleared

The above process can also be done by switching from units -> unit groups -> units. Any combination is valid

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
