### PR TITLE
fix: Unit groups drawer previous data bug

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
@@ -399,7 +399,12 @@ const FormUnits = ({
               variant={fieldHasError(errors?.units) ? "alert" : "primary-outlined"}
               size="sm"
               onClick={() => {
-                editUnit(units.length + 1)
+                if (enableUnitGroups) {
+                  editUnitGroup(unitGroups.length + 1)
+                } else {
+                  editUnit(units.length + 1)
+                }
+
                 clearErrors("units")
               }}
             >
@@ -468,6 +473,7 @@ const FormUnits = ({
               saveUnitGroup(unitGroup)
             }}
             onClose={() => {
+              setDefaultUnitGroup(null)
               setUnitDrawerOpen(false)
             }}
             defaultUnitGroup={defaultUnitGroup}


### PR DESCRIPTION
This PR addresses #4904 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Fix an issue where previously opened unit group drawer data persists between different drawers

## How Can This Be Tested/Reviewed?

* Go to `/listings/add` in the admin panel 
* Select a jurisdiction with the `enableUnitGroups` flag set to true
* Go to the units section and click `Add Unit Group`
* Fill out the drawer data and save the unit group
* Click edit on the newly added unit group and close the drawer without any changes
* Click `Add Unit Group`
* The new unit group from drawer should have no of the data previously set for the added unit group

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
