### PR TITLE
fix: unit group closed waitlist bug

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/UnitGroupForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitGroupForm.tsx
@@ -16,6 +16,7 @@ import {
   AmiChart,
   EnumUnitGroupAmiLevelMonthlyRentDeterminationType,
   UnitAccessibilityPriorityType,
+  YesNoEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { arrayToFormOptions, fieldHasError } from "../../../lib/helpers"
 import { TempAmiLevel, TempUnitGroup } from "../../../lib/listings/formTypes"
@@ -98,20 +99,6 @@ const UnitGroupForm = ({
     { label: "5", value: "5" },
   ]
 
-  const waitlistStatusOptions = [
-    {
-      id: "true",
-      label: t("listings.listingStatus.active"),
-      value: "true",
-      defaultChecked: true,
-    },
-    {
-      id: "false",
-      label: t("listings.listingStatus.closed"),
-      value: "false",
-    },
-  ]
-
   // sets the options for the ami charts
   useEffect(() => {
     if (amiCharts.length === 0 || amiChartsOptions.length) return
@@ -149,6 +136,7 @@ const UnitGroupForm = ({
 
       reset({
         ...defaultUnitGroup,
+        openWaitlist: defaultUnitGroup.openWaitlist ? YesNoEnum.yes : YesNoEnum.no,
         unitTypes: defaultUnitGroup?.unitTypes?.map((elem) => elem.id ?? elem.toString()),
       })
     }
@@ -190,7 +178,7 @@ const UnitGroupForm = ({
   const amiLevelsTableData = useMemo(
     () =>
       amiLevels?.map((ami) => {
-        const selectedAmiChart = amiChartsOptions.find((chart) => chart.value === ami.amiChart.id)
+        const selectedAmiChart = amiChartsOptions.find((chart) => chart.value === ami.amiChart?.id)
 
         let rentValue = undefined
         let monthlyRentDeterminationType = undefined
@@ -280,6 +268,7 @@ const UnitGroupForm = ({
       createdAt: undefined,
       updatedAt: undefined,
       ...data,
+      openWaitlist: data.openWaitlist === YesNoEnum.yes,
       tempId: draft ? nextId : defaultUnitGroup.tempId,
       unitGroupAmiLevels: amiLevelsData,
     }
@@ -531,7 +520,20 @@ const UnitGroupForm = ({
                   <FieldGroup
                     name="openWaitlist"
                     type="radio"
-                    fields={waitlistStatusOptions}
+                    fields={[
+                      {
+                        id: "waitlistStatusOpen",
+                        dataTestId: "waitlistStatusOpen",
+                        label: t("listings.listingStatus.active"),
+                        value: YesNoEnum.yes,
+                      },
+                      {
+                        id: "waitlistStatusClosed",
+                        dataTestId: "waitlistStatusClosed",
+                        label: t("listings.listingStatus.closed"),
+                        value: YesNoEnum.no,
+                      },
+                    ]}
                     register={register}
                     fieldClassName="m-0"
                     fieldGroupClassName="flex h-12 items-center"

--- a/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
@@ -403,7 +403,7 @@ const FormUnits = ({
                 clearErrors("units")
               }}
             >
-              {t(enableUnitGroups ? "listings.unitGroupd.add" : "listings.unit.add")}
+              {t(enableUnitGroups ? "listings.unitGroup.add" : "listings.unit.add")}
             </Button>
           </Grid.Cell>
         </Grid.Row>
@@ -449,7 +449,7 @@ const FormUnits = ({
         ariaLabelledBy="units-drawer-header"
       >
         <Drawer.Header id="units-drawer-header">
-          {t(enableUnitGroups ? "listings.unitGroupd.add" : "listings.unit.add")}
+          {t(enableUnitGroups ? "listings.unitGroup.add" : "listings.unit.add")}
           <Tag
             variant={
               units.some((unit) => unit.tempId === defaultUnit?.tempId)

--- a/sites/partners/src/page_content/locale_overrides/general.json
+++ b/sites/partners/src/page_content/locale_overrides/general.json
@@ -477,7 +477,7 @@
   "listings.unit.unitTypes": "Unit Types",
   "listings.unit.groupVacancies": "Unit Group Vacancies",
   "listings.unit.waitlistStatus": "Waitlist Status",
-  "listings.unitGroupd.add": "Add Unit Group",
+  "listings.unitGroup.add": "Add Unit Group",
   "listings.unitGroup.delete": "Delete this Unit Group",
   "listings.unitGroup.deleteConf": "Do you really want to delete this unit group?",
   "listings.unitTypesOrIndividual": "Do you want to show unit types or individual units?",


### PR DESCRIPTION
This PR addresses #4917 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Fix issue causing the unit groups to save and retrieve the `openWaitlist` values incorrectly

## How Can This Be Tested/Reviewed?

* Go to `/listings` on the partner's side
* Select one of the listings containing unit groups and click `Edit`
* Add a new unit group
* Verify the `Open Waitlist` section in the drawer is properly set on multiple re-openings of the drawer

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
