### PR TITLE
feat: portal of origin field (#4997)

### DIFF
--- a/api/prisma/migrations/26_was_created_externally/migration.sql
+++ b/api/prisma/migrations/26_was_created_externally/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "applications" ADD COLUMN     "was_created_externally" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "listings" ADD COLUMN     "was_created_externally" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "multiselect_questions" ADD COLUMN     "was_created_externally" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -204,6 +204,8 @@ model Applications {
   markedAsDuplicate            Boolean                       @default(false) @map("marked_as_duplicate")
   confirmationCode             String                        @map("confirmation_code")
   reviewStatus                 ApplicationReviewStatusEnum   @default(pending) @map("review_status")
+  // Used to denote when an application was transferred from another jurisdiction
+  wasCreatedExternally         Boolean                       @default(false) @map("was_created_externally")
   userId                       String?                       @map("user_id") @db.Uuid
   listingId                    String?                       @map("listing_id") @db.Uuid
   applicantId                  String?                       @unique() @map("applicant_id") @db.Uuid
@@ -573,6 +575,8 @@ model Listings {
   includeCommunityDisclaimer            Boolean?                      @map("include_community_disclaimer")
   communityDisclaimerTitle              String?                       @map("community_disclaimer_title")
   communityDisclaimerDescription        String?                       @map("community_disclaimer_description")
+  // Used to denote when a listing was transferred from another jurisdiction
+  wasCreatedExternally                  Boolean                       @default(false) @map("was_created_externally")
   // START DETROIT SPECIFIC
   hrdId                                 String?                       @map("hrd_id")
   ownerCompany                          String?                       @map("owner_company")
@@ -661,6 +665,8 @@ model MultiselectQuestions {
   options                     Json?
   optOutText                  String?                                    @map("opt_out_text")
   hideFromListing             Boolean?                                   @map("hide_from_listing")
+  // Used to denote when a multiselect question was transferred from another jurisdiction
+  wasCreatedExternally        Boolean                                    @default(false) @map("was_created_externally")
   applicationSection          MultiselectQuestionsApplicationSectionEnum @map("application_section")
   jurisdictions               Jurisdictions[]
   listings                    ListingMultiselectQuestions[]


### PR DESCRIPTION
This PR addresses [#(4977)](https://github.com/bloom-housing/bloom/issues/4977)

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Doorway wants to know if a listing, preference/program or application was created in HBA and migrated over. This new field will allow us to mark the specific instances as true in Doorway while having the db column exist everywhere correctly.

A script will be created in Doorway to handle setting the values.

## How Can This Be Tested/Reviewed?

Run `yarn setup` in the api dir.
Check db has the new columns and has default value of false.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
