### PR TITLE
fix: fix accessibility tag (#5016)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,6 @@
   "lint-staged": {
     "*.{js,ts,tsx}": "eslint"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/sites/public/__tests__/components/browse/ListingCard.test.tsx
+++ b/sites/public/__tests__/components/browse/ListingCard.test.tsx
@@ -3,7 +3,10 @@ import { render } from "@testing-library/react"
 import { listing, jurisdiction } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { ListingCard } from "../../../src/components/browse/ListingCard"
 import { getListingTags } from "../../../src/components/listing/listing_sections/MainDetails"
-import { ListingsStatusEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import {
+  FeatureFlagEnum,
+  ListingsStatusEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import dayjs from "dayjs"
 
 describe("<ListingCard>", () => {
@@ -15,7 +18,21 @@ describe("<ListingCard>", () => {
           status: ListingsStatusEnum.active,
           applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
         }}
-        jurisdiction={jurisdiction}
+        jurisdiction={{
+          ...jurisdiction,
+          featureFlags: [
+            ...jurisdiction.featureFlags,
+            {
+              id: "id_2",
+              name: FeatureFlagEnum.enableAccessibilityFeatures,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              active: true,
+              jurisdictions: [],
+              description: "",
+            },
+          ],
+        }}
       />
     )
     const tags = getListingTags(listing, true)

--- a/sites/public/src/components/browse/ListingCard.tsx
+++ b/sites/public/src/components/browse/ListingCard.tsx
@@ -38,8 +38,17 @@ export const ListingCard = ({
   const enableIsVerified = jurisdiction.featureFlags.find(
     (flag) => flag.name === FeatureFlagEnum.enableIsVerified
   )?.active
+  const enableAccessibilityFeatures = jurisdiction.featureFlags.find(
+    (flag) => flag.name === FeatureFlagEnum.enableAccessibilityFeatures
+  )?.active
   const imageUrl = imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize))[0]
-  const listingTags = getListingTags(listing, true, !showHomeType, enableIsVerified)
+  const listingTags = getListingTags(
+    listing,
+    true,
+    !showHomeType,
+    !enableAccessibilityFeatures,
+    enableIsVerified
+  )
   const status = getListingApplicationStatus(listing, true, true)
   const actions = []
 

--- a/sites/public/src/components/listing/listing_sections/MainDetails.tsx
+++ b/sites/public/src/components/listing/listing_sections/MainDetails.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction } from "react"
-import { CheckIcon } from "@heroicons/react/16/solid"
+import { CheckIcon, HandRaisedIcon } from "@heroicons/react/16/solid"
 import {
   FeatureFlagEnum,
   Jurisdiction,
@@ -39,6 +39,7 @@ export const getListingTags = (
   listing: Listing,
   hideReviewTags?: boolean,
   hideHomeTypeTag?: boolean,
+  hideAccessibilityTag?: boolean,
   enableIsVerified?: boolean
 ): ListingTag[] => {
   const listingTags: ListingTag[] = []
@@ -86,6 +87,16 @@ export const getListingTags = (
     }
   }
 
+  if (!hideAccessibilityTag && listing.listingFeatures) {
+    if (Object.values(listing.listingFeatures).some((feature) => feature)) {
+      listingTags.push({
+        title: t("listing.tags.accessible"),
+        variant: "warn",
+        icon: <HandRaisedIcon />,
+      })
+    }
+  }
+
   return listingTags
 }
 
@@ -101,10 +112,19 @@ export const MainDetails = ({
   const enableIsVerified = jurisdiction.featureFlags.find(
     (flag) => flag.name === FeatureFlagEnum.enableIsVerified
   )?.active
+  const enableAccessibilityFeatures = jurisdiction.featureFlags.find(
+    (flag) => flag.name === FeatureFlagEnum.enableAccessibilityFeatures
+  )?.active
 
   const googleMapsHref =
     "https://www.google.com/maps/place/" + oneLineAddress(listing.listingsBuildingAddress)
-  const listingTags = getListingTags(listing, true, !showHomeType, enableIsVerified)
+  const listingTags = getListingTags(
+    listing,
+    true,
+    !showHomeType,
+    !enableAccessibilityFeatures,
+    enableIsVerified
+  )
   return (
     <div>
       <ImageCard


### PR DESCRIPTION
This PR addresses #4889 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Add new translation strings to the public site translation strings
* Update exiting tags formatting function to include the accessibility tags

## How Can This Be Tested/Reviewed?

* General Accessible tag:
   * Go to the partner's site and enable any accessibility feature on an under-construction listing
   * Go to the public site homepage and view the modified listing card (The "Accessible" tag should be visible)

* Specific Accessibility tags:
   *  Go to the partner's site and enable the following accessibility features on an under-construction listing:
       * `Units for those with hearing disabilities`  and
       * `Units for those with mobility disabilities`
   * Go to the public site's home page and verify that the listing card shows appropriate tags
   * Go back to the listing edit on the partners page and update the accessibility features to:
      * Disable `Units for those with hearing disabilities`
      * Enable `Units for those with visual disabilities`
    * Go to the public page and verify the new tags 
    * Go back to the listing edit on the partners page and re-enable `Units for those with hearing disabilities`
    * Got to public sites, a collective tag for viaula and hearing accessibility should be visible

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
