### PR TITLE
fix: update listing card to show no preview table if data is empty

### DIFF
--- a/sites/public/__tests__/components/browse/ListingBrowse.test.tsx
+++ b/sites/public/__tests__/components/browse/ListingBrowse.test.tsx
@@ -1,9 +1,14 @@
 import React from "react"
 import { setupServer } from "msw/lib/node"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { listing, jurisdiction } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { ListingBrowse, TabsIndexEnum } from "../../../src/components/browse/ListingBrowse"
 import { mockNextRouter } from "../../testUtils"
+import {
+  EnumUnitGroupAmiLevelMonthlyRentDeterminationType,
+  FeatureFlagEnum,
+  UnitTypeEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 
 const server = setupServer()
 
@@ -31,6 +36,294 @@ describe("<ListingBrowse>", () => {
     expect(screen.queryByRole("button", { name: /previous/i })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument()
     expect(screen.queryByText(/page \d* of \d*/i)).not.toBeInTheDocument()
+  })
+
+  describe("listing unit previews", () => {
+    it("render units preview table", () => {
+      render(
+        <ListingBrowse
+          listings={[listing]}
+          tab={TabsIndexEnum.open}
+          paginationData={{
+            currentPage: 1,
+            totalPages: 1,
+            itemsPerPage: 2,
+            totalItems: 2,
+            itemCount: 2,
+          }}
+          jurisdiction={jurisdiction}
+        />
+      )
+
+      const listingName = screen.getByRole("heading", { level: 2, name: /archer studios/i })
+      expect(listingName).toBeInTheDocument()
+
+      const listingCard = listingName.parentElement.parentElement
+      const unitsTable = within(listingCard).getByRole("table")
+
+      expect(unitsTable).toBeInTheDocument()
+      const headAndBody = within(unitsTable).getAllByRole("rowgroup")
+      expect(headAndBody).toHaveLength(2)
+      const [head, body] = headAndBody
+
+      const columnHeaders = within(head).getAllByRole("columnheader")
+      expect(columnHeaders).toHaveLength(3)
+
+      expect(columnHeaders[0]).toHaveTextContent("Unit Type")
+      expect(columnHeaders[1]).toHaveTextContent("Minimum Income")
+      expect(columnHeaders[2]).toHaveTextContent("Rent")
+
+      const rows = within(body).getAllByRole("row")
+      expect(rows).toHaveLength(1)
+      // Validate first row
+      const [unitType, minIncome, rent] = within(rows[0]).getAllByRole("cell")
+
+      expect(unitType).toHaveTextContent("1 BR")
+      expect(minIncome).toHaveTextContent("$150")
+      expect(minIncome).toHaveTextContent("per month")
+      expect(rent).toHaveTextContent("% of income, or up to $1,200")
+      expect(rent).toHaveTextContent("per month")
+    })
+
+    it("render no unit preview table", () => {
+      render(
+        <ListingBrowse
+          listings={[
+            {
+              ...listing,
+              units: [],
+            },
+          ]}
+          tab={TabsIndexEnum.open}
+          paginationData={{
+            currentPage: 1,
+            totalPages: 1,
+            itemsPerPage: 2,
+            totalItems: 2,
+            itemCount: 2,
+          }}
+          jurisdiction={jurisdiction}
+        />
+      )
+
+      const listingName = screen.getByRole("heading", { level: 2, name: /archer studios/i })
+      expect(listingName).toBeInTheDocument()
+
+      const listingCard = listingName.parentElement.parentElement
+      expect(within(listingCard).queryByRole("table")).not.toBeInTheDocument()
+    })
+
+    it("render unit groups preview table", () => {
+      render(
+        <ListingBrowse
+          listings={[
+            {
+              ...listing,
+              unitGroups: [
+                {
+                  id: "1d4971f5-b651-430c-9a2f-4655534f1bda",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  maxOccupancy: 4,
+                  minOccupancy: 1,
+                  floorMin: 1,
+                  floorMax: 4,
+                  totalCount: 2,
+                  totalAvailable: null,
+                  bathroomMin: 1,
+                  bathroomMax: 3,
+                  openWaitlist: true,
+                  sqFeetMin: 340,
+                  sqFeetMax: 725,
+                  unitGroupAmiLevels: [
+                    {
+                      id: "8025f0c3-4103-4321-8261-da536e489572",
+                      createdAt: new Date(),
+                      updatedAt: new Date(),
+                      amiPercentage: 20,
+                      monthlyRentDeterminationType:
+                        EnumUnitGroupAmiLevelMonthlyRentDeterminationType.flatRent,
+                      percentageOfIncomeValue: null,
+                      flatRentValue: 1500,
+                      amiChart: {
+                        id: "cf8574bb-599f-40fa-9468-87c1e16be898",
+                        createdAt: new Date(),
+                        updatedAt: new Date(),
+                        items: [],
+                        name: "Divine Orchard",
+                        jurisdictions: {
+                          id: "e674b260-d26f-462a-9090-abaabe939cae",
+                          name: "Bloomington",
+                        },
+                      },
+                    },
+                  ],
+                  unitTypes: [
+                    {
+                      id: "d20ada5f-3b33-4ec6-86b8-ce9412bb8844",
+                      createdAt: new Date(),
+                      updatedAt: new Date(),
+                      name: UnitTypeEnum.studio,
+                      numBedrooms: 0,
+                    },
+                    {
+                      id: "a7195b0a-2311-494c-9765-7304a3637312",
+                      createdAt: new Date(),
+                      updatedAt: new Date(),
+                      name: UnitTypeEnum.oneBdrm,
+                      numBedrooms: 1,
+                    },
+                  ],
+                },
+              ],
+              unitGroupsSummarized: {
+                unitGroupSummary: [
+                  {
+                    unitTypes: [
+                      {
+                        id: "d20ada5f-3b33-4ec6-86b8-ce9412bb8844",
+                        createdAt: new Date(),
+                        updatedAt: new Date(),
+                        name: UnitTypeEnum.studio,
+                        numBedrooms: 0,
+                      },
+                      {
+                        id: "a7195b0a-2311-494c-9765-7304a3637312",
+                        createdAt: new Date(),
+                        updatedAt: new Date(),
+                        name: UnitTypeEnum.oneBdrm,
+                        numBedrooms: 1,
+                      },
+                    ],
+                    rentRange: {
+                      min: "$1500",
+                      max: "$1500",
+                    },
+                    amiPercentageRange: {
+                      min: 20,
+                      max: 20,
+                    },
+                    openWaitlist: true,
+                    unitVacancies: null,
+                    bathroomRange: {
+                      min: 1,
+                      max: 3,
+                    },
+                    floorRange: {
+                      min: 1,
+                      max: 4,
+                    },
+                    sqFeetRange: {
+                      min: 340,
+                      max: 725,
+                    },
+                  },
+                ],
+                householdMaxIncomeSummary: {
+                  columns: {
+                    householdSize: "householdSize",
+                  },
+                  rows: [],
+                },
+              },
+            },
+          ]}
+          tab={TabsIndexEnum.open}
+          paginationData={{
+            currentPage: 1,
+            totalPages: 1,
+            itemsPerPage: 2,
+            totalItems: 2,
+            itemCount: 2,
+          }}
+          jurisdiction={{
+            ...jurisdiction,
+            featureFlags: [
+              ...jurisdiction.featureFlags,
+              {
+                id: "test_id",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                description: "",
+                active: true,
+                jurisdictions: [],
+                name: FeatureFlagEnum.enableUnitGroups,
+              },
+            ],
+          }}
+        />
+      )
+
+      const listingName = screen.getByRole("heading", { level: 2, name: /archer studios/i })
+      expect(listingName).toBeInTheDocument()
+
+      const listingCard = listingName.parentElement.parentElement
+      const unitsTable = within(listingCard).getByRole("table")
+
+      expect(unitsTable).toBeInTheDocument()
+      const headAndBody = within(unitsTable).getAllByRole("rowgroup")
+      expect(headAndBody).toHaveLength(2)
+      const [head, body] = headAndBody
+
+      const columnHeaders = within(head).getAllByRole("columnheader")
+      expect(columnHeaders).toHaveLength(3)
+
+      expect(columnHeaders[0]).toHaveTextContent("Unit Type")
+      expect(columnHeaders[1]).toHaveTextContent("Rent")
+      expect(columnHeaders[2]).toHaveTextContent("Availability")
+
+      const rows = within(body).getAllByRole("row")
+      expect(rows).toHaveLength(1)
+      // Validate first row
+      const [unitType, rent, availability] = within(rows[0]).getAllByRole("cell")
+
+      expect(unitType).toHaveTextContent("Studio - 1 BR")
+      expect(rent).toHaveTextContent("$1,500per month")
+      expect(availability).toHaveTextContent("Open Waitlist")
+    })
+
+    it("render no unit groups preview table", () => {
+      render(
+        <ListingBrowse
+          listings={[
+            {
+              ...listing,
+              units: [],
+              unitGroups: [],
+            },
+          ]}
+          tab={TabsIndexEnum.open}
+          paginationData={{
+            currentPage: 1,
+            totalPages: 1,
+            itemsPerPage: 2,
+            totalItems: 2,
+            itemCount: 2,
+          }}
+          jurisdiction={{
+            ...jurisdiction,
+            featureFlags: [
+              ...jurisdiction.featureFlags,
+              {
+                id: "test_id",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                description: "",
+                active: true,
+                jurisdictions: [],
+                name: FeatureFlagEnum.enableUnitGroups,
+              },
+            ],
+          }}
+        />
+      )
+
+      const listingName = screen.getByRole("heading", { level: 2, name: /archer studios/i })
+      expect(listingName).toBeInTheDocument()
+
+      const listingCard = listingName.parentElement.parentElement
+      expect(within(listingCard).queryByRole("table")).not.toBeInTheDocument()
+    })
   })
 
   it("shows multiple open listings without pagination", () => {

--- a/sites/public/src/components/browse/ListingCard.tsx
+++ b/sites/public/src/components/browse/ListingCard.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import {
   FeatureFlagEnum,
   Jurisdiction,
@@ -38,6 +38,10 @@ export const ListingCard = ({
   const enableIsVerified = jurisdiction.featureFlags.find(
     (flag) => flag.name === FeatureFlagEnum.enableIsVerified
   )?.active
+  const enableUnitGroups = jurisdiction.featureFlags.find(
+    (flag) => flag.name === FeatureFlagEnum.enableUnitGroups
+  )?.active
+
   const imageUrl = imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize))[0]
   const listingTags = getListingTags(listing, true, !showHomeType, enableIsVerified)
   const status = getListingApplicationStatus(listing, true, true)
@@ -54,6 +58,48 @@ export const ListingCard = ({
       </FavoriteButton>
     )
   }
+
+  const unitsPreviewTable = useMemo(() => {
+    const hasData = listing.unitGroups.length || listing.units.length
+
+    if (!hasData) {
+      return
+    }
+
+    if (enableUnitGroups && listing.unitGroups?.length > 0) {
+      return (
+        <StackedTable
+          headers={{
+            unitType: "t.unitType",
+            rent: "t.rent",
+            availability: "t.availability",
+          }}
+          stackedData={getListingStackedGroupTableData(
+            listing.unitGroupsSummarized,
+            listing.marketingType === MarketingTypeEnum.comingSoon
+          )}
+        />
+      )
+    } else {
+      return (
+        <StackedTable
+          headers={{
+            unitType: "t.unitType",
+            minimumIncome: "t.minimumIncome",
+            rent: "t.rent",
+          }}
+          stackedData={getListingStackedTableData(listing.unitsSummarized)}
+        />
+      )
+    }
+  }, [
+    listing.units,
+    listing.unitGroups,
+    listing.marketingType,
+    listing.unitGroupsSummarized,
+    listing.unitsSummarized,
+    enableUnitGroups,
+  ])
 
   return (
     <li className={styles["list-item"]}>
@@ -94,30 +140,8 @@ export const ListingCard = ({
                 </div>
               )}
               <div className={`${styles["unit-table"]} styled-stacked-table`}>
-                {listing.unitGroups?.length > 0 ? (
-                  <StackedTable
-                    headers={{
-                      unitType: "t.unitType",
-                      rent: "t.rent",
-                      availability: "t.availability",
-                    }}
-                    stackedData={getListingStackedGroupTableData(
-                      listing.unitGroupsSummarized,
-                      listing.marketingType === MarketingTypeEnum.comingSoon
-                    )}
-                  />
-                ) : (
-                  <StackedTable
-                    headers={{
-                      unitType: "t.unitType",
-                      minimumIncome: "t.minimumIncome",
-                      rent: "t.rent",
-                    }}
-                    stackedData={getListingStackedTableData(listing.unitsSummarized)}
-                  />
-                )}
+                {unitsPreviewTable}
               </div>
-
               {actions.length > 0 && (
                 <div className={styles["action-container"]}>{actions.map((action) => action)}</div>
               )}


### PR DESCRIPTION
This PR addresses #4928 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Update listing browse card not to render the units/unit groups preview table when no data is available
* Add unit tests to cover units/unit groups preview table rendering

## How Can This Be Tested/Reviewed?

* Go to the partner's site and clear all unit groups from the listing 
* Go to the public site `/listings` page
* The cleared listing card should not show any table 

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
