### PR TITLE
fix: hide reservedCommunityTypes tags when flag turned off (#4986)

### DIFF
--- a/sites/public/__tests__/components/browse/ListingCard.test.tsx
+++ b/sites/public/__tests__/components/browse/ListingCard.test.tsx
@@ -54,4 +54,27 @@ describe("<ListingCard>", () => {
     expect(view.getByText("$150")).toBeDefined()
     expect(view.getByText("% of income, or up to $1,200")).toBeDefined()
   })
+  it("hides reserved tag when swapCommunityTypeWithPrograms is true", () => {
+    const view = render(
+      <ListingCard
+        listing={listing}
+        jurisdiction={{
+          ...jurisdiction,
+          featureFlags: [
+            ...jurisdiction.featureFlags,
+            {
+              name: FeatureFlagEnum.swapCommunityTypeWithPrograms,
+              id: "id",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              active: true,
+              description: "",
+              jurisdictions: [],
+            },
+          ],
+        }}
+      />
+    )
+    expect(view.queryByText("Veteran")).toBeNull()
+  })
 })

--- a/sites/public/__tests__/components/listing/listing_sections/MainDetails.test.tsx
+++ b/sites/public/__tests__/components/listing/listing_sections/MainDetails.test.tsx
@@ -3,7 +3,10 @@ import { render, cleanup } from "@testing-library/react"
 import { listing, jurisdiction } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { MainDetails } from "../../../../src/components/listing/listing_sections/MainDetails"
 import { oneLineAddress } from "@bloom-housing/shared-helpers"
-import { ReviewOrderTypeEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import {
+  FeatureFlagEnum,
+  ReviewOrderTypeEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 
 afterEach(cleanup)
 
@@ -52,5 +55,28 @@ describe("<MainDetails>", () => {
     )
     expect(getByTestId("listing-tags")).toBeDefined()
     expect(getAllByText("Veteran").length).toBeGreaterThan(0)
+  })
+  it("hides reserved tag when swapCommunityTypeWithPrograms is true", () => {
+    const view = render(
+      <MainDetails
+        listing={listing}
+        jurisdiction={{
+          ...jurisdiction,
+          featureFlags: [
+            ...jurisdiction.featureFlags,
+            {
+              name: FeatureFlagEnum.swapCommunityTypeWithPrograms,
+              id: "id",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              active: true,
+              description: "",
+              jurisdictions: [],
+            },
+          ],
+        }}
+      />
+    )
+    expect(view.queryByText("Veteran")).toBeNull()
   })
 })

--- a/sites/public/src/components/browse/ListingCard.tsx
+++ b/sites/public/src/components/browse/ListingCard.tsx
@@ -13,6 +13,7 @@ import {
   getListingStackedGroupTableData,
   getListingStackedTableData,
   getListingStatusMessage,
+  isFeatureFlagOn,
 } from "../../lib/helpers"
 import { getListingTags } from "../listing/listing_sections/MainDetails"
 import styles from "./ListingCard.module.scss"
@@ -35,19 +36,14 @@ export const ListingCard = ({
   setFavorited,
   showHomeType,
 }: ListingCardProps) => {
-  const enableIsVerified = jurisdiction.featureFlags.find(
-    (flag) => flag.name === FeatureFlagEnum.enableIsVerified
-  )?.active
-  const enableAccessibilityFeatures = jurisdiction.featureFlags.find(
-    (flag) => flag.name === FeatureFlagEnum.enableAccessibilityFeatures
-  )?.active
   const imageUrl = imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize))[0]
   const listingTags = getListingTags(
     listing,
     true,
     !showHomeType,
-    !enableAccessibilityFeatures,
-    enableIsVerified
+    !isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableAccessibilityFeatures),
+    isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableIsVerified),
+    isFeatureFlagOn(jurisdiction, FeatureFlagEnum.swapCommunityTypeWithPrograms)
   )
   const status = getListingApplicationStatus(listing, true, true)
   const actions = []

--- a/sites/public/src/components/listing/listing_sections/MainDetails.tsx
+++ b/sites/public/src/components/listing/listing_sections/MainDetails.tsx
@@ -19,6 +19,7 @@ import FavoriteButton from "../../shared/FavoriteButton"
 import { Availability } from "./Availability"
 import listingStyles from "../ListingViewSeeds.module.scss"
 import styles from "./MainDetails.module.scss"
+import { isFeatureFlagOn } from "../../../lib/helpers"
 
 type MainDetailsProps = {
   listing: Listing
@@ -40,7 +41,8 @@ export const getListingTags = (
   hideReviewTags?: boolean,
   hideHomeTypeTag?: boolean,
   hideAccessibilityTag?: boolean,
-  enableIsVerified?: boolean
+  enableIsVerified?: boolean,
+  swapCommunityTypeWithPrograms?: boolean
 ): ListingTag[] => {
   const listingTags: ListingTag[] = []
 
@@ -59,7 +61,7 @@ export const getListingTags = (
     })
   }
 
-  if (listing.reservedCommunityTypes) {
+  if (!swapCommunityTypeWithPrograms && listing.reservedCommunityTypes) {
     listingTags.push({
       title: t(`listings.reservedCommunityTypes.${listing.reservedCommunityTypes.name}`),
       variant: "highlight-warm",
@@ -109,12 +111,6 @@ export const MainDetails = ({
   showHomeType,
 }: MainDetailsProps) => {
   if (!listing) return
-  const enableIsVerified = jurisdiction.featureFlags.find(
-    (flag) => flag.name === FeatureFlagEnum.enableIsVerified
-  )?.active
-  const enableAccessibilityFeatures = jurisdiction.featureFlags.find(
-    (flag) => flag.name === FeatureFlagEnum.enableAccessibilityFeatures
-  )?.active
 
   const googleMapsHref =
     "https://www.google.com/maps/place/" + oneLineAddress(listing.listingsBuildingAddress)
@@ -122,8 +118,9 @@ export const MainDetails = ({
     listing,
     true,
     !showHomeType,
-    !enableAccessibilityFeatures,
-    enableIsVerified
+    !isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableAccessibilityFeatures),
+    isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableIsVerified),
+    isFeatureFlagOn(jurisdiction, FeatureFlagEnum.swapCommunityTypeWithPrograms)
   )
   return (
     <div>


### PR DESCRIPTION
Release of https://github.com/bloom-housing/bloom/pull/4986