### PR TITLE
fix: show closed waitlist (#4978)

### DIFF
--- a/shared-helpers/__tests__/views/summaryTables.test.ts
+++ b/shared-helpers/__tests__/views/summaryTables.test.ts
@@ -5,6 +5,7 @@ import {
   stackedUnitSummariesTable,
   mergeGroupSummaryRows,
   stackedUnitGroupsSummariesTable,
+  getAvailabilityText,
 } from "../../src/views/summaryTables"
 
 afterEach(cleanup)
@@ -741,5 +742,34 @@ describe("stackedUnitGroupsSummariesTable", () => {
         availability: { cellText: "Under Construction" },
       },
     ])
+  })
+})
+
+describe("getAvailabilityText", () => {
+  it("should show closed waitlist text", () => {
+    expect(getAvailabilityText(defaultUnitGroupSummary)).toEqual({ text: "Closed waitlist" })
+  })
+  it("should show open waitlist text", () => {
+    expect(getAvailabilityText({ ...defaultUnitGroupSummary, openWaitlist: true })).toEqual({
+      text: "Open waitlist",
+    })
+  })
+  it("should show plural units available text", () => {
+    expect(
+      getAvailabilityText({ ...defaultUnitGroupSummary, openWaitlist: true, unitVacancies: 10 })
+    ).toEqual({ text: "10 Vacant Units & Open waitlist" })
+  })
+  it("should show singular units available text", () => {
+    expect(
+      getAvailabilityText({ ...defaultUnitGroupSummary, openWaitlist: false, unitVacancies: 1 })
+    ).toEqual({ text: "1 Vacant Unit & Closed waitlist" })
+  })
+  it("should show under construction text", () => {
+    expect(
+      getAvailabilityText(
+        { ...defaultUnitGroupSummary, openWaitlist: true, unitVacancies: 10 },
+        true
+      )
+    ).toEqual({ text: "Under Construction" })
   })
 })

--- a/shared-helpers/src/views/summaryTables.tsx
+++ b/shared-helpers/src/views/summaryTables.tsx
@@ -452,8 +452,8 @@ export const getAvailabilityText = (
   }
   const hasVacantUnits = group.unitVacancies > 0
   const waitlistStatus = group.openWaitlist
-    ? t("listings.waitlist.open")
-    : t("listings.waitlist.closed")
+    ? t("listings.availability.openWaitlist")
+    : t("listings.availability.closedWaitlist")
 
   // Create an array of status elements to combine
   const statusElements = []
@@ -466,9 +466,7 @@ export const getAvailabilityText = (
     )
   }
 
-  if (group.openWaitlist) {
-    statusElements.push(waitlistStatus)
-  }
+  statusElements.push(waitlistStatus)
 
   // Combine statuses with proper formatting
   let availability = null

--- a/sites/partners/src/components/listings/PaperListingForm/UnitGroupForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitGroupForm.tsx
@@ -524,6 +524,7 @@ const UnitGroupForm = ({
                         dataTestId: "waitlistStatusOpen",
                         label: t("listings.listingStatus.active"),
                         value: YesNoEnum.yes,
+                        defaultChecked: !defaultUnitGroup,
                       },
                       {
                         id: "waitlistStatusClosed",


### PR DESCRIPTION
Releases the below commit from core

Creates the ability to save a closed waitlist, and also shows it on the public site. This is only visible with unit groups on, so nothing should be visible.
