### PR TITLE
feat: custom filtering empty state

### DIFF
--- a/sites/public/__tests__/components/browse/ListingBrowse.test.tsx
+++ b/sites/public/__tests__/components/browse/ListingBrowse.test.tsx
@@ -77,6 +77,15 @@ describe("<ListingBrowse>", () => {
     await waitFor(() => {
       expect(replaceMock).toBeCalledWith("/")
     })
+    expect(
+      screen.queryAllByRole("heading", {
+        level: 2,
+        name: /no listings currently have open applications/i,
+      })
+    ).toBeDefined()
+    expect(screen.queryByRole("button", { name: /previous/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument()
+    expect(screen.queryByText(/page \d* of \d*/i)).not.toBeInTheDocument()
   })
 
   it("shows empty state, closed listings with filters", async () => {
@@ -396,6 +405,68 @@ describe("<ListingBrowse>", () => {
 
       const listingCard = listingName.parentElement.parentElement
       expect(within(listingCard).queryByRole("table")).not.toBeInTheDocument()
+    })
+  })
+
+  it("shows empty state, open listings with filters", async () => {
+    const { replaceMock } = mockNextRouter({ bedroomTypes: "fiveBdrm" })
+    render(
+      <ListingBrowse
+        listings={[]}
+        tab={TabsIndexEnum.open}
+        jurisdiction={jurisdiction}
+        multiselectData={[]}
+        areFiltersActive={true}
+      />
+    )
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /no matching listings with open applications/i,
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/try removing some of your filters or show all listings./i)
+    ).toBeInTheDocument()
+
+    const showAllButton = screen.getByRole("button", { name: /^Show all listings$/i })
+    expect(showAllButton).toBeInTheDocument()
+
+    await userEvent.click(showAllButton)
+    await waitFor(() => {
+      expect(replaceMock).toBeCalledWith("/")
+    })
+  })
+
+  it("shows empty state, closed listings with filters", async () => {
+    const { replaceMock } = mockNextRouter({ bedroomTypes: "fiveBdrm" })
+    render(
+      <ListingBrowse
+        listings={[]}
+        tab={TabsIndexEnum.closed}
+        jurisdiction={jurisdiction}
+        multiselectData={[]}
+        areFiltersActive={true}
+      />
+    )
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /no matching listings with closed applications/i,
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/try removing some of your filters or show all listings./i)
+    ).toBeInTheDocument()
+
+    const showAllButton = screen.getByRole("button", { name: /^Show all listings$/i })
+    expect(showAllButton).toBeInTheDocument()
+
+    await userEvent.click(showAllButton)
+    await waitFor(() => {
+      expect(replaceMock).toBeCalledWith("/")
     })
   })
 


### PR DESCRIPTION
This PR addresses #4964

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Add new translation strings for the new empty state 
* Add special empty state filter clear button when listing browse page has filters active

## How Can This Be Tested/Reviewed?

* Go to `/listings` or `/listings-closed` on the public site
* Open the "Filters" drawer and input an impossible set of filters for Your database configuration
* A new subtitle for the empty state, and a "Show all listings" should be visible
* Click the "Show all listings" button, which should navigate to the current path without any query strings in the URL and without adding a record in the browser history.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
