### PR TITLE
fix: add null checks (#5055)

### DIFF
--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
@@ -54,7 +54,7 @@ const FormMultiselectQuestions = ({
   const allOptionFieldNames = useMemo(() => {
     const keys = []
     questions?.forEach((listingQuestion) =>
-      listingQuestion?.multiselectQuestions.options.forEach((option) =>
+      listingQuestion?.multiselectQuestions?.options?.forEach((option) =>
         keys.push(
           fieldName(
             listingQuestion?.multiselectQuestions.text,

--- a/sites/public/src/pages/applications/financial/income.tsx
+++ b/sites/public/src/pages/applications/financial/income.tsx
@@ -76,10 +76,11 @@ const ApplicationIncome = () => {
     const { income, incomePeriod } = data
     const incomeValue = income.replaceAll(",", "")
     // Commenting out validation to not have income be a blocker https://github.com/bloom-housing/bloom/issues/3675
-    // // Skip validation of total income if the applicant has income vouchers.
-    // const validationError = application.incomeVouchers
-    //   ? null
-    //   : verifyIncome(listing, incomeValue, incomePeriod)
+    // Skip validation of total income if no units or the applicant has income vouchers.
+    // const validationError =
+    //   !listing.units?.length || application.incomeVouchers
+    //     ? null
+    //     : verifyIncome(listing, incomeValue, incomePeriod)
     // setIncomeError(validationError)
 
     // if (!validationError) {

--- a/sites/public/src/pages/applications/start/choose-language.tsx
+++ b/sites/public/src/pages/applications/start/choose-language.tsx
@@ -185,7 +185,7 @@ const ApplicationChooseLanguage = () => {
           </CardSection>
         )}
 
-        {listing?.applicationConfig.languages.length > 1 && (
+        {listing?.applicationConfig?.languages?.length && (
           <CardSection divider={"flush"}>
             <>
               <Heading priority={2} size={"lg"} className={"pb-4"}>


### PR DESCRIPTION
RELEASE

This PR partially addresses #4991 by fixing #5041 and #5040 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

This PR adds three different null checks based on common application flow testing.

1. Currently the community types (programs under the hood) from Detroit prod have no options set. This will need to be handled by updating the data but as a partial step, I added a null check so the paper application form can load even with these listings attached to them.
2. Detroit prod data had {en} set for the languages field on the jurisdiction table. This resulted in no options appearing on the choose-language.tsx page. This check allows for one button to show.
3. Common app flows with unit groups were failing on the income step because of the verify income logic. This PR checks for units before verifying the income. I also made a follow up ticket [here](https://github.com/bloom-housing/bloom/issues/5056) to explore adding income verification for unit groups but that is not easily done right now with the fields that unit groups collects.

NOTE: I am still testing other parts of the common application flow but these changes should help free up testing and allow for common app submissions.

## How Can This Be Tested/Reviewed?

This can be tested by 

1. Delete the options on a program, add it to a Lakeview listing, try to add a paper app
2. Set the languages field on the jurisdiction table to be {en} and then try to apply to a listing in that jurisdiction
3. Try to submit a common app to a listing with unit groups or no unit and no unit groups and see if you can get past the income step

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
