### PR TITLE
fix: clean up finder styling (#5065)

### DIFF
--- a/sites/public/src/components/finder/RentalsFinder.module.scss
+++ b/sites/public/src/components/finder/RentalsFinder.module.scss
@@ -13,6 +13,7 @@
     margin-inline: auto;
 
     .questionnaire-header {
+      --bloom-color-primary: var(--seeds-color-primary);
       font-family: var(--seeds-font-alt-sans);
       margin-block-end: var(--seeds-s6);
       display: grid;


### PR DESCRIPTION
This PR addresses #5052 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This updates the finder styling to reflect the jurisdictions styling (and cleans up an unused class)

## How Can This Be Tested/Reviewed?

This can be tested by going to the `/finder` page on the lakeview and seeing the progress/step nav is purple and then trying bloomington to see that it is still blue there.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
