### PR TITLE
feat: Update unitGroups sorting algorithm to secondary sort over ami percentage

### DIFF
--- a/api/src/utilities/unit-groups-transformations.ts
+++ b/api/src/utilities/unit-groups-transformations.ts
@@ -29,12 +29,26 @@ export const getUnitGroupSummary = (
 ): UnitGroupSummary[] => {
   const summary: UnitGroupSummary[] = [];
 
-  //Sort unit groups by the lowest possible number of bedrooms in unit types (lowest to highest)
-  const sortedUnitGroups = unitGroups?.sort(
-    (a, b) =>
+  const sortedUnitGroups = unitGroups?.sort((a, b) => {
+    const unitTypeComparison =
       a.unitTypes.sort((c, d) => c.numBedrooms - d.numBedrooms)[0].numBedrooms -
-      b.unitTypes.sort((e, f) => e.numBedrooms - f.numBedrooms)[0].numBedrooms,
-  );
+      b.unitTypes.sort((e, f) => e.numBedrooms - f.numBedrooms)[0].numBedrooms;
+
+    if (unitTypeComparison === 0) {
+      return (
+        a.unitGroupAmiLevels.reduce(
+          (acc, curr) => (acc > curr.amiPercentage ? acc : curr.amiPercentage),
+          -Infinity,
+        ) -
+        b.unitGroupAmiLevels.reduce(
+          (acc, curr) => (acc > curr.amiPercentage ? acc : curr.amiPercentage),
+          -Infinity,
+        )
+      );
+    }
+
+    return unitTypeComparison;
+  });
 
   sortedUnitGroups?.forEach((group) => {
     let rentAsPercentIncomeRange: MinMax,

--- a/api/test/unit/utilities/unit-group-transformations.spec.ts
+++ b/api/test/unit/utilities/unit-group-transformations.spec.ts
@@ -317,6 +317,186 @@ describe('Unit Group Transformations', () => {
         },
       });
     });
+
+    it('should properly sort multiple unit groups by unit types and AMI percentage', () => {
+      const unitGroups: UnitGroup[] = [
+        {
+          ...defaultValues,
+          id: 'unit_group_1',
+          unitTypes: [
+            {
+              ...defaultValues,
+              id: 'type_1',
+              name: UnitTypeEnum.oneBdrm,
+              numBedrooms: 1,
+            },
+          ],
+          unitGroupAmiLevels: [
+            {
+              ...defaultValues,
+              id: 'level1',
+              amiPercentage: 30,
+              monthlyRentDeterminationType:
+                MonthlyRentDeterminationTypeEnum.percentageOfIncome,
+              flatRentValue: 30,
+            },
+          ],
+        },
+        {
+          ...defaultValues,
+          id: 'unit_group_2',
+          unitTypes: [
+            {
+              ...defaultValues,
+              id: 'type_3',
+              name: UnitTypeEnum.threeBdrm,
+              numBedrooms: 3,
+            },
+          ],
+          unitGroupAmiLevels: [
+            {
+              ...defaultValues,
+              id: 'level1',
+              amiPercentage: 20,
+              monthlyRentDeterminationType:
+                MonthlyRentDeterminationTypeEnum.percentageOfIncome,
+              flatRentValue: 30,
+            },
+          ],
+        },
+        {
+          ...defaultValues,
+          id: 'unit_group_3',
+          unitTypes: [
+            {
+              ...defaultValues,
+              id: 'type_1',
+              name: UnitTypeEnum.oneBdrm,
+              numBedrooms: 1,
+            },
+          ],
+          unitGroupAmiLevels: [
+            {
+              ...defaultValues,
+              id: 'level1',
+              amiPercentage: 60,
+              monthlyRentDeterminationType:
+                MonthlyRentDeterminationTypeEnum.percentageOfIncome,
+              flatRentValue: 30,
+            },
+          ],
+        },
+        {
+          ...defaultValues,
+          id: 'unit_group_1',
+          unitTypes: [
+            {
+              ...defaultValues,
+              id: 'type_2',
+              name: UnitTypeEnum.twoBdrm,
+              numBedrooms: 2,
+            },
+          ],
+          unitGroupAmiLevels: [
+            {
+              ...defaultValues,
+              id: 'level1',
+              amiPercentage: 50,
+              monthlyRentDeterminationType:
+                MonthlyRentDeterminationTypeEnum.percentageOfIncome,
+              flatRentValue: 30,
+            },
+          ],
+        },
+        {
+          ...defaultValues,
+          id: 'unit_group_1',
+          unitTypes: [
+            {
+              ...defaultValues,
+              id: 'type_1',
+              name: UnitTypeEnum.oneBdrm,
+              numBedrooms: 1,
+            },
+          ],
+          unitGroupAmiLevels: [
+            {
+              ...defaultValues,
+              id: 'level1',
+              amiPercentage: 10,
+              monthlyRentDeterminationType:
+                MonthlyRentDeterminationTypeEnum.percentageOfIncome,
+              flatRentValue: 30,
+            },
+          ],
+        },
+      ];
+
+      const result = getUnitGroupSummary(unitGroups);
+      expect(result).toHaveLength(5);
+
+      const [rowOne, rowTwo, rowThree, rowFour, rowFive] = result;
+      expect(rowOne).toMatchObject({
+        unitTypes: [
+          {
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+            id: 'type_1',
+            name: UnitTypeEnum.oneBdrm,
+            numBedrooms: 1,
+          },
+        ],
+        amiPercentageRange: { max: 10, min: 10 },
+      });
+      expect(rowTwo).toMatchObject({
+        unitTypes: [
+          {
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+            id: 'type_1',
+            name: UnitTypeEnum.oneBdrm,
+            numBedrooms: 1,
+          },
+        ],
+        amiPercentageRange: { max: 30, min: 30 },
+      });
+      expect(rowThree).toMatchObject({
+        unitTypes: [
+          {
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+            id: 'type_1',
+            name: UnitTypeEnum.oneBdrm,
+            numBedrooms: 1,
+          },
+        ],
+        amiPercentageRange: { max: 60, min: 60 },
+      });
+      expect(rowFour).toMatchObject({
+        unitTypes: [
+          {
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+            id: 'type_2',
+            name: UnitTypeEnum.twoBdrm,
+            numBedrooms: 2,
+          },
+        ],
+        amiPercentageRange: { max: 50, min: 50 },
+      });
+      expect(rowFive).toMatchObject({
+        unitTypes: [
+          {
+            createdAt: expect.any(Date),
+            updatedAt: expect.any(Date),
+            id: 'type_3',
+            name: UnitTypeEnum.threeBdrm,
+            numBedrooms: 3,
+          },
+        ],
+        amiPercentageRange: { max: 20, min: 20 },
+      });
+    });
   });
 
   describe('getHouseholdMaxIncomeSummary', () => {


### PR DESCRIPTION
This PR addresses #5034 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Updates the algorithms for sorting unit groups on the backend when listing is created/updated

## How Can This Be Tested/Reviewed?

* Make sure the `enableUnitGroups` feature flag has been turned on on the currently configured jurisdiction
* Go to the partner's sites dashboard and select any listing
* Update/Create a few unit groups with different unit types and ami percentages values (some unit types should be duplicated to test secondary sorting, example below)
<img width="991" height="457" alt="Screenshot 2025-07-14 at 16 00 07" src="https://github.com/user-attachments/assets/aa563688-9bfb-4d35-8cfb-d67296d6a34d" />

* Save the listing with the new configuration 
* Go to the public sites `/listings` page and select the previously updated listing
* The rent section table should show properly sorted unit groups

<img width="664" height="382" alt="Screenshot 2025-07-14 at 16 02 44" src="https://github.com/user-attachments/assets/a58d33d2-6c60-445a-849c-821390e98159" />

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
