### PR TITLE
fix: can't unselect unit types in paper applications

### DIFF
--- a/api/src/services/application.service.ts
+++ b/api/src/services/application.service.ts
@@ -900,7 +900,7 @@ export class ApplicationService {
           : undefined,
         preferredUnitTypes: dto.preferredUnitTypes
           ? {
-              connect: dto.preferredUnitTypes.map((unitType) => ({
+              set: dto.preferredUnitTypes.map((unitType) => ({
                 id: unitType.id,
               })),
             }

--- a/api/test/unit/services/application.service.spec.ts
+++ b/api/test/unit/services/application.service.spec.ts
@@ -2124,11 +2124,7 @@ describe('Testing application service', () => {
           },
         },
         preferredUnitTypes: {
-          connect: [
-            {
-              id: expect.anything(),
-            },
-          ],
+          set: [{ id: expect.anything() }],
         },
         householdMember: {
           create: [

--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -347,7 +347,10 @@ export const mapApiToForm = (applicationData: ApplicationUpdate, listing: Listin
       workInRegion,
     }
 
-    const preferredUnit = applicationData?.preferredUnitTypes?.map((unit) => unit.id)
+    const preferredUnit =
+      applicationData?.preferredUnitTypes?.length > 0
+        ? applicationData?.preferredUnitTypes?.map((unit) => unit.id)
+        : null
 
     const accessibility: string[] = adaFeatureKeys.filter(
       (feature) =>


### PR DESCRIPTION
Release of https://github.com/bloom-housing/bloom/pull/5084