### PR TITLE
chore: make sj the main jurisdiction

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -23,11 +23,11 @@
     "db:migration:run": "yarn prisma migrate deploy",
     "db:seed:production": "npx prisma db seed -- --environment production",
     "db:seed:staging": "npx prisma db seed -- --environment staging",
-    "db:seed:development": "npx prisma db seed -- --environment development --jurisdictionName Alameda",
+    "db:seed:development": "npx prisma db seed -- --environment development",
     "generate:client": "ts-node scripts/generate-axios-client.ts && prettier -w ../shared-helpers/src/types/backend-swagger.ts",
     "test:e2e": "yarn db:resetup && yarn db:migration:run && jest --config ./test/jest-e2e.config.js",
     "db:setup": "yarn db:resetup && yarn db:migration:run && yarn db:seed:development",
-    "db:setup:staging": "yarn db:resetup && yarn db:migration:run && yarn db:seed:staging --jurisdictionName Alameda",
+    "db:setup:staging": "yarn db:resetup && yarn db:migration:run && yarn db:seed:staging",
     "setup": "yarn install && yarn prisma generate && yarn build && yarn db:setup:staging",
     "db:migration:skip": "yarn prisma migrate resolve --applied ",
     "setup:dev": "yarn install && yarn prisma generate && yarn build && yarn db:setup"

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -21,7 +21,7 @@ async function main() {
     case 'production':
       // Setting up a production database we would just need the bare minimum such as jurisdiction
       const jurisdictionId = await prisma.jurisdictions.create({
-        data: jurisdictionFactory(jurisdictionName as string),
+        data: jurisdictionFactory((jurisdictionName as string) || 'San Jose'),
       });
       await unitTypeFactoryAll(prisma);
       await unitAccessibilityPriorityTypeFactoryAll(prisma);
@@ -30,13 +30,13 @@ async function main() {
     case 'staging':
       // Staging setup should have realistic looking data with a preset list of listings
       // along with all of the required tables (ami, users, etc)
-      stagingSeed(prisma, jurisdictionName as string);
+      stagingSeed(prisma, (jurisdictionName as string) || 'San Jose');
       break;
     case 'development':
     default:
       // Development is less realistic data, but can be more experimental and also should
       // be partially randomized so we cover all bases
-      devSeeding(prisma, jurisdictionName as string);
+      devSeeding(prisma, (jurisdictionName as string) || 'San Jose');
       break;
   }
 }


### PR DESCRIPTION
- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Since Alameda and San Mateo have been migrated to Doorway, San Jose should be the default jurisdiction for HBA local. These changes align San Jose as the main jurisdiction and as close to production settings as possible.

## How Can This Be Tested/Reviewed?

Run `yarn setup` for any stage (dev, staging, prod).
San Jose should be the main jurisdiction with listings added to it.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
