### PR TITLE
fix: Fix search page waitlist status closed label bug  (#5073)

### DIFF
--- a/shared-helpers/__tests__/views/summaryTables.test.ts
+++ b/shared-helpers/__tests__/views/summaryTables.test.ts
@@ -618,7 +618,7 @@ describe("stackedUnitGroupsSummariesTable", () => {
       {
         rent: { cellSubText: "per month", cellText: "$1,200" },
         unitType: { cellSubText: "", cellText: "1 BR" },
-        availability: { cellText: "Not available" },
+        availability: { cellText: "Waitlist Closed" },
       },
     ])
   })
@@ -627,7 +627,7 @@ describe("stackedUnitGroupsSummariesTable", () => {
       {
         rent: { cellSubText: "per month", cellText: "$1,200 to $1,500" },
         unitType: { cellSubText: "", cellText: "1 BR" },
-        availability: { cellText: "Not available" },
+        availability: { cellText: "Waitlist Closed" },
       },
     ])
   })
@@ -636,7 +636,7 @@ describe("stackedUnitGroupsSummariesTable", () => {
       {
         rent: { cellSubText: "per month", cellText: "30% of income" },
         unitType: { cellSubText: "", cellText: "1 BR" },
-        availability: { cellText: "Not available" },
+        availability: { cellText: "Waitlist Closed" },
       },
     ])
   })
@@ -645,7 +645,7 @@ describe("stackedUnitGroupsSummariesTable", () => {
       {
         rent: { cellSubText: "per month", cellText: "5% to 20% of income" },
         unitType: { cellSubText: "", cellText: "1 BR" },
-        availability: { cellText: "Not available" },
+        availability: { cellText: "Waitlist Closed" },
       },
     ])
   })
@@ -654,7 +654,7 @@ describe("stackedUnitGroupsSummariesTable", () => {
       {
         rent: { cellSubText: "per month", cellText: "% of income, or up to $750" },
         unitType: { cellSubText: "", cellText: "1 BR - 3 BR" },
-        availability: { cellText: "Not available" },
+        availability: { cellText: "Waitlist Closed" },
       },
     ])
   })
@@ -663,7 +663,7 @@ describe("stackedUnitGroupsSummariesTable", () => {
       {
         rent: { cellSubText: "", cellText: "n/a" },
         unitType: { cellSubText: "", cellText: "1 BR" },
-        availability: { cellText: "Not available" },
+        availability: { cellText: "Waitlist Closed" },
       },
     ])
   })
@@ -672,7 +672,7 @@ describe("stackedUnitGroupsSummariesTable", () => {
       {
         rent: { cellSubText: "per month", cellText: "$1,200 to $1,500" },
         unitType: { cellSubText: "", cellText: "1 BR - 2 BR" },
-        availability: { cellText: "Not available" },
+        availability: { cellText: "Waitlist Closed" },
       },
     ])
   })
@@ -717,7 +717,7 @@ describe("stackedUnitGroupsSummariesTable", () => {
         rent: { cellSubText: "", cellText: "n/a" },
         unitType: { cellSubText: "", cellText: "1 BR" },
         availability: {
-          cellText: "3 Vacant Units",
+          cellText: "3 Vacant Units & Waitlist Closed",
         },
       },
     ])

--- a/shared-helpers/src/views/summaryTables.tsx
+++ b/shared-helpers/src/views/summaryTables.tsx
@@ -496,18 +496,15 @@ export const getAvailabilityTextForGroup = (
   }
   // Track all statuses across groups
   const statusSet = new Set<string>()
-  let totalVacantUnits = 0
 
   // Collect information from all groups
-  groups.forEach((group) => {
-    if (group.openWaitlist) {
-      statusSet.add(t("listings.waitlist.open"))
-    }
+  statusSet.add(
+    groups.some((entry) => entry.openWaitlist)
+      ? t("listings.waitlist.open")
+      : t("listings.waitlist.closed")
+  )
 
-    if (group.unitVacancies > 0) {
-      totalVacantUnits += group.unitVacancies
-    }
-  })
+  const totalVacantUnits = groups.reduce((acc, group) => (acc += group.unitVacancies), 0)
 
   const statusElements = Array.from(statusSet)
   if (totalVacantUnits > 0) {


### PR DESCRIPTION
This PR addresses #5048 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Update the waitlist status label for closed status (the logic now mirrors one used on the details page)

## How Can This Be Tested/Reviewed?

* Make sure the `enableUnitGroups` flag is turned on for the jurisdiction currently configured in the .env file
* Make sure at least one listing has all unit groups `Waitlist Status` set to 'Closed'
* Go to the public sites "/listings" page
* Scroll to the listing configured in the second step
* The unit groups preview table on the listing card should say “Closed waitlist” instead of “Not available”

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
