### PR TITLE
Fix: Fix occupancy formatting for multiple unit groups with only max or min values

### DIFF
--- a/shared-helpers/__tests__/occupancyFormatting.test.tsx
+++ b/shared-helpers/__tests__/occupancyFormatting.test.tsx
@@ -299,7 +299,35 @@ describe("occupancy formatting helper stacked table", () => {
       },
       {
         ...unitGroup,
+        minOccupancy: 2,
+        maxOccupancy: undefined,
+        unitTypes: [
+          {
+            id: "unit_id_1",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            name: UnitTypeEnum.twoBdrm,
+            numBedrooms: 2,
+          },
+        ],
+      },
+      {
+        ...unitGroup,
         minOccupancy: 3,
+        maxOccupancy: undefined,
+        unitTypes: [
+          {
+            id: "unit_id_1",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            name: UnitTypeEnum.twoBdrm,
+            numBedrooms: 2,
+          },
+        ],
+      },
+      {
+        ...unitGroup,
+        minOccupancy: undefined,
         maxOccupancy: 6,
         unitTypes: [
           {
@@ -309,6 +337,27 @@ describe("occupancy formatting helper stacked table", () => {
             name: UnitTypeEnum.threeBdrm,
             numBedrooms: 3,
           },
+        ],
+      },
+      {
+        ...unitGroup,
+        minOccupancy: undefined,
+        maxOccupancy: 4,
+        unitTypes: [
+          {
+            id: "unit_id_1",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            name: UnitTypeEnum.threeBdrm,
+            numBedrooms: 3,
+          },
+        ],
+      },
+      {
+        ...unitGroup,
+        minOccupancy: 3,
+        maxOccupancy: 6,
+        unitTypes: [
           {
             id: "unit_id_1",
             createdAt: new Date(),
@@ -326,7 +375,15 @@ describe("occupancy formatting helper stacked table", () => {
         occupancy: { cellText: "1-4 people" },
       },
       {
-        unitType: { cellText: "3 BR, 4 BR" },
+        unitType: { cellText: "2 BR" },
+        occupancy: { cellText: "at least 2 people" },
+      },
+      {
+        unitType: { cellText: "3 BR" },
+        occupancy: { cellText: "no more than 6 people" },
+      },
+      {
+        unitType: { cellText: "4 BR" },
         occupancy: { cellText: "3-6 people" },
       },
     ])

--- a/shared-helpers/src/views/occupancyFormatting.tsx
+++ b/shared-helpers/src/views/occupancyFormatting.tsx
@@ -105,6 +105,11 @@ export const stackedUnitGroupsOccupancyTable = (listing: Listing) => {
       }
       return 0
     })
+    .map((unitGroup) => ({
+      ...unitGroup,
+      maxOccupancy: unitGroup.maxOccupancy === -Infinity ? null : unitGroup.maxOccupancy,
+      minOccupancy: unitGroup.minOccupancy === Infinity ? null : unitGroup.minOccupancy,
+    }))
     .filter((unitGroup) => unitGroup.maxOccupancy || unitGroup.minOccupancy)
 
   const tableRows = sortedUnitGroups?.reduce<Record<string, StackedTableRow>[]>((acc, curr) => {


### PR DESCRIPTION
This PR addresses #5035 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Fixes and issues when formatting multiple unit groups with only max or min occupancy set would result in a `n/a` label

## How Can This Be Tested/Reviewed?

* Make sure the `enableUnitGroups` is enabled for the currently configured jurisdiction
* Go to the partners site dashboard and select any listing for the configured jurisdiction 
* Edit the listing by adding multiple unit groups with shared unit types by only max or min occupancy set for a value (example below)
<img width="842" height="488" alt="Screenshot 2025-07-24 at 11 13 09" src="https://github.com/user-attachments/assets/208c9336-fc3d-4a43-9dbc-eaab9bf66183" />
* Save the updated listing
* Go to public sites `/listings` page
* Click on the updated listing and scroll down to the "Occupancy" section
* The occupancy table should now show `at least <x> people` or `no more than <x> people` (result for the example below):
<img width="646" height="308" alt="Screenshot 2025-07-24 at 11 16 46" src="https://github.com/user-attachments/assets/c3cdc19b-2c30-432a-88c3-7b64c1b61da2" />


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
