### PR TITLE
chore: improve seed data (#5116)

### DIFF
--- a/api/prisma/seed-helpers/listing-data/blue-sky-apartments.ts
+++ b/api/prisma/seed-helpers/listing-data/blue-sky-apartments.ts
@@ -31,7 +31,6 @@ export const blueSkyApartments = {
   unitAmenities: null,
   servicesOffered: null,
   yearBuilt: 1900,
-  applicationDueDate: null,
   applicationOpenDate: dayjs(new Date()).subtract(1, 'days').toDate(),
   applicationFee: '60',
   applicationOrganization: null,

--- a/api/prisma/seed-helpers/listing-data/hollywood-hills-heights.ts
+++ b/api/prisma/seed-helpers/listing-data/hollywood-hills-heights.ts
@@ -25,7 +25,6 @@ export const hollywoodHillsHeights = {
   unitAmenities: null,
   servicesOffered: null,
   yearBuilt: null,
-  applicationDueDate: null,
   applicationOpenDate: dayjs(new Date()).subtract(70, 'days').toDate(),
   applicationFee: null,
   applicationOrganization: null,

--- a/api/prisma/seed-helpers/listing-data/lakeview-villa.ts
+++ b/api/prisma/seed-helpers/listing-data/lakeview-villa.ts
@@ -34,7 +34,6 @@ export const lakeviewVilla: Prisma.ListingsCreateInput = {
   unitAmenities: null,
   servicesOffered: null,
   yearBuilt: null,
-  applicationDueDate: null,
   applicationOpenDate: dayjs(new Date()).subtract(70, 'days').toDate(),
   applicationFee: null,
   applicationOrganization: null,

--- a/api/prisma/seed-helpers/listing-data/little-village-apartments.ts
+++ b/api/prisma/seed-helpers/listing-data/little-village-apartments.ts
@@ -24,7 +24,6 @@ export const littleVillageApartments = {
   unitAmenities: null,
   servicesOffered: null,
   yearBuilt: 1996,
-  applicationDueDate: null,
   applicationOpenDate: dayjs(new Date()).subtract(30, 'days').toDate(),
   applicationFee: null,
   applicationOrganization: null,

--- a/api/prisma/seed-helpers/listing-data/sunshine-flats.ts
+++ b/api/prisma/seed-helpers/listing-data/sunshine-flats.ts
@@ -27,7 +27,6 @@ export const sunshineFlats: Prisma.ListingsCreateInput = {
   unitAmenities: null,
   servicesOffered: null,
   yearBuilt: null,
-  applicationDueDate: null,
   applicationOpenDate: dayjs(new Date()).subtract(2, 'days').toDate(),
   applicationFee: null,
   applicationOrganization: null,

--- a/api/prisma/seed-helpers/listing-data/valley-heights-senior-community.ts
+++ b/api/prisma/seed-helpers/listing-data/valley-heights-senior-community.ts
@@ -24,7 +24,6 @@ export const valleyHeightsSeniorCommunity = {
   unitAmenities: null,
   servicesOffered: null,
   yearBuilt: 2019,
-  applicationDueDate: null,
   applicationOpenDate: dayjs(new Date()).subtract(100, 'days').toDate(),
   applicationFee: '50',
   applicationOrganization: null,

--- a/api/prisma/seed-helpers/listing-factory.ts
+++ b/api/prisma/seed-helpers/listing-factory.ts
@@ -88,6 +88,7 @@ export const listingFactory = async (
     status?: ListingsStatusEnum;
     unitGroups?: Prisma.UnitGroupCreateWithoutListingsInput[];
     units?: Prisma.UnitsCreateWithoutListingsInput[];
+    userAccounts?: Prisma.UserAccountsWhereUniqueInput[];
   },
 ): Promise<Prisma.ListingsCreateInput> => {
   const previousListing = optionalParams?.listing || {};
@@ -248,6 +249,9 @@ export const listingFactory = async (
       ? {
           create: units,
         }
+      : undefined,
+    userAccounts: optionalParams?.userAccounts
+      ? { connect: optionalParams?.userAccounts }
       : undefined,
 
     ...additionalEligibilityRules(optionalParams?.includeEligibilityRules),

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -194,7 +194,7 @@ export const stagingSeed = async (
     }),
   });
   // create a partner
-  await prismaClient.userAccounts.create({
+  const partnerUser = await prismaClient.userAccounts.create({
     data: await userFactory({
       roles: { isPartner: true },
       email: 'partner@example.com',
@@ -466,6 +466,7 @@ export const stagingSeed = async (
         multiselectQuestionPrograms,
       ],
       applications: [await applicationFactory(), await applicationFactory()],
+      userAccounts: [{ id: partnerUser.id }],
     },
     {
       jurisdictionId: mainJurisdiction.id,
@@ -653,6 +654,7 @@ export const stagingSeed = async (
           ],
         }),
       ],
+      userAccounts: [{ id: partnerUser.id }],
     },
     {
       jurisdictionId: mainJurisdiction.id,
@@ -677,15 +679,18 @@ export const stagingSeed = async (
           },
         },
       ],
+      userAccounts: [{ id: partnerUser.id }],
     },
     {
       jurisdictionId: mainJurisdiction.id,
       listing: valleyHeightsSeniorCommunity,
+      userAccounts: [{ id: partnerUser.id }],
     },
     {
       jurisdictionId: mainJurisdiction.id,
       listing: littleVillageApartments,
       multiselectQuestions: [workInCityQuestion],
+      userAccounts: [{ id: partnerUser.id }],
     },
     {
       jurisdictionId: mainJurisdiction.id,
@@ -827,6 +832,7 @@ export const stagingSeed = async (
           },
         },
       ],
+      userAccounts: [{ id: partnerUser.id }],
     },
     {
       jurisdictionId: lakeviewJurisdiction.id,
@@ -927,6 +933,7 @@ export const stagingSeed = async (
         unitGroups?: Prisma.UnitGroupCreateWithoutListingsInput[];
         multiselectQuestions?: MultiselectQuestions[];
         applications?: Prisma.ApplicationsCreateInput[];
+        userAccounts?: Prisma.UserAccountsWhereUniqueInput[];
       },
       index,
     ) => {
@@ -939,6 +946,7 @@ export const stagingSeed = async (
         multiselectQuestions: value.multiselectQuestions,
         applications: value.applications,
         afsLastRunSetInPast: true,
+        userAccounts: value.userAccounts,
       });
       const savedListing = await prismaClient.listings.create({
         data: listing,


### PR DESCRIPTION
## Description

To improve our seed data, two changes:
- remove setting applicationDueDate explicitly to null for seeded listings
- add logic to allow associating seeded partner users to listings and associate one partner with all listings on the main jurisdiction

## How Can This Be Tested/Reviewed?

Reseed your local
Run the partner site and backend
Sign in as partner@example.com
Check all bloomington listings are associated with the user
Look into the listings and confirm they all have applicationDueDate set by default

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
