### PR TITLE
fix: allow null ami chart in unit group ami levels

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -2309,9 +2309,11 @@ export class ListingService implements OnModuleInit {
                             level.monthlyRentDeterminationType,
                           percentageOfIncomeValue:
                             level.percentageOfIncomeValue,
-                          amiChart: {
-                            connect: { id: level.amiChart.id },
-                          },
+                          amiChart: level.amiChart
+                            ? {
+                                connect: { id: level.amiChart.id },
+                              }
+                            : undefined,
                         })),
                       }
                     : undefined,


### PR DESCRIPTION
Release of https://github.com/bloom-housing/bloom/pull/5190