### PR TITLE
Fix: Update the listing accessibility based filtering logic 

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -847,7 +847,7 @@ export class ListingService implements OnModuleInit {
         }
         if (filter[ListingFilterKeys.listingFeatures]) {
           filters.push({
-            OR: filter[ListingFilterKeys.listingFeatures].map((feature) => ({
+            AND: filter[ListingFilterKeys.listingFeatures].map((feature) => ({
               listingFeatures: {
                 [feature]: true,
               },

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -1952,7 +1952,7 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
+            AND: [
               {
                 listingFeatures: {
                   hearing: true,


### PR DESCRIPTION
This PR addresses #4885

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Updates the query formatting logic for the listings endpoint to use the AND logic instead of OR

## How Can This Be Tested/Reviewed?

* Go to the partner's site and update the listings for the setup jurisdiction in a way that allows for accessibility features overlapping (Example below)
<img width="1692" height="429" alt="Screenshot 2025-08-27 at 14 12 33" src="https://github.com/user-attachments/assets/bbebe8e9-0e88-42d2-b0a9-50b812c7da5f" />
* Go to the public sites `/listings` page
*  Open the `Filters` drawer
* Verify that the `Accessibility features` section options follow the AND logic

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
