### PR TITLE
chore: add application method validation 

### DIFF
--- a/api/prisma/seed-helpers/listing-data/blue-sky-apartments.ts
+++ b/api/prisma/seed-helpers/listing-data/blue-sky-apartments.ts
@@ -16,7 +16,7 @@ export const blueSkyApartments = {
   additionalApplicationSubmissionNotes: null,
   digitalApplication: true,
   commonDigitalApplication: true,
-  paperApplication: true,
+  paperApplication: false,
   referralOpportunity: false,
   assets: [],
   accessibility: null,

--- a/sites/public/cypress/support/commands.js
+++ b/sites/public/cypress/support/commands.js
@@ -54,10 +54,9 @@ Cypress.Commands.add("checkErrorMessages", (command) => {
 Cypress.Commands.add("beginApplicationRejectAutofill", (listingName) => {
   cy.visit("/listings")
   if (Cypress.env("showSeedsDesign")) {
-    cy.getByID("listing-seeds-link").contains(listingName)
-    cy.getByID("listing-seeds-link").eq(1).click()
+    cy.getByID("listing-seeds-link").contains(listingName).parent().click()
   } else {
-    cy.get(".is-card-link").contains(listingName).click()
+    cy.get(".is-card-link").contains(listingName).parent().click()
   }
   cy.getByID("listing-view-apply-button").eq(1).click()
   cy.getByID("app-choose-language-sign-in-button").click()
@@ -82,10 +81,9 @@ Cypress.Commands.add("beginApplicationRejectAutofill", (listingName) => {
 Cypress.Commands.add("beginApplicationSignedIn", (listingName) => {
   cy.visit("/listings")
   if (Cypress.env("showSeedsDesign")) {
-    cy.getByID("listing-seeds-link").contains(listingName)
-    cy.getByID("listing-seeds-link").eq(1).click()
+    cy.getByID("listing-seeds-link").contains(listingName).parent().click()
   } else {
-    cy.get(".is-card-link").contains(listingName).click()
+    cy.get(".is-card-link").contains(listingName).parent().click()
   }
   cy.getByID("listing-view-apply-button").eq(1).click()
   cy.getByID("app-choose-language-button").eq(0).click()

--- a/sites/public/src/components/listing/listing_sections/Apply.tsx
+++ b/sites/public/src/components/listing/listing_sections/Apply.tsx
@@ -110,6 +110,10 @@ export const Apply = ({ listing, preview, setShowDownloadModal }: ApplyProps) =>
     </Button>
   )
 
+  const validPaperApplication = !listing.paperApplication || hasPaperApplication
+  const validOnlineApplication =
+    !listing.digitalApplication || listing.commonDigitalApplication || onlineApplicationUrl
+
   const hasPrimaryApplicationMethod = onlineApplicationUrl || hasPaperApplication
 
   const shouldShowApplyButton = getHasNonReferralMethods(listing)
@@ -120,6 +124,8 @@ export const Apply = ({ listing, preview, setShowDownloadModal }: ApplyProps) =>
       applicationPickUpAddress ||
       applicationDropOffAddress) &&
     !applicationsClosed &&
+    validOnlineApplication &&
+    validPaperApplication &&
     listing.status !== ListingsStatusEnum.closed
 
   const showSecondarySection =


### PR DESCRIPTION
This PR addresses #5232 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Add validation to the listings application methods (if applicable, is the paper application document uploaded/is the custom application URL)

## How Can This Be Tested/Reviewed?

* Go to the `/partners` site
* Select a listing to edit or create a new listing 
* Go to the application tab and fill out the following
   * Is there a digital application? => Yes
   * Are you using the common digital application? => No
   * Is there a paper application? => Yes
   * Custom Online Application URL is left blank
   * No paper application is uploaded
* Save the listing
* Go to the public's site `/listings` page
* Selected the edit/added listing
* The `How to apply` section should not be visible to the user

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
