### PR TITLE
fix: remove time field clearing on date error 

### DIFF
--- a/sites/partners/__tests__/components/applications/sections/FormApplicationData.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormApplicationData.test.tsx
@@ -73,7 +73,7 @@ describe("<FormApplicationData>", () => {
     expect((languageSelect as HTMLSelectElement).value).toBe(LanguagesEnum.en)
   })
 
-  it("clearing date fields resets time fields", async () => {
+  it("clearing date fields does not resets time fields", async () => {
     render(
       <FormProviderWrapper>
         <FormApplicationData />
@@ -112,8 +112,8 @@ describe("<FormApplicationData>", () => {
     expect(timeHours).toBeDisabled()
     expect(timeMinutes).toBeDisabled()
     expect(timePeriod).toBeDisabled()
-    expect((timeHours as HTMLInputElement).value).toBe("")
-    expect((timeMinutes as HTMLInputElement).value).toBe("")
+    expect((timeHours as HTMLInputElement).value).toBe("12")
+    expect((timeMinutes as HTMLInputElement).value).toBe("30")
     expect((timePeriod as HTMLSelectElement).value).toBe("pm")
   })
 })

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormApplicationData.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormApplicationData.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React from "react"
 import { t, Select, TimeField, DateField, DateFieldValues } from "@bloom-housing/ui-components"
 import { Grid } from "@bloom-housing/ui-seeds"
 import { LanguagesEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
@@ -12,20 +12,11 @@ const FormApplicationData = () => {
   const { register, watch, errors, setValue } = formMethods
 
   const dateSubmittedValue: DateFieldValues = watch("dateSubmitted")
-  const dateSubmittedError = !!errors?.dateSubmitted
   const isDateFilled =
     dateSubmittedValue?.day && dateSubmittedValue?.month && dateSubmittedValue?.year
 
   const isDateRequired =
     dateSubmittedValue?.day || dateSubmittedValue?.month || dateSubmittedValue?.year
-
-  useEffect(() => {
-    if (dateSubmittedError || !isDateRequired) {
-      setValue("timeSubmitted.hours", null)
-      setValue("timeSubmitted.minutes", null)
-      setValue("timeSubmitted.seconds", null)
-    }
-  }, [dateSubmittedError, isDateRequired, setValue])
 
   return (
     <SectionWithGrid heading={t("application.details.applicationData")}>


### PR DESCRIPTION
This PR addresses #4621 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Remove paper application time field reset on invalid date error. 

## How Can This Be Tested/Reviewed?

* Go to the partner's site dashboard
* Select any listing and go to the `Applications` tab
* Select any application and click the `Edit` button
* Update the `Date Submitted` field to an invalid value
* Click the `Save & exit` button
* The `Please enter a valid date` error should show up, but the time field should remain unchanged (only disabled)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
