### PR TITLE
fix: use jurisdictional disclaimer

### DIFF
--- a/sites/public/src/components/content-pages/DisclaimerDeprecated.tsx
+++ b/sites/public/src/components/content-pages/DisclaimerDeprecated.tsx
@@ -1,13 +1,22 @@
-import React, { useEffect, useContext } from "react"
+import React, { useEffect, useContext, useState } from "react"
 import { PageHeader, MarkdownSection, t } from "@bloom-housing/ui-components"
 import Markdown from "markdown-to-jsx"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../../lib/constants"
 import Layout from "../../layouts/application"
-import pageContent from "../../md_content/disclaimer_deprecated.md"
+import RenderIf from "../../RenderIf"
+
+const getDisclaimerSection = async (jurisdiction: string) => {
+  return import(
+    `../../page_content/jurisdiction_overrides/${jurisdiction
+      .toLowerCase()
+      .replace(" ", "_")}/disclaimer.md`
+  )
+}
 
 const DisclaimerDeprecated = () => {
   const { profile } = useContext(AuthContext)
+  const [disclaimerSection, setDisclaimerSection] = useState("")
 
   useEffect(() => {
     pushGtmEvent<PageView>({
@@ -17,13 +26,31 @@ const DisclaimerDeprecated = () => {
     })
   }, [profile])
 
+  useEffect(() => {
+    const loadPageContent = async () => {
+      const disclaimer = await getDisclaimerSection(process.env.jurisdictionName || "")
+      setDisclaimerSection(disclaimer.default)
+    }
+    loadPageContent().catch(() => {
+      console.log("disclaimer section doesn't exist")
+    })
+  }, [])
+
   const pageTitle = <>{t("pageTitle.disclaimer")}</>
 
   return (
     <Layout>
       <PageHeader inverse={true} title={pageTitle} />
       <MarkdownSection>
-        <Markdown>{pageContent.toString()}</Markdown>
+        <Markdown
+          options={{
+            overrides: {
+              RenderIf,
+            },
+          }}
+        >
+          {disclaimerSection.toString()}
+        </Markdown>
       </MarkdownSection>
     </Layout>
   )


### PR DESCRIPTION
## Description

Pulls over the pattern from the deprecated privacy page here to use jurisdictional content on the disclaimer page.

## How Can This Be Tested/Reviewed?

Ensure the [SJ preview](https://deploy-preview-1012--san-jose-public-stage.netlify.app/disclaimer) does not show San Mateo content.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
