### PR TITLE
release: external listings externalize endpoint

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -100,7 +100,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "~29.6.2",
-    "jest-mock-extended": "^3.0.7",
+    "jest-extended": "^7.0.0",
     "prettier": "^2.3.2",
     "supertest": "^6.1.3",
     "ts-jest": "~29.1.1",
@@ -125,7 +125,10 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "setupFilesAfterEnv": [
+      "jest-extended/all"
+    ]
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"

--- a/api/prisma/seed-helpers/unit-factory.ts
+++ b/api/prisma/seed-helpers/unit-factory.ts
@@ -2,12 +2,16 @@ import {
   AmiChart,
   Prisma,
   PrismaClient,
+  UnitRentTypeEnum,
   UnitTypeEnum,
   UnitTypes,
 } from '@prisma/client';
 import { unitTypeFactorySingle } from './unit-type-factory';
 import { unitAccessibilityPriorityTypeFactorySingle } from './unit-accessibility-priority-type-factory';
-import { unitRentTypeFactory } from './unit-rent-type-factory';
+import {
+  unitRentTypeFactory,
+  unitRentTypeFactorySingle,
+} from './unit-rent-type-factory';
 import { randomInt } from 'crypto';
 
 const unitTypes = Object.values(UnitTypeEnum);
@@ -72,8 +76,14 @@ export const unitFactoryMany = async (
         ? await unitAccessibilityPriorityTypeFactorySingle(prismaClient)
         : undefined;
 
+    const unitRentType = await unitRentTypeFactorySingle(
+      prismaClient,
+      UnitRentTypeEnum.fixed,
+    );
+
     return unitFactorySingle(unitType, {
       ...optionalParams,
+      unitRentTypeId: unitRentType.id,
       otherFields: {
         unitAccessibilityPriorityTypes: unitAccessibilityPriorityTypes
           ? {

--- a/api/prisma/seed-helpers/unit-rent-type-factory.ts
+++ b/api/prisma/seed-helpers/unit-rent-type-factory.ts
@@ -1,4 +1,9 @@
-import { Prisma, UnitRentTypeEnum } from '@prisma/client';
+import {
+  Prisma,
+  PrismaClient,
+  UnitRentTypeEnum,
+  UnitRentTypes,
+} from '@prisma/client';
 import { randomInt } from 'crypto';
 
 export const unitRentTypeFactory = (
@@ -8,3 +13,39 @@ export const unitRentTypeFactory = (
 });
 
 export const unitRentTypeArray = Object.values(UnitRentTypeEnum);
+
+export const unitRentTypeFactorySingle = async (
+  prismaClient: PrismaClient,
+  type: UnitRentTypeEnum,
+): Promise<UnitRentTypes> => {
+  const unitRentType = await prismaClient.unitRentTypes.findFirst({
+    where: {
+      name: {
+        equals: type,
+      },
+    },
+  });
+  if (!unitRentType) {
+    console.warn(
+      `Unit rent type ${unitRentType} was not created, run unitRentTypeFactoryAll`,
+    );
+  }
+  return unitRentType;
+};
+
+// All unit rent types should only be created once. This function checks if they have been created
+// before putting all types in the database
+export const unitRentTypeFactoryAll = async (
+  prismaClient: PrismaClient,
+): Promise<UnitRentTypes[]> => {
+  const all = await prismaClient.unitRentTypes.findMany({});
+  const unitRentTypes = Object.values(unitRentTypeArray);
+  if (all.length !== unitRentTypes.length) {
+    await prismaClient.unitRentTypes.createMany({
+      data: Object.values(unitRentTypeArray).map((value) => ({
+        name: value,
+      })),
+    });
+  }
+  return await prismaClient.unitRentTypes.findMany({});
+};

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -11,6 +11,7 @@ import {
 import { jurisdictionFactory } from './seed-helpers/jurisdiction-factory';
 import { listingFactory } from './seed-helpers/listing-factory';
 import { amiChartFactory } from './seed-helpers/ami-chart-factory';
+import { unitRentTypeFactoryAll } from './seed-helpers/unit-rent-type-factory';
 import { userFactory } from './seed-helpers/user-factory';
 import { unitTypeFactoryAll } from './seed-helpers/unit-type-factory';
 import { unitAccessibilityPriorityTypeFactoryAll } from './seed-helpers/unit-accessibility-priority-type-factory';
@@ -444,6 +445,7 @@ export const stagingSeed = async (
 
   // create pre-determined values
   const unitTypes = await unitTypeFactoryAll(prismaClient);
+  await unitRentTypeFactoryAll(prismaClient);
   await unitAccessibilityPriorityTypeFactoryAll(prismaClient);
   await reservedCommunityTypeFactoryAll(mainJurisdiction.id, prismaClient);
   // list of predefined listings WARNING: images only work if image setup is cloudinary on exygy account

--- a/api/src/controllers/external-listing.controller.ts
+++ b/api/src/controllers/external-listing.controller.ts
@@ -1,0 +1,24 @@
+import {
+  Controller,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { PermissionTypeDecorator } from '../decorators/permission-type.decorator';
+import { JwtAuthGuard } from '../guards/jwt.guard';
+import { PermissionGuard } from '../guards/permission.guard';
+import { ApiKeyGuard } from '../guards/api-key.guard';
+import { ExternalListingService } from '../services/external-listing.service';
+import { defaultValidationPipeOptions } from '../utilities/default-validation-pipe-options';
+
+@Controller('externalListings')
+@ApiTags('externalListings')
+@UsePipes(new ValidationPipe(defaultValidationPipeOptions))
+@PermissionTypeDecorator('externalListings')
+@UseGuards(ApiKeyGuard, JwtAuthGuard, PermissionGuard)
+export class ExternalListingController {
+  constructor(
+    private readonly externalListingService: ExternalListingService,
+  ) {}
+}

--- a/api/src/controllers/external-listing.controller.ts
+++ b/api/src/controllers/external-listing.controller.ts
@@ -1,14 +1,23 @@
 import {
+  // Body,
+  ClassSerializerInterceptor,
   Controller,
-  UseGuards,
+  Get,
+  // Put,
+  // UseGuards,
+  UseInterceptors,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiTags, ApiOkResponse } from '@nestjs/swagger';
+// import { PermissionAction } from '../decorators/permission-action.decorator';
 import { PermissionTypeDecorator } from '../decorators/permission-type.decorator';
-import { JwtAuthGuard } from '../guards/jwt.guard';
-import { PermissionGuard } from '../guards/permission.guard';
-import { ApiKeyGuard } from '../guards/api-key.guard';
+import { ExternalizedDetails } from '../dtos/external-listings/externalized-details.dto';
+// import { IngestParams } from '../dtos/external-listings/ingest-params.dto';
+// import { SuccessDTO } from '../dtos/shared/success.dto';
+// import { permissionActions } from '../enums/permissions/permission-actions-enum';
+// import { JwtAuthGuard } from '../guards/jwt.guard';
+// import { PermissionGuard } from '../guards/permission.guard';
 import { ExternalListingService } from '../services/external-listing.service';
 import { defaultValidationPipeOptions } from '../utilities/default-validation-pipe-options';
 
@@ -16,9 +25,32 @@ import { defaultValidationPipeOptions } from '../utilities/default-validation-pi
 @ApiTags('externalListings')
 @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
 @PermissionTypeDecorator('externalListings')
-@UseGuards(ApiKeyGuard, JwtAuthGuard, PermissionGuard)
 export class ExternalListingController {
   constructor(
     private readonly externalListingService: ExternalListingService,
   ) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get an object of externalized system data details',
+    operationId: 'externalize',
+  })
+  @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
+  @UseInterceptors(ClassSerializerInterceptor)
+  @ApiOkResponse({ type: ExternalizedDetails })
+  async externalize() {
+    return await this.externalListingService.externalize();
+  }
+
+  // @Put('ingest')
+  // @ApiOperation({
+  //   summary: 'Ingest listing data from an external Bloom instance',
+  //   operationId: 'ingest',
+  // })
+  // @PermissionAction(permissionActions.submit)
+  // @UseGuards(JwtAuthGuard, PermissionGuard)
+  // @ApiOkResponse({ type: SuccessDTO })
+  // async ingest(@Body() dto: IngestParams): Promise<SuccessDTO> {
+  //   return await this.externalListingService.ingest(dto);
+  // }
 }

--- a/api/src/dtos/external-listings/externalized-details.dto.ts
+++ b/api/src/dtos/external-listings/externalized-details.dto.ts
@@ -1,0 +1,48 @@
+import { Type, Expose } from 'class-transformer';
+import { ValidateNested, IsArray, IsDefined } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { ExternalizedListing } from './externalized-listing.dto';
+import { IdDTO } from '../shared/id.dto';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class ExternalizedDetails {
+  @Expose()
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => IdDTO)
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty({ type: IdDTO, isArray: true })
+  jurisdictions: IdDTO[];
+
+  @Expose()
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => ExternalizedListing)
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty({ type: ExternalizedListing, isArray: true })
+  listings: ExternalizedListing[];
+
+  @Expose()
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => IdDTO)
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty({ type: IdDTO, isArray: true })
+  reservedCommunityTypes: IdDTO[];
+
+  @Expose()
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => IdDTO)
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty({ type: IdDTO, isArray: true })
+  unitRentTypes: IdDTO[];
+
+  @Expose()
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => IdDTO)
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty({ type: IdDTO, isArray: true })
+  unitTypes: IdDTO[];
+}

--- a/api/src/dtos/external-listings/externalized-listing.dto.ts
+++ b/api/src/dtos/external-listings/externalized-listing.dto.ts
@@ -1,0 +1,18 @@
+import { Type, Expose } from 'class-transformer';
+import { IsDate, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IdDTO } from '../shared/id.dto';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class ExternalizedListing extends IdDTO {
+  @Expose()
+  @IsDate({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => Date)
+  @ApiProperty()
+  contentUpdatedAt: Date;
+
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  jurisdictionId: string;
+}

--- a/api/src/dtos/external-listings/ingest-params.dto.ts
+++ b/api/src/dtos/external-listings/ingest-params.dto.ts
@@ -1,0 +1,30 @@
+import { Expose } from 'class-transformer';
+import { IsDefined, IsString, IsUrl } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { hasHttps } from '../../decorators/hasHttps.decorator';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class IngestParams {
+  @Expose()
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @hasHttps({ groups: [ValidationsGroupsEnum.default] })
+  @IsUrl(
+    { require_protocol: false, require_tld: false },
+    { groups: [ValidationsGroupsEnum.default] },
+  )
+  @ApiProperty()
+  externalURL: string;
+
+  @Expose()
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  jurisdictionId: string;
+
+  @Expose()
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  targetName: string;
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -70,7 +70,12 @@ async function bootstrap() {
       ];
     });
   });
-  SwaggerModule.setup('api', app, document);
+  SwaggerModule.setup('api', app, document, {
+    swaggerOptions: {
+      tagsSorter: 'alpha',
+      operationsSorter: 'alpha',
+    },
+  });
   const configService: ConfigService = app.get(ConfigService);
 
   await app.listen(configService.get<number>('PORT'));

--- a/api/src/modules/app.module.ts
+++ b/api/src/modules/app.module.ts
@@ -23,6 +23,7 @@ import { ThrottleGuard } from '../guards/throttler.guard';
 import { ScriptRunnerModule } from './script-runner.module';
 import { LotteryModule } from './lottery.module';
 import { FeatureFlagModule } from './feature-flag.module';
+import { ExternalListingModule } from './external-listing.module';
 
 @Module({
   imports: [
@@ -44,6 +45,7 @@ import { FeatureFlagModule } from './feature-flag.module';
     ScriptRunnerModule,
     LotteryModule,
     FeatureFlagModule,
+    ExternalListingModule,
     ThrottlerModule.forRoot([
       {
         ttl: Number(process.env.THROTTLE_TTL),
@@ -80,6 +82,7 @@ import { FeatureFlagModule } from './feature-flag.module';
     ScriptRunnerModule,
     LotteryModule,
     FeatureFlagModule,
+    ExternalListingModule,
   ],
 })
 export class AppModule {}

--- a/api/src/modules/external-listing.module.ts
+++ b/api/src/modules/external-listing.module.ts
@@ -1,0 +1,13 @@
+import { Logger, Module } from '@nestjs/common';
+import { PermissionModule } from './permission.module';
+import { PrismaModule } from './prisma.module';
+import { ExternalListingController } from '../controllers/external-listing.controller';
+import { ExternalListingService } from '../services/external-listing.service';
+
+@Module({
+  imports: [PermissionModule, PrismaModule],
+  controllers: [ExternalListingController],
+  providers: [ExternalListingService, Logger],
+  exports: [ExternalListingService],
+})
+export class ExternalListingModule {}

--- a/api/src/modules/external-listing.module.ts
+++ b/api/src/modules/external-listing.module.ts
@@ -1,3 +1,4 @@
+import { HttpModule } from '@nestjs/axios';
 import { Logger, Module } from '@nestjs/common';
 import { PermissionModule } from './permission.module';
 import { PrismaModule } from './prisma.module';
@@ -5,7 +6,7 @@ import { ExternalListingController } from '../controllers/external-listing.contr
 import { ExternalListingService } from '../services/external-listing.service';
 
 @Module({
-  imports: [PermissionModule, PrismaModule],
+  imports: [HttpModule, PermissionModule, PrismaModule],
   controllers: [ExternalListingController],
   providers: [ExternalListingService, Logger],
   exports: [ExternalListingService],

--- a/api/src/permission-configs/permission_policy.csv
+++ b/api/src/permission-configs/permission_policy.csv
@@ -82,6 +82,8 @@ p, partner, paperApplication, true, read
 p, admin, mapLayers, true, .*
 p, jurisdictionAdmin, mapLayers, true, .*
 
+p, admin, externalListings, true, .*
+
 p, admin, featureFlags, true, .*
 
 g, admin, jurisdictionAdmin

--- a/api/src/services/external-listing.service.ts
+++ b/api/src/services/external-listing.service.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+import { PermissionService } from './permission.service';
+
+/**
+  this is the service for external listings
+  it handles all the backend's business logic for exposing and ingesting listings
+*/
+@Injectable()
+export class ExternalListingService {
+  constructor(
+    private prisma: PrismaService,
+    private permissionService: PermissionService,
+    @Inject(Logger)
+    private logger = new Logger(ExternalListingService.name),
+  ) {}
+}

--- a/api/src/services/external-listing.service.ts
+++ b/api/src/services/external-listing.service.ts
@@ -1,6 +1,22 @@
-import { Inject, Injectable, Logger } from '@nestjs/common';
+// import { AxiosError } from 'axios';
+// import dayjs from 'dayjs';
+// import utc from 'dayjs/plugin/utc';
+// import { catchError, firstValueFrom } from 'rxjs';
+// import { HttpService } from '@nestjs/axios';
+// import { HttpException, Inject, Injectable, Logger } from '@nestjs/common';
+// import { ListingsStatusEnum, Prisma } from '@prisma/client';
+// import { PrismaService } from './prisma.service';
+// import { ExternalizedDetails } from '../dtos/external-listings/externalized-details.dto';
+// import { IngestParams } from '../dtos/external-listings/ingest-params.dto';
+// import Listing from '../dtos/listings/listing.dto';
+// import { IdDTO } from '../dtos/shared/id.dto';
+
+import { Injectable } from '@nestjs/common';
+import { ListingsStatusEnum } from '@prisma/client';
 import { PrismaService } from './prisma.service';
-import { PermissionService } from './permission.service';
+import { ExternalizedDetails } from '../dtos/external-listings/externalized-details.dto';
+
+// dayjs.extend(utc);
 
 /**
   this is the service for external listings
@@ -8,10 +24,476 @@ import { PermissionService } from './permission.service';
 */
 @Injectable()
 export class ExternalListingService {
-  constructor(
-    private prisma: PrismaService,
-    private permissionService: PermissionService,
-    @Inject(Logger)
-    private logger = new Logger(ExternalListingService.name),
-  ) {}
+  // constructor(
+  //   private httpService: HttpService,
+  //   private prisma: PrismaService,
+  //   @Inject(Logger)
+  //   private logger = new Logger(ExternalListingService.name),
+  // ) {}
+  constructor(private prisma: PrismaService) {}
+
+  async externalize(): Promise<ExternalizedDetails> {
+    const jurisdictions = await this.prisma.jurisdictions.findMany({
+      select: { id: true, name: true },
+    });
+    const listings = await this.prisma.listings.findMany({
+      select: { id: true, contentUpdatedAt: true, jurisdictionId: true },
+      where: { status: ListingsStatusEnum.active },
+    });
+    const reservedCommunityTypes =
+      await this.prisma.reservedCommunityTypes.findMany({
+        select: { id: true, name: true },
+      });
+    const unitRentTypes = await this.prisma.unitRentTypes.findMany({
+      select: { id: true, name: true },
+    });
+    const unitTypes = await this.prisma.unitTypes.findMany({
+      select: { id: true, name: true },
+    });
+
+    const externalizedDetails: ExternalizedDetails = {
+      jurisdictions,
+      listings,
+      reservedCommunityTypes,
+      unitRentTypes,
+      unitTypes,
+    };
+
+    return externalizedDetails;
+  }
+
+  // async ingest(ingestParams: IngestParams) {
+  //   const { externalURL, jurisdictionId, targetName } = ingestParams;
+
+  //   // fetch the externalized data from the external system
+  //   const { data } = await firstValueFrom(
+  //     this.httpService
+  //       .get<ExternalizedDetails>(`${externalURL}/externalListings`)
+  //       .pipe(
+  //         catchError((error: AxiosError) => {
+  //           this.logger.error(
+  //             `Request to external Bloom instance with URL ${externalURL} failed`,
+  //             error,
+  //           );
+  //           throw new HttpException('External details call failed', 500);
+  //         }),
+  //       ),
+  //   );
+
+  //   const {
+  //     jurisdictions = [],
+  //     listings = [],
+  //     reservedCommunityTypes = [],
+  //     unitRentTypes = [],
+  //     unitTypes = [],
+  //   } = data;
+  //   const externalJurisdiction = jurisdictions.find(
+  //     (juris) => juris.name === targetName,
+  //   );
+
+  //   if (!externalJurisdiction) {
+  //     this.logger.error(
+  //       `Target jurisdiction ${targetName} not found when calling URL ${externalURL}`,
+  //       jurisdictions.toString(),
+  //     );
+  //     throw new HttpException('Target jurisdiction not found', 500);
+  //   }
+
+  //   let listingIdsToDelete = [];
+
+  //   // query for existing external listings within the system
+  //   const currentExternalListings = await this.prisma.listings.findMany({
+  //     select: { id: true, contentUpdatedAt: true, externalListingId: true },
+  //     where: {
+  //       externalJurisdictionId: externalJurisdiction.id,
+  //       jurisdictionId: jurisdictionId,
+  //     },
+  //   });
+
+  //   if (listings.length === 0) {
+  //     listingIdsToDelete = currentExternalListings.map((listing) => listing.id);
+  //   } else {
+  //     // query and compare reserved community types
+  //     const internalReservedCommunityTypes =
+  //       await this.prisma.reservedCommunityTypes.findMany({
+  //         select: { id: true, name: true },
+  //       });
+
+  //     const combinedRCTs = reservedCommunityTypes.reduce((acc, rct) => {
+  //       const matchingRCT = internalReservedCommunityTypes.find(
+  //         (internalRCT) => internalRCT.name === rct.name,
+  //       );
+  //       if (matchingRCT) {
+  //         acc.push({ internalId: matchingRCT.id, externalId: rct.id });
+  //       } else {
+  //         this.logger.error(
+  //           `External reserved community type ${rct.name} could not be matched`,
+  //         );
+  //       }
+  //       return acc;
+  //     }, []);
+
+  //     // query and compare unit rent types
+  //     const internalUnitRentTypes = await this.prisma.unitRentTypes.findMany({
+  //       select: { id: true, name: true },
+  //     });
+
+  //     const combinedURTs = unitRentTypes.reduce((acc, urt) => {
+  //       const matchingURT = internalUnitRentTypes.find(
+  //         (internalUnitRentType) => internalUnitRentType.name === urt.name,
+  //       );
+  //       if (matchingURT) {
+  //         acc.push({ internalId: matchingURT.id, externalId: urt.id });
+  //       } else {
+  //         this.logger.error(
+  //           `External unit rent type ${urt.name} could not be matched`,
+  //         );
+  //       }
+  //       return acc;
+  //     }, []);
+
+  //     // query and compare unit types
+  //     const internalUnitTypes = await this.prisma.unitTypes.findMany({
+  //       select: { id: true, name: true },
+  //     });
+
+  //     const combinedUTs = unitTypes.reduce((acc, unitType) => {
+  //       const matchingUT = internalUnitTypes.find(
+  //         (internalUnitType) => internalUnitType.name === unitType.name,
+  //       );
+  //       if (matchingUT) {
+  //         acc.push({ internalId: matchingUT.id, externalId: unitType.id });
+  //       } else {
+  //         this.logger.error(
+  //           `External unit type ${unitType.name} could not be matched`,
+  //         );
+  //       }
+  //       return acc;
+  //     }, []);
+
+  //     for (const existingListing of currentExternalListings) {
+  //       const index = listings.findIndex(
+  //         (listing) => listing?.id === existingListing.externalListingId,
+  //       );
+
+  //       if (index >= 0) {
+  //         const externalListing = listings.at(index);
+  //         delete listings[index];
+
+  //         if (
+  //           dayjs
+  //             .utc(existingListing.contentUpdatedAt)
+  //             .isBefore(dayjs.utc(externalListing.contentUpdatedAt))
+  //         ) {
+  //           // delete existing listing
+  //           await this.prisma.listings.delete({
+  //             where: { id: existingListing.id },
+  //           });
+  //           // recreate with updated data
+  //           this.createExternalListing(
+  //             combinedRCTs,
+  //             combinedURTs,
+  //             combinedUTs,
+  //             externalJurisdiction,
+  //             externalListing,
+  //             externalURL,
+  //             jurisdictionId,
+  //           );
+  //         } else {
+  //           continue;
+  //         }
+  //       } else {
+  //         // add to list for deletion
+  //         listingIdsToDelete.push(existingListing.id);
+  //       }
+  //     }
+
+  //     for (const newExternalListing of listings) {
+  //       if (
+  //         newExternalListing &&
+  //         newExternalListing.jurisdictionId === externalJurisdiction.id
+  //       ) {
+  //         // create newly active listings
+  //         this.createExternalListing(
+  //           combinedRCTs,
+  //           combinedURTs,
+  //           combinedUTs,
+  //           externalJurisdiction,
+  //           newExternalListing,
+  //           externalURL,
+  //           jurisdictionId,
+  //         );
+  //       } else {
+  //         continue;
+  //       }
+  //     }
+  //   }
+
+  //   if (listingIdsToDelete.length > 0) {
+  //     // delete all listings that are no longer active
+  //     await this.prisma.listings.deleteMany({
+  //       where: {
+  //         id: {
+  //           in: listingIdsToDelete,
+  //         },
+  //       },
+  //     });
+  //   }
+
+  //   return {
+  //     success: true,
+  //   };
+  // }
+
+  // async createExternalListing(
+  //   combinedRCTs: Array<any>,
+  //   combinedURTs: Array<any>,
+  //   combinedUTs: Array<any>,
+  //   externalJurisdiction: IdDTO,
+  //   externalListing: IdDTO,
+  //   externalURL: string,
+  //   jurisdictionId: string,
+  // ) {
+  //   // fetch the full data for the external listing
+  //   const { data } = await firstValueFrom(
+  //     this.httpService
+  //       .get<Listing>(`${externalURL}/listings/${externalListing.id}?view=base`)
+  //       .pipe(
+  //         catchError((error: AxiosError) => {
+  //           this.logger.error(
+  //             `Request to external Bloom instance with URL ${externalURL} for listing ${externalListing.id} failed`,
+  //             error,
+  //           );
+  //           throw new HttpException('External listing fetch call failed', 500);
+  //         }),
+  //       ),
+  //   );
+
+  //   if (data === null || data === undefined) {
+  //     this.logger.error(
+  //       `Listing with external id ${externalListing.id} could not be created. Endpoint returned null.`,
+  //     );
+  //     return;
+  //   }
+
+  //   let reservedCommunityTypeId: string;
+  //   if (data.reservedCommunityTypes) {
+  //     reservedCommunityTypeId = combinedRCTs.find(
+  //       (rct) => rct.externalId === data.reservedCommunityTypes.id,
+  //     )?.internalId;
+
+  //     if (reservedCommunityTypeId === undefined) {
+  //       this.logger.error(
+  //         `Listing with external id ${externalListing.id} could not be created. Reserved community type ${data.reservedCommunityTypes.name} does not exist.`,
+  //       );
+  //       return;
+  //     }
+  //   }
+
+  //   await this.prisma.listings.create({
+  //     data: {
+  //       accessibility: data.accessibility,
+  //       additionalApplicationSubmissionNotes:
+  //         data.additionalApplicationSubmissionNotes,
+  //       allowsCats: data.allowsCats,
+  //       allowsDogs: data.allowsDogs,
+  //       amenities: data.amenities,
+  //       applicationDueDate: data.applicationDueDate,
+  //       applicationFee: data.applicationFee,
+  //       applicationOpenDate: data.applicationOpenDate,
+  //       applicationOrganization: data.applicationOrganization,
+  //       buildingTotalUnits: data.buildingTotalUnits,
+  //       cocInfo: data.cocInfo,
+  //       commonDigitalApplication: data.commonDigitalApplication,
+  //       communityDisclaimerDescription: data.communityDisclaimerDescription,
+  //       communityDisclaimerTitle: data.communityDisclaimerTitle,
+  //       configurableRegion: data.configurableRegion,
+  //       contentUpdatedAt: data.contentUpdatedAt,
+  //       costsNotIncluded: data.costsNotIncluded,
+  //       creditHistory: data.creditHistory,
+  //       creditScreeningFee: data.creditScreeningFee,
+  //       criminalBackground: data.criminalBackground,
+  //       customMapPin: data.customMapPin,
+  //       depositHelperText: data.depositHelperText,
+  //       depositMax: data.depositMax,
+  //       depositMin: data.depositMin,
+  //       depositType: data.depositType,
+  //       depositValue: data.depositValue,
+  //       developer: data.developer,
+  //       digitalApplication: data.digitalApplication,
+  //       disableUnitsAccordion: data.disableUnitsAccordion,
+  //       displayWaitlistSize: data.displayWaitlistSize,
+  //       externalJurisdictionId: externalJurisdiction.id,
+  //       externalListingId: externalListing.id,
+  //       externalURL: externalURL,
+  //       hasHudEbllClearance: data.hasHudEbllClearance,
+  //       homeType: data.homeType,
+  //       householdSizeMax: data.householdSizeMax,
+  //       householdSizeMin: data.householdSizeMin,
+  //       includeCommunityDisclaimer: data.includeCommunityDisclaimer,
+  //       isVerified: data.isVerified,
+  //       isWaitlistOpen: data.isWaitlistOpen,
+  //       leasingAgentEmail: data.leasingAgentEmail,
+  //       leasingAgentName: data.leasingAgentName,
+  //       leasingAgentOfficeHours: data.leasingAgentOfficeHours,
+  //       leasingAgentPhone: data.leasingAgentPhone,
+  //       leasingAgentTitle: data.leasingAgentTitle,
+  //       listingFileNumber: data.listingFileNumber,
+  //       listingType: data.listingType,
+  //       lotteryOptIn: data.lotteryOptIn,
+  //       managementWebsite: data.managementWebsite,
+  //       marketingMonth: data.marketingMonth,
+  //       marketingSeason: data.marketingSeason,
+  //       marketingType: data.marketingType,
+  //       marketingYear: data.marketingYear,
+  //       name: data.name,
+  //       neighborhood: data.neighborhood,
+  //       paperApplication: data.paperApplication,
+  //       parkingFee: data.parkingFee,
+  //       petPolicy: data.petPolicy,
+  //       postmarkedApplicationsReceivedByDate:
+  //         data.postmarkedApplicationsReceivedByDate,
+  //       programRules: data.programRules,
+  //       publishedAt: data.publishedAt,
+  //       referralOpportunity: data.referralOpportunity,
+  //       rentalAssistance: data.rentalAssistance,
+  //       rentalHistory: data.rentalHistory,
+  //       reservedCommunityDescription: data.reservedCommunityDescription,
+  //       reservedCommunityMinAge: data.reservedCommunityMinAge,
+  //       reviewOrderType: data.reviewOrderType,
+  //       scheduledPublishAt: data.scheduledPublishAt,
+  //       scheduledApplicationOpenAt: data.scheduledApplicationOpenAt,
+  //       section8Acceptance: data.section8Acceptance,
+  //       servicesOffered: data.servicesOffered,
+  //       smokingPolicy: data.smokingPolicy,
+  //       specialNotes: data.specialNotes,
+  //       status: data.status,
+  //       unitAmenities: data.unitAmenities,
+  //       unitsAvailable: data.unitsAvailable,
+  //       waitlistCurrentSize: data.waitlistCurrentSize,
+  //       waitlistMaxSize: data.waitlistMaxSize,
+  //       waitlistOpenSpots: data.waitlistOpenSpots,
+  //       whatToExpect: data.whatToExpect,
+  //       whatToExpectAdditionalText: data.whatToExpectAdditionalText,
+  //       yearBuilt: data.yearBuilt,
+
+  //       assets: data.assets
+  //         ? {
+  //             create: data.assets.map((asset) => ({
+  //               fileId: asset.fileId,
+  //               label: asset.label,
+  //             })),
+  //           }
+  //         : Prisma.JsonNullValueInput.JsonNull,
+  //       jurisdictions: {
+  //         connect: {
+  //           id: jurisdictionId,
+  //         },
+  //       },
+  //       listingImages: data.listingImages
+  //         ? {
+  //             create: data.listingImages.map((image) => ({
+  //               assets: {
+  //                 create: {
+  //                   fileId: image.assets.fileId,
+  //                   label: image.assets.label,
+  //                 },
+  //               },
+  //               ordinal: image.ordinal,
+  //               description: image.description,
+  //             })),
+  //           }
+  //         : undefined,
+  //       listingsBuildingAddress: data.listingsBuildingAddress
+  //         ? {
+  //             create: {
+  //               ...data.listingsBuildingAddress,
+  //               id: undefined,
+  //             },
+  //           }
+  //         : undefined,
+  //       reservedCommunityTypes: reservedCommunityTypeId
+  //         ? {
+  //             connect: {
+  //               id: reservedCommunityTypeId,
+  //             },
+  //           }
+  //         : undefined,
+  //       unitGroups: data.unitGroups
+  //         ? {
+  //             create: data.unitGroups.map((group) => ({
+  //               bathroomMax: group.bathroomMax,
+  //               bathroomMin: group.bathroomMin,
+  //               floorMax: group.floorMax,
+  //               floorMin: group.floorMin,
+  //               maxOccupancy: group.maxOccupancy,
+  //               minOccupancy: group.minOccupancy,
+  //               openWaitlist: group.openWaitlist,
+  //               sqFeetMax: group.sqFeetMax,
+  //               sqFeetMin: group.sqFeetMin,
+  //               rentType: group.rentType,
+  //               flatRentValueFrom: group.flatRentValueFrom,
+  //               flatRentValueTo: group.flatRentValueTo,
+  //               monthlyRent: group.monthlyRent,
+  //               totalAvailable: group.totalAvailable,
+  //               totalCount: group.totalCount,
+  //               accessibilityPriorityType: group.accessibilityPriorityType,
+  //               unitGroupAmiLevels: undefined,
+  //               unitTypes: {
+  //                 connect: group.unitTypes.map((type) => ({
+  //                   id: combinedUTs.find(
+  //                     (unitType) => unitType.externalId === type.id,
+  //                   )?.internalId,
+  //                 })),
+  //               },
+  //             })),
+  //           }
+  //         : undefined,
+  //       units: data.units
+  //         ? {
+  //             create: data.units.map((unit) => ({
+  //               accessibilityPriorityType: unit.accessibilityPriorityType,
+  //               amiPercentage: unit.amiPercentage,
+  //               annualIncomeMax: unit.annualIncomeMax,
+  //               annualIncomeMin: unit.annualIncomeMin,
+  //               bmrProgramChart: unit.bmrProgramChart,
+  //               floor: unit.floor,
+  //               maxOccupancy: unit.maxOccupancy,
+  //               minOccupancy: unit.minOccupancy,
+  //               monthlyIncomeMin: unit.monthlyIncomeMin,
+  //               monthlyRent: unit.monthlyRent,
+  //               monthlyRentAsPercentOfIncome: unit.monthlyRentAsPercentOfIncome,
+  //               numBedrooms: unit.numBedrooms,
+  //               numBathrooms: unit.numBathrooms,
+  //               number: unit.number,
+  //               sqFeet: unit.sqFeet,
+
+  //               amiChart: undefined,
+  //               unitAmiChartOverrides: undefined,
+  //               unitRentTypes: unit.unitRentTypes
+  //                 ? {
+  //                     connect: {
+  //                       id: combinedURTs.find(
+  //                         (unitRentType) =>
+  //                           unitRentType.externalId === unit.unitRentTypes.id,
+  //                       )?.internalId,
+  //                     },
+  //                   }
+  //                 : undefined,
+  //               unitTypes: unit.unitTypes
+  //                 ? {
+  //                     connect: {
+  //                       id: combinedUTs.find(
+  //                         (unitType) =>
+  //                           unitType.externalId === unit.unitTypes.id,
+  //                       )?.internalId,
+  //                     },
+  //                   }
+  //                 : undefined,
+  //             })),
+  //           }
+  //         : undefined,
+  //     },
+  //   });
+  // }
 }

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -110,8 +110,9 @@ views.base = {
   ...views.fundamentals,
   units: {
     include: {
-      unitTypes: true,
       unitAmiChartOverrides: true,
+      unitRentTypes: true,
+      unitTypes: true,
     },
   },
   unitGroups: {

--- a/api/test/integration/external-listing.e2e-spec.ts
+++ b/api/test/integration/external-listing.e2e-spec.ts
@@ -1,0 +1,453 @@
+import cookieParser from 'cookie-parser';
+import { randomUUID } from 'crypto';
+import dayjs from 'dayjs';
+import { Observable, of } from 'rxjs';
+import request from 'supertest';
+import { HttpService } from '@nestjs/axios';
+import { INestApplication, Logger } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  ListingsStatusEnum,
+  UnitRentTypeEnum,
+  UnitRentTypes,
+  UnitTypeEnum,
+  UnitTypes,
+} from '@prisma/client';
+import { AppModule } from '../../src/modules/app.module';
+import { jurisdictionFactory } from '../../prisma/seed-helpers/jurisdiction-factory';
+import { listingFactory } from '../../prisma/seed-helpers/listing-factory';
+import {
+  reservedCommunityTypeFactoryAll,
+  reservedCommunityTypeFactoryGet,
+} from '../../prisma/seed-helpers/reserved-community-type-factory';
+import { unitTypeFactoryAll } from '../../prisma/seed-helpers/unit-type-factory';
+import { unitRentTypeFactoryAll } from '../../prisma/seed-helpers/unit-rent-type-factory';
+import { userFactory } from '../../prisma/seed-helpers/user-factory';
+import { randomNoun } from '../../prisma/seed-helpers/word-generator';
+import { PrismaService } from '../../src/services/prisma.service';
+
+describe('External Listings Controller Tests', () => {
+  let app: INestApplication;
+  let logger: Logger;
+  let prisma: PrismaService;
+  let unitRentTypes: UnitRentTypes[];
+  let unitTypes: UnitTypes[];
+
+  const testHttpService = {
+    pipe: jest.fn(),
+    get: jest.fn((url) => {
+      // Get and parse the URL parameter.
+      let response = {};
+      if (url === 'https://www.error.com/externalListings') {
+        response = { response: 'resp', status: '500' };
+        return new Observable((subscriber) => subscriber.error(response));
+      } else if (url === 'https://www.noMatch.com/externalListings') {
+        response = {
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {
+            headers: undefined,
+          },
+          data: {
+            jurisdictions: [{ id: randomUUID(), name: randomNoun() }],
+            listings: [],
+            reservedCommunityTypes: [],
+            unitRentTypes: [],
+            unitTypes: [],
+          },
+        };
+      } else if (
+        url === 'https://www.externalJurisdictionName.com/externalListings'
+      ) {
+        response = {
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {
+            headers: undefined,
+          },
+          data: {
+            jurisdictions: [
+              {
+                id: 'externalJurisdictionId',
+                name: 'externalJurisdictionName',
+              },
+            ],
+            listings: [
+              {
+                id: 'externalListingId',
+                contentUpdatedAt: dayjs(new Date())
+                  .subtract(1, 'days')
+                  .toDate(),
+                jurisdictionId: 'externalJurisdictionId',
+              },
+            ],
+            reservedCommunityTypes: [
+              { id: 'externalRCTId', name: 'senior' },
+              { id: randomUUID(), name: 'fake' },
+            ],
+            unitRentTypes: [
+              { id: 'externalURTId', name: UnitRentTypeEnum.fixed },
+              { id: randomUUID(), name: UnitRentTypeEnum.percentageOfIncome },
+            ],
+            unitTypes: [
+              { id: 'externalUTId', name: UnitTypeEnum.studio },
+              { id: randomUUID(), name: UnitTypeEnum.oneBdrm },
+            ],
+          },
+        };
+      } else if (
+        url ===
+        `https://www.externalJurisdictionName.com/listings/externalListingId?view=base`
+      ) {
+        response = {
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {
+            headers: undefined,
+          },
+          data: {
+            id: 'externalListingId',
+            assets: [
+              {
+                fileId: randomUUID(),
+                label: 'example asset',
+              },
+            ],
+            contentUpdatedAt: dayjs(new Date()).subtract(1, 'days').toDate(),
+            displayWaitlistSize: false,
+            isVerified: true,
+            jurisdictions: [
+              {
+                id: 'externalJurisdictionId',
+                name: 'externalJurisdictionName',
+              },
+            ],
+            name: 'example listing name',
+            reservedCommunityTypes: { id: 'externalRCTId', name: 'senior' },
+            status: ListingsStatusEnum.active,
+            units: [
+              {
+                amiPercentage: '1',
+                annualIncomeMax: '5',
+                annualIncomeMin: '2',
+                bmrProgramChart: true,
+                floor: 4,
+                maxOccupancy: 6,
+                minOccupancy: 7,
+                monthlyIncomeMin: '3',
+                monthlyRent: '8',
+                monthlyRentAsPercentOfIncome: '13',
+                numBathrooms: 9,
+                numBedrooms: 10,
+                number: '11',
+                sqFeet: '12',
+
+                unitRentTypes: {
+                  id: 'externalURTId',
+                  name: UnitRentTypeEnum.fixed,
+                },
+                unitTypes: { id: 'externalUTId', name: UnitTypeEnum.studio },
+              },
+            ],
+          },
+        };
+      }
+
+      return of(response);
+    }),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(HttpService)
+      .useValue(testHttpService)
+      .overrideProvider(Logger)
+      .useValue({
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    logger = moduleFixture.get<Logger>(Logger);
+    prisma = moduleFixture.get<PrismaService>(PrismaService);
+    app.use(cookieParser());
+    await app.init();
+    unitRentTypes = await unitRentTypeFactoryAll(prisma);
+    unitTypes = await unitTypeFactoryAll(prisma);
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+    await app.close();
+  });
+
+  describe('Test externalize endpoint', () => {
+    it('should return object with lists of needed info', async () => {
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: jurisdictionFactory('exposeJurisdiction'),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdiction.id, prisma);
+      const reservedCommunityType = await reservedCommunityTypeFactoryGet(
+        prisma,
+        jurisdiction.id,
+      );
+      const listingData = await listingFactory(jurisdiction.id, prisma);
+      const listingCreated = await prisma.listings.create({
+        data: listingData,
+      });
+
+      const res = await request(app.getHttpServer())
+        .get(`/externalListings`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(200);
+
+      const { jurisdictions, listings, reservedCommunityTypes } = res.body;
+      expect(jurisdictions).toContainEqual({
+        id: jurisdiction.id,
+        name: jurisdiction.name,
+      });
+      expect(listings).toContainEqual({
+        id: listingCreated.id,
+        contentUpdatedAt: listingCreated.contentUpdatedAt,
+        jurisdictionId: jurisdiction.id,
+      });
+      expect(reservedCommunityTypes).toContainEqual({
+        id: reservedCommunityType.id,
+        name: reservedCommunityType.name,
+      });
+      unitRentTypes.forEach((urt) => {
+        expect(res.body.unitRentTypes).toContainEqual({
+          id: urt.id,
+          name: urt.name,
+        });
+      });
+      unitTypes.forEach((ut) => {
+        expect(res.body.unitTypes).toContainEqual({
+          id: ut.id,
+          name: ut.name,
+        });
+      });
+    });
+  });
+
+  describe.skip('Test ingest endpoint', () => {
+    let adminAccessToken: string;
+    beforeAll(async () => {
+      const adminUser = await prisma.userAccounts.create({
+        data: await userFactory({
+          roles: {
+            isAdmin: true,
+          },
+          mfaEnabled: false,
+          confirmedAt: new Date(),
+        }),
+      });
+      const res = await request(app.getHttpServer())
+        .post('/auth/login')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({ email: adminUser.email, password: 'Abcdef12345!' })
+        .expect(201);
+      adminAccessToken = res.header?.['set-cookie'].find((cookie) =>
+        cookie.startsWith('access-token='),
+      );
+    });
+
+    it('should error if external call fails', async () => {
+      const ingestParams = {
+        externalURL: 'https://www.error.com',
+        jurisdictionId: '',
+        targetName: '',
+      };
+      const res = await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .send(ingestParams)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', adminAccessToken)
+        .expect(500);
+
+      expect(res.body.message).toEqual('External details call failed');
+      expect(logger.error).toBeCalledWith(
+        'Request to external Bloom instance with URL https://www.error.com failed',
+        { response: 'resp', status: '500' },
+      );
+    });
+
+    it('should error if jurisdiction cannot be matched', async () => {
+      const ingestParams = {
+        externalURL: 'https://www.noMatch.com',
+        jurisdictionId: '',
+        targetName: 'externalJurisdictionName',
+      };
+      const res = await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .send(ingestParams)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', adminAccessToken)
+        .expect(500);
+
+      expect(res.body.message).toEqual('Target jurisdiction not found');
+    });
+
+    it('should call createExternalListing if external listing does not exist in the system', async () => {
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: jurisdictionFactory('newExternalListing'),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdiction.id, prisma);
+
+      const ingestParams = {
+        externalURL: 'https://www.externalJurisdictionName.com',
+        jurisdictionId: jurisdiction.id,
+        targetName: 'externalJurisdictionName',
+      };
+      const res = await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .send(ingestParams)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+
+      expect(res.body.success).toEqual(true);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const listings = await prisma.listings.findMany({
+        include: {
+          units: {
+            include: {
+              unitRentTypes: true,
+              unitTypes: true,
+            },
+          },
+        },
+        where: {
+          externalJurisdictionId: 'externalJurisdictionId',
+          jurisdictionId: jurisdiction.id,
+        },
+      });
+
+      expect(listings.length).toEqual(1);
+      expect(listings[0].externalListingId).toEqual('externalListingId');
+      expect(listings[0].externalURL).toEqual(
+        'https://www.externalJurisdictionName.com',
+      );
+      expect(listings[0].units.length).toEqual(1);
+      expect(listings[0].units[0].unitRentTypes.name).toEqual(
+        UnitRentTypeEnum.fixed,
+      );
+      expect(listings[0].units[0].unitTypes.name).toEqual(UnitTypeEnum.studio);
+    });
+
+    it('should delete and recreate a listing if external listing has been updated', async () => {
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: jurisdictionFactory('updateExternalListing'),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdiction.id, prisma);
+      const listingData = await listingFactory(jurisdiction.id, prisma);
+      const listingCreated = await prisma.listings.create({
+        data: {
+          ...listingData,
+          contentUpdatedAt: dayjs(new Date()).subtract(2, 'days').toDate(),
+          externalJurisdictionId: 'externalJurisdictionId',
+          externalListingId: 'externalListingId',
+          externalURL: 'https://www.externalJurisdictionName.com',
+        },
+      });
+
+      const ingestParams = {
+        externalURL: 'https://www.externalJurisdictionName.com',
+        jurisdictionId: jurisdiction.id,
+        targetName: 'externalJurisdictionName',
+      };
+      const res = await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .send(ingestParams)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+
+      expect(res.body.success).toEqual(true);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const listings = await prisma.listings.findMany({
+        include: {
+          units: {
+            include: {
+              unitRentTypes: true,
+              unitTypes: true,
+            },
+          },
+        },
+        where: {
+          externalJurisdictionId: 'externalJurisdictionId',
+          jurisdictionId: jurisdiction.id,
+        },
+      });
+
+      expect(listings.length).toEqual(1);
+      expect(listings[0].id).not.toEqual(listingCreated.id);
+      expect(listings[0].contentUpdatedAt).not.toEqual(
+        listingCreated.contentUpdatedAt,
+      );
+      expect(listings[0].externalListingId).toEqual('externalListingId');
+      expect(listings[0].externalURL).toEqual(
+        'https://www.externalJurisdictionName.com',
+      );
+      expect(listings[0].units.length).toEqual(1);
+      expect(listings[0].units[0].unitRentTypes.name).toEqual(
+        UnitRentTypeEnum.fixed,
+      );
+      expect(listings[0].units[0].unitTypes.name).toEqual(UnitTypeEnum.studio);
+    });
+
+    it('should do nothing if external listing has not been updated', async () => {
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: jurisdictionFactory('doNothingExternalListing'),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdiction.id, prisma);
+      const listingData = await listingFactory(jurisdiction.id, prisma);
+      const listingCreated = await prisma.listings.create({
+        data: {
+          ...listingData,
+          contentUpdatedAt: new Date(),
+          externalJurisdictionId: 'externalJurisdictionId',
+          externalListingId: 'externalListingId',
+          externalURL: 'https://www.externalJurisdictionName.com',
+        },
+      });
+
+      const ingestParams = {
+        externalURL: 'https://www.externalJurisdictionName.com',
+        jurisdictionId: jurisdiction.id,
+        targetName: 'externalJurisdictionName',
+      };
+      const res = await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .send(ingestParams)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+
+      expect(res.body.success).toEqual(true);
+
+      const listings = await prisma.listings.findUnique({
+        where: {
+          id: listingCreated.id,
+        },
+      });
+
+      expect(listings.contentUpdatedAt).toEqual(
+        listingCreated.contentUpdatedAt,
+      );
+      expect(listings.externalListingId).toEqual('externalListingId');
+      expect(listings.externalURL).toEqual(
+        'https://www.externalJurisdictionName.com',
+      );
+    });
+  });
+});

--- a/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
@@ -65,6 +65,7 @@ import {
 } from './helpers';
 import { ApplicationFlaggedSetService } from '../../../src/services/application-flagged-set.service';
 import { featureFlagFactory } from '../../../prisma/seed-helpers/feature-flag-factory';
+import { randomUUID } from 'crypto';
 
 const testEmailService = {
   confirmation: jest.fn(),
@@ -1514,6 +1515,31 @@ describe('Testing Permissioning of endpoints as Admin User', () => {
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
         .expect(200);
+    });
+  });
+
+  describe('Testing external listing endpoints', () => {
+    it('should succeed for externalize endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/externalListings`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+
+    it.skip('should error as forbidden for ingest endpoint', async () => {
+      const body = {
+        externalURL: 'externalJurisdictionName.com',
+        jurisdictionId: randomUUID(),
+        targetName: 'externalJurisdictionName',
+      };
+
+      await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
+        .set('Cookie', cookies)
+        .expect(403);
     });
   });
 });

--- a/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
@@ -63,6 +63,7 @@ import {
   createSimpleListing,
 } from './helpers';
 import { ApplicationFlaggedSetService } from '../../../src/services/application-flagged-set.service';
+import { randomUUID } from 'crypto';
 
 const testEmailService = {
   confirmation: jest.fn(),
@@ -1437,6 +1438,31 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
       await request(app.getHttpServer())
         .get(`/featureFlags/example`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
+
+  describe('Testing external listing endpoints', () => {
+    it('should succeed for externalize endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/externalListings`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+
+    it.skip('should error as forbidden for ingest endpoint', async () => {
+      const body = {
+        externalURL: 'externalJurisdictionName.com',
+        jurisdictionId: randomUUID(),
+        targetName: 'externalJurisdictionName',
+      };
+
+      await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
         .set('Cookie', cookies)
         .expect(403);
     });

--- a/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
@@ -63,6 +63,7 @@ import {
   createSimpleListing,
 } from './helpers';
 import { ApplicationFlaggedSetService } from '../../../src/services/application-flagged-set.service';
+import { randomUUID } from 'crypto';
 
 const testEmailService = {
   confirmation: jest.fn(),
@@ -1376,6 +1377,31 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the wron
       await request(app.getHttpServer())
         .get(`/featureFlags/example`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
+
+  describe('Testing external listing endpoints', () => {
+    it('should succeed for externalize endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/externalListings`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+
+    it.skip('should error as forbidden for ingest endpoint', async () => {
+      const body = {
+        externalURL: 'externalJurisdictionName.com',
+        jurisdictionId: randomUUID(),
+        targetName: 'externalJurisdictionName',
+      };
+
+      await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
         .set('Cookie', cookies)
         .expect(403);
     });

--- a/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
@@ -63,6 +63,7 @@ import {
   createListing,
   createComplexApplication,
 } from './helpers';
+import { randomUUID } from 'crypto';
 
 const testEmailService = {
   confirmation: jest.fn(),
@@ -1287,6 +1288,31 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
       await request(app.getHttpServer())
         .get(`/featureFlags/example`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
+
+  describe('Testing external listing endpoints', () => {
+    it('should succeed for externalize endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/externalListings`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+
+    it.skip('should error as forbidden for ingest endpoint', async () => {
+      const body = {
+        externalURL: 'externalJurisdictionName.com',
+        jurisdictionId: randomUUID(),
+        targetName: 'externalJurisdictionName',
+      };
+
+      await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
         .set('Cookie', cookies)
         .expect(403);
     });

--- a/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
@@ -1359,4 +1359,29 @@ describe('Testing Permissioning of endpoints as partner with correct listing', (
         .expect(403);
     });
   });
+
+  describe('Testing external listing endpoints', () => {
+    it('should succeed for externalize endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/externalListings`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+
+    it.skip('should error as forbidden for ingest endpoint', async () => {
+      const body = {
+        externalURL: 'externalJurisdictionName.com',
+        jurisdictionId: randomUUID(),
+        targetName: 'externalJurisdictionName',
+      };
+
+      await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
 });

--- a/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
@@ -66,6 +66,7 @@ import {
   createSimpleApplication,
 } from './helpers';
 import { ApplicationFlaggedSetService } from '../../../src/services/application-flagged-set.service';
+import { randomUUID } from 'crypto';
 
 const testEmailService = {
   confirmation: jest.fn(),
@@ -1317,6 +1318,31 @@ describe('Testing Permissioning of endpoints as partner with wrong listing', () 
       await request(app.getHttpServer())
         .get(`/featureFlags/example`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
+
+  describe('Testing external listing endpoints', () => {
+    it('should succeed for externalize endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/externalListings`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+
+    it.skip('should error as forbidden for ingest endpoint', async () => {
+      const body = {
+        externalURL: 'externalJurisdictionName.com',
+        jurisdictionId: randomUUID(),
+        targetName: 'externalJurisdictionName',
+      };
+
+      await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
         .set('Cookie', cookies)
         .expect(403);
     });

--- a/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
@@ -64,6 +64,7 @@ import {
   createListing,
   createComplexApplication,
 } from './helpers';
+import { randomUUID } from 'crypto';
 
 const testEmailService = {
   confirmation: jest.fn(),
@@ -1358,6 +1359,31 @@ describe('Testing Permissioning of endpoints as public user', () => {
       await request(app.getHttpServer())
         .get(`/featureFlags/example`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(403);
+    });
+  });
+
+  describe('Testing external listing endpoints', () => {
+    it('should succeed for externalize endpoint', async () => {
+      await request(app.getHttpServer())
+        .get(`/externalListings`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+    });
+
+    it.skip('should error as forbidden for ingest endpoint', async () => {
+      const body = {
+        externalURL: 'externalJurisdictionName.com',
+        jurisdictionId: randomUUID(),
+        targetName: 'externalJurisdictionName',
+      };
+
+      await request(app.getHttpServer())
+        .put(`/externalListings/ingest`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send(body)
         .set('Cookie', cookies)
         .expect(403);
     });

--- a/api/test/jest-e2e.config.js
+++ b/api/test/jest-e2e.config.js
@@ -11,4 +11,5 @@ module.exports = {
       },
     ],
   },
+  setupFilesAfterEnv: ['jest-extended/all'],
 };

--- a/api/test/jest.config.js
+++ b/api/test/jest.config.js
@@ -11,4 +11,5 @@ module.exports = {
       },
     ],
   },
+  setupFilesAfterEnv: ['jest-extended/all'],
 };

--- a/api/test/unit/services/external-listing.service.spec.ts
+++ b/api/test/unit/services/external-listing.service.spec.ts
@@ -1,0 +1,880 @@
+import { AxiosResponse } from 'axios';
+import { randomUUID } from 'crypto';
+import dayjs from 'dayjs';
+import { Observable, of } from 'rxjs';
+import { HttpService } from '@nestjs/axios';
+import { HttpException, Logger } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ListingsStatusEnum } from '@prisma/client';
+import { randomNoun } from '../../../prisma/seed-helpers/word-generator';
+import { ExternalListingService } from '../../../src/services/external-listing.service';
+import { PrismaService } from '../../../src/services/prisma.service';
+
+describe('Testing external listing service', () => {
+  let httpService: HttpService;
+  let prisma: PrismaService;
+  let service: ExternalListingService;
+  const externalURL = 'example.com';
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExternalListingService,
+        Logger,
+        PrismaService,
+        {
+          provide: HttpService,
+          useValue: {
+            get: jest.fn(),
+            pipe: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    httpService = module.get<HttpService>(HttpService);
+    prisma = module.get<PrismaService>(PrismaService);
+    service = module.get<ExternalListingService>(ExternalListingService);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+  });
+
+  describe('Test externalize function', () => {
+    it('should return object with lists of needed info', async () => {
+      const jurisdictions = [
+        { id: randomUUID(), name: randomNoun() },
+        { id: randomUUID(), name: randomNoun() },
+      ];
+      const listings = [
+        {
+          id: randomUUID(),
+          contentUpdatedAt: new Date(),
+          jurisdictionId: randomUUID(),
+        },
+        {
+          id: randomUUID(),
+          contentUpdatedAt: new Date(),
+          jurisdictionId: randomUUID(),
+        },
+      ];
+      const reservedCommunityTypes = [
+        { id: randomUUID(), name: randomNoun() },
+        { id: randomUUID(), name: randomNoun() },
+      ];
+      const unitRentTypes = [
+        { id: randomUUID(), name: randomNoun() },
+        { id: randomUUID(), name: randomNoun() },
+      ];
+      const unitTypes = [
+        { id: randomUUID(), name: randomNoun() },
+        { id: randomUUID(), name: randomNoun() },
+      ];
+
+      prisma.jurisdictions.findMany = jest
+        .fn()
+        .mockResolvedValue(jurisdictions);
+      prisma.listings.findMany = jest.fn().mockResolvedValue(listings);
+      prisma.reservedCommunityTypes.findMany = jest
+        .fn()
+        .mockResolvedValue(reservedCommunityTypes);
+      prisma.unitRentTypes.findMany = jest
+        .fn()
+        .mockResolvedValue(unitRentTypes);
+      prisma.unitTypes.findMany = jest.fn().mockResolvedValue(unitTypes);
+
+      const response = await service.externalize();
+
+      expect(response).toStrictEqual({
+        jurisdictions,
+        listings,
+        reservedCommunityTypes,
+        unitRentTypes,
+        unitTypes,
+      });
+
+      expect(prisma.jurisdictions.findMany).toHaveBeenCalledExactlyOnceWith({
+        select: { id: true, name: true },
+      });
+      expect(prisma.listings.findMany).toHaveBeenCalledExactlyOnceWith({
+        select: { id: true, contentUpdatedAt: true, jurisdictionId: true },
+        where: { status: ListingsStatusEnum.active },
+      });
+      expect(
+        prisma.reservedCommunityTypes.findMany,
+      ).toHaveBeenCalledExactlyOnceWith({
+        select: { id: true, name: true },
+      });
+      expect(prisma.unitRentTypes.findMany).toHaveBeenCalledExactlyOnceWith({
+        select: { id: true, name: true },
+      });
+      expect(prisma.unitTypes.findMany).toHaveBeenCalledExactlyOnceWith({
+        select: { id: true, name: true },
+      });
+    });
+  });
+
+  describe.skip('Test ingest function', () => {
+    it('should error if external call fails', async () => {
+      const externalResponseFailure = { response: 'resp', status: '500' };
+
+      // Create a spy on the `get` method of `httpService` and mock the implementation
+      jest
+        .spyOn(httpService, 'get')
+        .mockImplementationOnce(
+          () =>
+            new Observable((subscriber) =>
+              subscriber.error(externalResponseFailure),
+            ),
+        );
+
+      await expect(
+        service.ingest({ externalURL: '', jurisdictionId: '', targetName: '' }),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('should error if nothing is returned', async () => {
+      // Create a spy on the `get` method of `httpService` and mock the implementation
+      const mockExternalDetailsResponse: AxiosResponse = {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {
+          headers: undefined,
+        },
+        data: {},
+      };
+
+      jest
+        .spyOn(httpService, 'get')
+        .mockImplementationOnce(() => of(mockExternalDetailsResponse));
+
+      await expect(
+        service.ingest({
+          externalURL: 'example.com',
+          jurisdictionId: randomUUID(),
+          targetName: 'mismatch',
+        }),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('should error if jurisdiction cannot be matched', async () => {
+      // Create a spy on the `get` method of `httpService` and mock the implementation
+      const mockExternalDetailsResponse: AxiosResponse = {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {
+          headers: undefined,
+        },
+        data: {
+          jurisdictions: [
+            { id: randomUUID(), name: randomNoun() },
+            { id: randomUUID(), name: randomNoun() },
+          ],
+          listings: [],
+          reservedCommunityTypes: [],
+          unitRentTypes: [],
+          unitTypes: [],
+        },
+      };
+
+      jest
+        .spyOn(httpService, 'get')
+        .mockImplementationOnce(() => of(mockExternalDetailsResponse));
+
+      await expect(
+        service.ingest({
+          externalURL: 'example.com',
+          jurisdictionId: randomUUID(),
+          targetName: 'mismatch',
+        }),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('should call createExternalListing if external listing does not exist in the system', async () => {
+      const externalJurisdictionId = randomUUID();
+      const externalListingDate = new Date();
+      const externalListingId = randomUUID();
+      const externalRCTId = randomUUID();
+      const externalURL = 'example.com';
+      const externalURTId = randomUUID();
+      const externalUTId = randomUUID();
+
+      const mockExternalDetailsResponse: AxiosResponse = {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {
+          headers: undefined,
+        },
+        data: {
+          jurisdictions: [
+            { id: externalJurisdictionId, name: 'targetJurisdiction' },
+          ],
+          listings: [
+            {
+              id: externalListingId,
+              contentUpdateAt: externalListingDate,
+              jurisdictionId: externalJurisdictionId,
+            },
+          ],
+          reservedCommunityTypes: [
+            { id: externalRCTId, name: 'targetReservedCommunityType' },
+          ],
+          unitRentTypes: [{ id: externalURTId, name: 'targetUnitRentType' }],
+          unitTypes: [{ id: externalUTId, name: 'targetUnitType' }],
+        },
+      };
+      const mockExternalListingResponse: AxiosResponse = {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {
+          headers: undefined,
+        },
+        data: {
+          id: externalListingId,
+          assets: [],
+          contentUpdatedAt: externalListingDate,
+          displayWaitlistSize: false,
+          isVerified: true,
+          jurisdictions: [],
+          name: 'example listing name',
+          reservedCommunityTypes: {
+            id: externalRCTId,
+            name: 'targetReservedCommunityType',
+          },
+          status: ListingsStatusEnum.active,
+          units: [],
+        },
+      };
+
+      jest
+        .spyOn(httpService, 'get')
+        .mockImplementationOnce(() => of(mockExternalDetailsResponse))
+        .mockImplementationOnce(() => of(mockExternalListingResponse));
+
+      const internalJurisdictionId = randomUUID();
+      const internalRCTId = randomUUID();
+      const internalURTId = randomUUID();
+      const internalUTId = randomUUID();
+
+      prisma.listings.create = jest.fn().mockResolvedValue({});
+      prisma.listings.findMany = jest.fn().mockResolvedValue([]);
+      prisma.reservedCommunityTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([
+          { id: internalRCTId, name: 'targetReservedCommunityType' },
+        ]);
+      prisma.unitRentTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([{ id: internalURTId, name: 'targetUnitRentType' }]);
+      prisma.unitTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([{ id: internalUTId, name: 'targetUnitType' }]);
+
+      const response = await service.ingest({
+        externalURL: externalURL,
+        jurisdictionId: internalJurisdictionId,
+        targetName: 'targetJurisdiction',
+      });
+
+      expect(response.success).toEqual(true);
+
+      expect(prisma.listings.create).toHaveBeenCalledOnce();
+    });
+
+    it('should delete and recreate a listing if external listing has been updated', async () => {
+      const externalJurisdictionId = randomUUID();
+      const externalListingDate = new Date();
+      const externalListingId = randomUUID();
+      const externalRCTId = randomUUID();
+      const externalURTId = randomUUID();
+      const externalUTId = randomUUID();
+
+      const mockExternalDetailsResponse: AxiosResponse = {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {
+          headers: undefined,
+        },
+        data: {
+          jurisdictions: [
+            { id: externalJurisdictionId, name: 'targetJurisdiction' },
+          ],
+          listings: [
+            {
+              id: externalListingId,
+              contentUpdateAt: externalListingDate,
+              jurisdictionId: externalJurisdictionId,
+            },
+          ],
+          reservedCommunityTypes: [
+            { id: externalRCTId, name: 'targetReservedCommunityType' },
+          ],
+          unitRentTypes: [{ id: externalURTId, name: 'targetUnitRentType' }],
+          unitTypes: [{ id: externalUTId, name: 'targetUnitType' }],
+        },
+      };
+      const mockExternalListingResponse: AxiosResponse = {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {
+          headers: undefined,
+        },
+        data: {
+          id: externalListingId,
+          assets: [],
+          contentUpdatedAt: externalListingDate,
+          displayWaitlistSize: false,
+          isVerified: true,
+          jurisdictions: [],
+          name: 'example listing name',
+          reservedCommunityTypes: {
+            id: externalRCTId,
+            name: 'targetReservedCommunityType',
+          },
+          status: ListingsStatusEnum.active,
+          units: [],
+        },
+      };
+
+      jest
+        .spyOn(httpService, 'get')
+        .mockImplementationOnce(() => of(mockExternalDetailsResponse))
+        .mockImplementationOnce(() => of(mockExternalListingResponse));
+
+      const internalJurisdictionId = randomUUID();
+      const internalListingDate = dayjs(new Date())
+        .subtract(1, 'days')
+        .toDate();
+      const internalListingId = randomUUID();
+      const internalRCTId = randomUUID();
+      const internalURTId = randomUUID();
+      const internalUTId = randomUUID();
+
+      prisma.listings.create = jest.fn().mockResolvedValue({});
+      prisma.listings.delete = jest.fn().mockResolvedValue(undefined);
+      prisma.listings.findMany = jest.fn().mockResolvedValue([
+        {
+          id: internalListingId,
+          contentUpdatedAt: internalListingDate,
+          externalListingId,
+        },
+      ]);
+      prisma.reservedCommunityTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([
+          { id: internalRCTId, name: 'targetReservedCommunityType' },
+        ]);
+      prisma.unitRentTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([{ id: internalURTId, name: 'targetUnitRentType' }]);
+      prisma.unitTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([{ id: internalUTId, name: 'targetUnitType' }]);
+
+      const response = await service.ingest({
+        externalURL: externalURL,
+        jurisdictionId: internalJurisdictionId,
+        targetName: 'targetJurisdiction',
+      });
+
+      expect(response.success).toEqual(true);
+
+      expect(prisma.listings.delete).toHaveBeenCalledWith({
+        where: { id: internalListingId },
+      });
+      expect(prisma.listings.create).toHaveBeenCalledOnce();
+    });
+
+    it('should do nothing if external listing has not been updated', async () => {
+      const externalJurisdictionId = randomUUID();
+      const externalListingDate = new Date();
+      const externalListingId = randomUUID();
+      const externalRCTId = randomUUID();
+      const externalURL = 'example.com';
+      const externalURTId = randomUUID();
+      const externalUTId = randomUUID();
+
+      const mockExternalDetailsResponse: AxiosResponse = {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {
+          headers: undefined,
+        },
+        data: {
+          jurisdictions: [
+            { id: externalJurisdictionId, name: 'targetJurisdiction' },
+          ],
+          listings: [
+            {
+              id: externalListingId,
+              contentUpdateAt: externalListingDate,
+              jurisdictionId: externalJurisdictionId,
+            },
+          ],
+          reservedCommunityTypes: [
+            { id: externalRCTId, name: 'targetReservedCommunityType' },
+          ],
+          unitRentTypes: [{ id: externalURTId, name: 'targetUnitRentType' }],
+          unitTypes: [{ id: externalUTId, name: 'targetUnitType' }],
+        },
+      };
+
+      jest
+        .spyOn(httpService, 'get')
+        .mockImplementationOnce(() => of(mockExternalDetailsResponse));
+
+      const internalJurisdictionId = randomUUID();
+      const internalListingId = randomUUID();
+      const internalRCTId = randomUUID();
+      const internalURTId = randomUUID();
+      const internalUTId = randomUUID();
+
+      prisma.listings.delete = jest.fn().mockResolvedValue(undefined);
+      prisma.listings.findMany = jest.fn().mockResolvedValue([
+        {
+          id: internalListingId,
+          contentUpdatedAt: externalListingDate,
+          externalListingId,
+        },
+      ]);
+      prisma.reservedCommunityTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([
+          { id: internalRCTId, name: 'targetReservedCommunityType' },
+        ]);
+      prisma.unitRentTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([{ id: internalURTId, name: 'targetUnitRentType' }]);
+      prisma.unitTypes.findMany = jest
+        .fn()
+        .mockResolvedValue([{ id: internalUTId, name: 'targetUnitType' }]);
+
+      const response = await service.ingest({
+        externalURL: externalURL,
+        jurisdictionId: internalJurisdictionId,
+        targetName: 'targetJurisdiction',
+      });
+
+      expect(response.success).toEqual(true);
+
+      expect(prisma.listings.findMany).toHaveBeenCalledExactlyOnceWith({
+        select: { id: true, contentUpdatedAt: true, externalListingId: true },
+        where: {
+          externalJurisdictionId: externalJurisdictionId,
+          jurisdictionId: internalJurisdictionId,
+        },
+      });
+      expect(
+        prisma.reservedCommunityTypes.findMany,
+      ).toHaveBeenCalledExactlyOnceWith({
+        select: { id: true, name: true },
+      });
+      expect(prisma.unitRentTypes.findMany).toHaveBeenCalledExactlyOnceWith({
+        select: { id: true, name: true },
+      });
+      expect(prisma.unitTypes.findMany).toHaveBeenCalledExactlyOnceWith({
+        select: { id: true, name: true },
+      });
+      expect(prisma.listings.delete).not.toHaveBeenCalled();
+    });
+
+    it('should delete a listing if no longer returned from external system', async () => {
+      const externalJurisdictionId = randomUUID();
+      const externalRCTId = randomUUID();
+      const externalURL = 'example.com';
+      const externalURTId = randomUUID();
+      const externalUTId = randomUUID();
+
+      const mockExternalDetailsResponse: AxiosResponse = {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {
+          headers: undefined,
+        },
+        data: {
+          jurisdictions: [
+            { id: externalJurisdictionId, name: 'targetJurisdiction' },
+          ],
+          listings: [],
+          reservedCommunityTypes: [
+            { id: externalRCTId, name: 'targetReservedCommunityType' },
+          ],
+          unitRentTypes: [{ id: externalURTId, name: 'targetUnitRentType' }],
+          unitTypes: [{ id: externalUTId, name: 'targetUnitType' }],
+        },
+      };
+
+      jest
+        .spyOn(httpService, 'get')
+        .mockImplementationOnce(() => of(mockExternalDetailsResponse));
+
+      const internalJurisdictionId = randomUUID();
+      const internalListingId = randomUUID();
+
+      prisma.listings.deleteMany = jest.fn().mockResolvedValue(undefined);
+      prisma.listings.findMany = jest.fn().mockResolvedValue([
+        {
+          id: internalListingId,
+          contentUpdatedAt: new Date(),
+          externalListingId: randomUUID(),
+        },
+      ]);
+      prisma.reservedCommunityTypes.findMany = jest.fn();
+      prisma.unitRentTypes.findMany = jest.fn();
+      prisma.unitTypes.findMany = jest.fn();
+
+      const response = await service.ingest({
+        externalURL: externalURL,
+        jurisdictionId: internalJurisdictionId,
+        targetName: 'targetJurisdiction',
+      });
+
+      expect(response.success).toEqual(true);
+
+      expect(prisma.reservedCommunityTypes.findMany).not.toHaveBeenCalled();
+      expect(prisma.unitRentTypes.findMany).not.toHaveBeenCalled();
+      expect(prisma.unitTypes.findMany).not.toHaveBeenCalled();
+
+      expect(prisma.listings.deleteMany).toHaveBeenCalledWith({
+        where: { id: { in: [internalListingId] } },
+      });
+    });
+  });
+
+  describe.skip('Test createExternalListing function', () => {
+    it('should error if external listing call fails', async () => {
+      const externalResponseFailure = { response: 'resp', status: '500' };
+
+      // Create a spy on the `get` method of `httpService` and mock the implementation
+      jest
+        .spyOn(httpService, 'get')
+        .mockImplementationOnce(
+          () =>
+            new Observable((subscriber) =>
+              subscriber.error(externalResponseFailure),
+            ),
+        );
+
+      await expect(
+        service.createExternalListing(
+          [],
+          [],
+          [],
+          { id: randomUUID(), name: 'targetJurisdiction' },
+          { id: randomUUID() },
+          '',
+          randomUUID(),
+        ),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('should return early if reserved community type is not matched', async () => {
+      const externalJurisdictionId = randomUUID();
+      const externalListingId = randomUUID();
+      const externalRCTId = randomUUID();
+      const externalURTId = randomUUID();
+      const externalUTId = randomUUID();
+
+      const mockExternalListingResponse: AxiosResponse = {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {
+          headers: undefined,
+        },
+        data: {
+          id: externalListingId,
+          assets: [
+            {
+              fileId: randomUUID(),
+              label: 'example asset',
+            },
+          ],
+          contentUpdatedAt: new Date(),
+          displayWaitlistSize: false,
+          isVerified: true,
+          jurisdictions: [
+            { id: externalJurisdictionId, name: 'targetJurisdiction' },
+          ],
+          name: 'example listing name',
+          reservedCommunityTypes: {
+            id: externalRCTId,
+            name: 'targetReservedCommunityType',
+          },
+          status: ListingsStatusEnum.active,
+          units: [
+            {
+              amiPercentage: '1',
+              annualIncomeMin: '2',
+              monthlyIncomeMin: '3',
+              floor: 4,
+              annualIncomeMax: '5',
+              maxOccupancy: 6,
+              minOccupancy: 7,
+              monthlyRent: '8',
+              numBathrooms: 9,
+              numBedrooms: 10,
+              number: '11',
+              sqFeet: '12',
+              monthlyRentAsPercentOfIncome: '13',
+              bmrProgramChart: true,
+              unitRentTypes: { id: externalURTId, name: 'targetUnitRentType' },
+              unitTypes: { id: externalUTId, name: 'targetUnitType' },
+            },
+          ],
+        },
+      };
+
+      jest
+        .spyOn(httpService, 'get')
+        .mockImplementationOnce(() => of(mockExternalListingResponse));
+
+      prisma.listings.create = jest.fn();
+
+      await service.createExternalListing(
+        [],
+        [],
+        [],
+        { id: externalJurisdictionId, name: 'targetJurisdiction' },
+        { id: externalListingId },
+        externalURL,
+        randomUUID(),
+      );
+
+      expect(prisma.listings.create).not.toHaveBeenCalled();
+    });
+
+    it('should create new listing based on external listing data', async () => {
+      const externalJurisdictionId = randomUUID();
+      const externalListingId = randomUUID();
+      const externalRCTId = randomUUID();
+      const externalURTId = randomUUID();
+      const externalUTId = randomUUID();
+
+      const mockExternalListingResponse: AxiosResponse = {
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {
+          headers: undefined,
+        },
+        data: {
+          id: externalListingId,
+          assets: [
+            {
+              fileId: randomUUID(),
+              label: 'example asset',
+            },
+          ],
+          contentUpdatedAt: new Date(),
+          displayWaitlistSize: false,
+          isVerified: true,
+          jurisdictions: [
+            { id: externalJurisdictionId, name: 'targetJurisdiction' },
+          ],
+          name: 'example listing name',
+          reservedCommunityTypes: {
+            id: externalRCTId,
+            name: 'targetReservedCommunityType',
+          },
+          status: ListingsStatusEnum.active,
+          units: [
+            {
+              amiPercentage: '1',
+              annualIncomeMax: '5',
+              annualIncomeMin: '2',
+              bmrProgramChart: true,
+              floor: 4,
+              maxOccupancy: 6,
+              minOccupancy: 7,
+              monthlyIncomeMin: '3',
+              monthlyRent: '8',
+              monthlyRentAsPercentOfIncome: '13',
+              numBathrooms: 9,
+              numBedrooms: 10,
+              number: '11',
+              sqFeet: '12',
+
+              unitRentTypes: { id: externalURTId, name: 'targetUnitRentType' },
+              unitTypes: { id: externalUTId, name: 'targetUnitType' },
+            },
+          ],
+        },
+      };
+
+      jest
+        .spyOn(httpService, 'get')
+        .mockImplementationOnce(() => of(mockExternalListingResponse));
+
+      const internalJurisdictionId = randomUUID();
+      const internalRCTId = randomUUID();
+      const internalURTId = randomUUID();
+      const internalUTId = randomUUID();
+
+      prisma.listings.create = jest.fn().mockReturnValue({});
+
+      await service.createExternalListing(
+        [{ internalId: internalRCTId, externalId: externalRCTId }],
+        [{ internalId: internalURTId, externalId: externalURTId }],
+        [{ internalId: internalUTId, externalId: externalUTId }],
+        { id: externalJurisdictionId, name: 'targetJurisdiction' },
+        { id: externalListingId },
+        externalURL,
+        internalJurisdictionId,
+      );
+
+      expect(prisma.listings.create).toHaveBeenCalledWith({
+        data: {
+          accessibility: undefined,
+          additionalApplicationSubmissionNotes: undefined,
+          allowsCats: undefined,
+          allowsDogs: undefined,
+          amenities: undefined,
+          applicationDueDate: undefined,
+          applicationFee: undefined,
+          applicationOpenDate: undefined,
+          applicationOrganization: undefined,
+          buildingTotalUnits: undefined,
+          cocInfo: undefined,
+          commonDigitalApplication: undefined,
+          communityDisclaimerDescription: undefined,
+          communityDisclaimerTitle: undefined,
+          configurableRegion: undefined,
+          contentUpdatedAt: expect.anything(),
+          costsNotIncluded: undefined,
+          creditHistory: undefined,
+          creditScreeningFee: undefined,
+          criminalBackground: undefined,
+          customMapPin: undefined,
+          depositHelperText: undefined,
+          depositMax: undefined,
+          depositMin: undefined,
+          depositType: undefined,
+          depositValue: undefined,
+          developer: undefined,
+          digitalApplication: undefined,
+          disableUnitsAccordion: undefined,
+          displayWaitlistSize: false,
+          externalJurisdictionId: externalJurisdictionId,
+          externalListingId: externalListingId,
+          externalURL: externalURL,
+          hasHudEbllClearance: undefined,
+          homeType: undefined,
+          householdSizeMax: undefined,
+          householdSizeMin: undefined,
+          includeCommunityDisclaimer: undefined,
+          isVerified: true,
+          isWaitlistOpen: undefined,
+          leasingAgentEmail: undefined,
+          leasingAgentName: undefined,
+          leasingAgentOfficeHours: undefined,
+          leasingAgentPhone: undefined,
+          leasingAgentTitle: undefined,
+          listingFileNumber: undefined,
+          listingType: undefined,
+          lotteryOptIn: undefined,
+          managementWebsite: undefined,
+          marketingMonth: undefined,
+          marketingSeason: undefined,
+          marketingType: undefined,
+          marketingYear: undefined,
+          name: 'example listing name',
+          neighborhood: undefined,
+          paperApplication: undefined,
+          parkingFee: undefined,
+          petPolicy: undefined,
+          postmarkedApplicationsReceivedByDate: undefined,
+          programRules: undefined,
+          publishedAt: undefined,
+          referralOpportunity: undefined,
+          rentalAssistance: undefined,
+          rentalHistory: undefined,
+          reservedCommunityDescription: undefined,
+          reservedCommunityMinAge: undefined,
+          reviewOrderType: undefined,
+          scheduledPublishAt: undefined,
+          scheduledApplicationOpenAt: undefined,
+          section8Acceptance: undefined,
+          servicesOffered: undefined,
+          smokingPolicy: undefined,
+          specialNotes: undefined,
+          status: ListingsStatusEnum.active,
+          unitAmenities: undefined,
+          unitsAvailable: undefined,
+          waitlistCurrentSize: undefined,
+          waitlistMaxSize: undefined,
+          waitlistOpenSpots: undefined,
+          whatToExpect: undefined,
+          whatToExpectAdditionalText: undefined,
+          yearBuilt: undefined,
+
+          assets: {
+            create: [
+              {
+                fileId: expect.anything(),
+                label: 'example asset',
+              },
+            ],
+          },
+          jurisdictions: {
+            connect: {
+              id: internalJurisdictionId,
+            },
+          },
+          listingImages: undefined,
+          listingsBuildingAddress: undefined,
+          reservedCommunityTypes: {
+            connect: {
+              id: internalRCTId,
+            },
+          },
+          unitGroups: undefined,
+          units: {
+            create: [
+              {
+                accessibilityPriorityType: undefined,
+                amiPercentage: '1',
+                annualIncomeMax: '5',
+                annualIncomeMin: '2',
+                bmrProgramChart: true,
+                floor: 4,
+                maxOccupancy: 6,
+                minOccupancy: 7,
+                monthlyIncomeMin: '3',
+                monthlyRent: '8',
+                monthlyRentAsPercentOfIncome: '13',
+                numBathrooms: 9,
+                numBedrooms: 10,
+                number: '11',
+                sqFeet: '12',
+
+                amiChart: undefined,
+                unitAmiChartOverrides: undefined,
+                unitRentTypes: {
+                  connect: {
+                    id: internalURTId,
+                  },
+                },
+                unitTypes: {
+                  connect: {
+                    id: internalUTId,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      });
+    });
+  });
+});

--- a/api/test/unit/services/external-listing.service.spec.ts
+++ b/api/test/unit/services/external-listing.service.spec.ts
@@ -95,22 +95,20 @@ describe('Testing external listing service', () => {
         unitTypes,
       });
 
-      expect(prisma.jurisdictions.findMany).toHaveBeenCalledExactlyOnceWith({
+      expect(prisma.jurisdictions.findMany).toHaveBeenCalledWith({
         select: { id: true, name: true },
       });
-      expect(prisma.listings.findMany).toHaveBeenCalledExactlyOnceWith({
+      expect(prisma.listings.findMany).toHaveBeenCalledWith({
         select: { id: true, contentUpdatedAt: true, jurisdictionId: true },
         where: { status: ListingsStatusEnum.active },
       });
-      expect(
-        prisma.reservedCommunityTypes.findMany,
-      ).toHaveBeenCalledExactlyOnceWith({
+      expect(prisma.reservedCommunityTypes.findMany).toHaveBeenCalledWith({
         select: { id: true, name: true },
       });
-      expect(prisma.unitRentTypes.findMany).toHaveBeenCalledExactlyOnceWith({
+      expect(prisma.unitRentTypes.findMany).toHaveBeenCalledWith({
         select: { id: true, name: true },
       });
-      expect(prisma.unitTypes.findMany).toHaveBeenCalledExactlyOnceWith({
+      expect(prisma.unitTypes.findMany).toHaveBeenCalledWith({
         select: { id: true, name: true },
       });
     });

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -774,8 +774,9 @@ describe('Testing listing service', () => {
           listingNeighborhoodAmenities: true,
           units: {
             include: {
-              unitTypes: true,
               unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
             },
           },
           unitGroups: {
@@ -895,8 +896,9 @@ describe('Testing listing service', () => {
           listingNeighborhoodAmenities: true,
           units: {
             include: {
-              unitTypes: true,
               unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
             },
           },
           unitGroups: {
@@ -1275,8 +1277,9 @@ describe('Testing listing service', () => {
           listingNeighborhoodAmenities: true,
           units: {
             include: {
-              unitTypes: true,
               unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
             },
           },
           unitGroups: {
@@ -2263,8 +2266,9 @@ describe('Testing listing service', () => {
           listingNeighborhoodAmenities: true,
           units: {
             include: {
-              unitTypes: true,
               unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
             },
           },
           unitGroups: {
@@ -2745,8 +2749,9 @@ describe('Testing listing service', () => {
           listingNeighborhoodAmenities: true,
           units: {
             include: {
-              unitTypes: true,
               unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
             },
           },
           unitGroups: {
@@ -3036,8 +3041,9 @@ describe('Testing listing service', () => {
           },
           units: {
             include: {
-              unitTypes: true,
               unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
             },
           },
         },

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -19,7 +19,8 @@
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["jest", "jest-extended"]
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1420,6 +1420,11 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
+"@jest/diff-sequences@30.0.1":
+  version "30.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz#0ededeae4d071f5c8ffe3678d15f3a1be09156be"
+  integrity sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==
+
 "@jest/environment@^29.6.4":
   version "29.6.4"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.6.4.tgz#78ec2c9f8c8829a37616934ff4fea0c028c79f4f"
@@ -1464,6 +1469,11 @@
     jest-mock "^29.6.3"
     jest-util "^29.6.3"
 
+"@jest/get-type@30.1.0":
+  version "30.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/get-type/-/get-type-30.1.0.tgz#4fcb4dc2ebcf0811be1c04fd1cb79c2dba431cbc"
+  integrity sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==
+
 "@jest/globals@^29.6.4":
   version "29.6.4"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.6.4.tgz#4f04f58731b062b44ef23036b79bdb31f40c7f63"
@@ -1503,6 +1513,13 @@
     string-length "^4.0.1"
     strip-ansi "^6.0.0"
     v8-to-istanbul "^9.0.1"
+
+"@jest/schemas@30.0.5":
+  version "30.0.5"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-30.0.5.tgz#7bdf69fc5a368a5abdb49fd91036c55225846473"
+  integrity sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==
+  dependencies:
+    "@sinclair/typebox" "^0.34.0"
 
 "@jest/schemas@^29.6.0":
   version "29.6.0"
@@ -1977,6 +1994,11 @@
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+
+"@sinclair/typebox@^0.34.0":
+  version "0.34.47"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.34.47.tgz#61b684d8a20d2890b9f1f7b0d4f76b4b39f5bc0d"
+  integrity sha512-ZGIBQ+XDvO5JQku9wmwtabcVTHJsgSWAHYtVuM9pBNNR5E88v6Jcj/llpmsjivig5X8A8HHOb4/mbEKPS5EvAw==
 
 "@sinonjs/commons@^3.0.0":
   version "3.0.0"
@@ -3465,7 +3487,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^5.0.0:
+ansi-styles@^5.0.0, ansi-styles@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
@@ -6054,6 +6076,16 @@ jest-diff@^29.6.4:
     jest-get-type "^29.6.3"
     pretty-format "^29.6.3"
 
+jest-diff@^30.0.0:
+  version "30.2.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-30.2.0.tgz#e3ec3a6ea5c5747f605c9e874f83d756cba36825"
+  integrity sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==
+  dependencies:
+    "@jest/diff-sequences" "30.0.1"
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    pretty-format "30.2.0"
+
 jest-docblock@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.6.3.tgz#293dca5188846c9f7c0c2b1bb33e5b11f21645f2"
@@ -6083,6 +6115,13 @@ jest-environment-node@^29.6.4:
     "@types/node" "*"
     jest-mock "^29.6.3"
     jest-util "^29.6.3"
+
+jest-extended@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/jest-extended/-/jest-extended-7.0.0.tgz#ad6aa4601959bcd58f4676af53cec66a6c0f64ee"
+  integrity sha512-96jBsVJDxZKFh+kWY7E18Is2usUsUYtBn97MxCtb4COnbgD4aE1h+P0fdFQNeJaI6KOeduas4Numc9yTuk0+Gw==
+  dependencies:
+    jest-diff "^30.0.0"
 
 jest-get-type@^29.4.3:
   version "29.4.3"
@@ -6170,13 +6209,6 @@ jest-message-util@^29.6.3:
     pretty-format "^29.6.3"
     slash "^3.0.0"
     stack-utils "^2.0.3"
-
-jest-mock-extended@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/jest-mock-extended/-/jest-mock-extended-3.0.7.tgz#3d902dabad99d7831bbe5fccee85ab0371c22675"
-  integrity sha512-7lsKdLFcW9B9l5NzZ66S/yTQ9k8rFtnwYdCNuRU/81fqDWicNDVhitTSPnrGmNeNm0xyw0JHexEOShrIKRCIRQ==
-  dependencies:
-    ts-essentials "^10.0.0"
 
 jest-mock@^29.6.3:
   version "29.6.3"
@@ -7401,6 +7433,15 @@ prettier@^2.3.2, prettier@^2.7.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
+pretty-format@30.2.0:
+  version "30.2.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-30.2.0.tgz#2d44fe6134529aed18506f6d11509d8a62775ebe"
+  integrity sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==
+  dependencies:
+    "@jest/schemas" "30.0.5"
+    ansi-styles "^5.2.0"
+    react-is "^18.3.1"
+
 pretty-format@^29.0.0, pretty-format@^29.6.2:
   version "29.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.6.2.tgz#3d5829261a8a4d89d8b9769064b29c50ed486a47"
@@ -7567,6 +7608,11 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-is@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.2.2, readable-stream@~2.3.6:
   version "2.3.8"
@@ -8336,11 +8382,6 @@ tree-kill@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
-
-ts-essentials@^10.0.0:
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-10.0.2.tgz#8c7aa74ed79580ffe49df5ca28d06cc6bea0ff3c"
-  integrity sha512-Xwag0TULqriaugXqVdDiGZ5wuZpqABZlpwQ2Ho4GDyiu/R2Xjkp/9+zcFxL7uzeLl/QCPrflnvpVYyS3ouT7Zw==
 
 ts-jest@~29.1.1:
   version "29.1.1"

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -5,12 +5,23 @@
 /** Generate by swagger-axios-codegen */
 /* eslint-disable */
 // @ts-nocheck
-import axiosStatic, { AxiosInstance, AxiosRequestConfig } from "axios"
+import axiosStatic from "axios"
+import type { AxiosInstance, AxiosRequestConfig } from "axios"
 
 export interface IRequestOptions extends AxiosRequestConfig {
-  /** only in axios interceptor config*/
+  /**
+   * show loading status
+   */
   loading?: boolean
+  /**
+   * display error message
+   */
   showError?: boolean
+  /**
+   * indicates whether Authorization credentials are required for the request
+   * @default true
+   */
+  withAuthorization?: boolean
 }
 
 export interface IRequestConfig {
@@ -112,8 +123,6 @@ export class RootService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -126,8 +135,6 @@ export class RootService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -139,10 +146,6 @@ export class RootService {
       let url = basePath + "/clearTempFiles"
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
-
-      let data = null
-
-      configs.data = data
 
       axios(configs, resolve, reject)
     })
@@ -186,8 +189,6 @@ export class ListingsService {
         search: params["search"],
       }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -227,6 +228,10 @@ export class ListingsService {
       let url = basePath + "/listings"
 
       const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
+
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
 
       let data = params.body
 
@@ -273,8 +278,6 @@ export class ListingsService {
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
       configs.params = { timeZone: params["timeZone"] }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -286,8 +289,6 @@ export class ListingsService {
       let url = basePath + "/listings/mapMarkers"
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -310,8 +311,6 @@ export class ListingsService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
       configs.params = { view: params["view"] }
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -346,10 +345,6 @@ export class ListingsService {
       let url = basePath + "/listings/closeListings"
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
-
-      let data = null
-
-      configs.data = data
 
       axios(configs, resolve, reject)
     })
@@ -398,8 +393,6 @@ export class ListingsService {
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
       configs.params = { view: params["view"] }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -418,8 +411,6 @@ export class ListingsService {
       url = url.replace("{multiselectQuestionId}", params["multiselectQuestionId"] + "")
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -457,8 +448,6 @@ export class ApplicationFlaggedSetsService {
         search: params["search"],
       }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -492,8 +481,6 @@ export class ApplicationFlaggedSetsService {
         search: params["search"],
       }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -512,8 +499,6 @@ export class ApplicationFlaggedSetsService {
       url = url.replace("{afsId}", params["afsId"] + "")
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -549,10 +534,6 @@ export class ApplicationFlaggedSetsService {
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
-      let data = null
-
-      configs.data = data
-
       axios(configs, resolve, reject)
     })
   }
@@ -573,10 +554,6 @@ export class ApplicationFlaggedSetsService {
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
       configs.params = { listingId: params["listingId"], force: params["force"] }
-
-      let data = null
-
-      configs.data = data
 
       axios(configs, resolve, reject)
     })
@@ -622,8 +599,6 @@ export class AmiChartsService {
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
       configs.params = { jurisdictionId: params["jurisdictionId"] }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -664,6 +639,10 @@ export class AmiChartsService {
 
       const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
 
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
+
       let data = params.body
 
       configs.data = data
@@ -686,8 +665,6 @@ export class AmiChartsService {
       url = url.replace("{amiChartId}", params["amiChartId"] + "")
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -733,8 +710,6 @@ export class ReservedCommunityTypesService {
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
       configs.params = { jurisdictionId: params["jurisdictionId"] }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -775,6 +750,10 @@ export class ReservedCommunityTypesService {
 
       const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
 
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
+
       let data = params.body
 
       configs.data = data
@@ -797,8 +776,6 @@ export class ReservedCommunityTypesService {
       url = url.replace("{reservedCommunityTypeId}", params["reservedCommunityTypeId"] + "")
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -836,8 +813,6 @@ export class UnitTypesService {
       let url = basePath + "/unitTypes"
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -879,6 +854,10 @@ export class UnitTypesService {
 
       const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
 
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
+
       let data = params.body
 
       configs.data = data
@@ -901,8 +880,6 @@ export class UnitTypesService {
       url = url.replace("{unitTypeId}", params["unitTypeId"] + "")
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -940,8 +917,6 @@ export class UnitAccessibilityPriorityTypesService {
       let url = basePath + "/unitAccessibilityPriorityTypes"
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -983,6 +958,10 @@ export class UnitAccessibilityPriorityTypesService {
 
       const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
 
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
+
       let data = params.body
 
       configs.data = data
@@ -1008,8 +987,6 @@ export class UnitAccessibilityPriorityTypesService {
       )
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -1047,8 +1024,6 @@ export class UnitRentTypesService {
       let url = basePath + "/unitRentTypes"
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -1090,6 +1065,10 @@ export class UnitRentTypesService {
 
       const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
 
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
+
       let data = params.body
 
       configs.data = data
@@ -1112,8 +1091,6 @@ export class UnitRentTypesService {
       url = url.replace("{unitRentTypeId}", params["unitRentTypeId"] + "")
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -1151,8 +1128,6 @@ export class JurisdictionsService {
       let url = basePath + "/jurisdictions"
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -1194,6 +1169,10 @@ export class JurisdictionsService {
 
       const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
 
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
+
       let data = params.body
 
       configs.data = data
@@ -1216,8 +1195,6 @@ export class JurisdictionsService {
       url = url.replace("{jurisdictionId}", params["jurisdictionId"] + "")
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -1260,8 +1237,6 @@ export class JurisdictionsService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -1283,8 +1258,6 @@ export class MultiselectQuestionsService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
       configs.params = { filter: params["filter"] }
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -1326,6 +1299,10 @@ export class MultiselectQuestionsService {
 
       const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
 
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
+
       let data = params.body
 
       configs.data = data
@@ -1348,8 +1325,6 @@ export class MultiselectQuestionsService {
       url = url.replace("{multiselectQuestionId}", params["multiselectQuestionId"] + "")
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -1418,8 +1393,6 @@ export class ApplicationsService {
         markedAsDuplicate: params["markedAsDuplicate"],
       }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -1460,6 +1433,10 @@ export class ApplicationsService {
 
       const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
 
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
+
       let data = params.body
 
       configs.data = data
@@ -1482,8 +1459,6 @@ export class ApplicationsService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
       configs.params = { userId: params["userId"] }
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -1512,8 +1487,6 @@ export class ApplicationsService {
         includeLotteryApps: params["includeLotteryApps"],
       }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -1540,8 +1513,6 @@ export class ApplicationsService {
         includeDemographics: params["includeDemographics"],
         timeZone: params["timeZone"],
       }
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -1570,8 +1541,6 @@ export class ApplicationsService {
         timeZone: params["timeZone"],
       }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -1598,8 +1567,6 @@ export class ApplicationsService {
         includeDemographics: params["includeDemographics"],
         timeZone: params["timeZone"],
       }
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -1628,8 +1595,6 @@ export class ApplicationsService {
         timeZone: params["timeZone"],
       }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -1648,8 +1613,6 @@ export class ApplicationsService {
       url = url.replace("{applicationId}", params["applicationId"] + "")
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -1760,8 +1723,6 @@ export class UserService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -1779,6 +1740,10 @@ export class UserService {
       let url = basePath + "/user"
 
       const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
+
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
 
       let data = params.body
 
@@ -1839,8 +1804,6 @@ export class UserService {
         search: params["search"],
       }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -1852,8 +1815,6 @@ export class UserService {
       let url = basePath + "/user/csv"
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -2006,8 +1967,6 @@ export class UserService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -2071,8 +2030,6 @@ export class UserService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -2132,8 +2089,6 @@ export class AuthService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -2167,8 +2122,6 @@ export class AuthService {
       let url = basePath + "/auth/requestNewToken"
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -2236,8 +2189,6 @@ export class MapLayersService {
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
       configs.params = { jurisdictionId: params["jurisdictionId"] }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -2252,10 +2203,6 @@ export class ScriptRunnerService {
       let url = basePath + "/scriptRunner/exampleScript"
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
-
-      let data = null
-
-      configs.data = data
 
       axios(configs, resolve, reject)
     })
@@ -2335,10 +2282,6 @@ export class ScriptRunnerService {
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
-      let data = null
-
-      configs.data = data
-
       axios(configs, resolve, reject)
     })
   }
@@ -2351,10 +2294,6 @@ export class ScriptRunnerService {
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
-      let data = null
-
-      configs.data = data
-
       axios(configs, resolve, reject)
     })
   }
@@ -2366,10 +2305,6 @@ export class ScriptRunnerService {
       let url = basePath + "/scriptRunner/optOutExistingLotteries"
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
-
-      let data = null
-
-      configs.data = data
 
       axios(configs, resolve, reject)
     })
@@ -2405,10 +2340,6 @@ export class ScriptRunnerService {
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
-      let data = null
-
-      configs.data = data
-
       axios(configs, resolve, reject)
     })
   }
@@ -2423,10 +2354,6 @@ export class ScriptRunnerService {
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
-      let data = null
-
-      configs.data = data
-
       axios(configs, resolve, reject)
     })
   }
@@ -2438,10 +2365,6 @@ export class ScriptRunnerService {
       let url = basePath + "/scriptRunner/insertSanJoseMapLayers"
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
-
-      let data = null
-
-      configs.data = data
 
       axios(configs, resolve, reject)
     })
@@ -2455,10 +2378,6 @@ export class ScriptRunnerService {
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
-      let data = null
-
-      configs.data = data
-
       axios(configs, resolve, reject)
     })
   }
@@ -2470,10 +2389,6 @@ export class ScriptRunnerService {
       let url = basePath + "/scriptRunner/updatesWhatHappensInLotteryEmail"
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
-
-      let data = null
-
-      configs.data = data
 
       axios(configs, resolve, reject)
     })
@@ -2487,10 +2402,6 @@ export class ScriptRunnerService {
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
-      let data = null
-
-      configs.data = data
-
       axios(configs, resolve, reject)
     })
   }
@@ -2503,10 +2414,6 @@ export class ScriptRunnerService {
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
-      let data = null
-
-      configs.data = data
-
       axios(configs, resolve, reject)
     })
   }
@@ -2518,10 +2425,6 @@ export class ScriptRunnerService {
       let url = basePath + "/scriptRunner/correctLegacyMSQData"
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
-
-      let data = null
-
-      configs.data = data
 
       axios(configs, resolve, reject)
     })
@@ -2537,8 +2440,6 @@ export class FeatureFlagsService {
       let url = basePath + "/featureFlags"
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -2602,6 +2503,10 @@ export class FeatureFlagsService {
 
       const configs: IRequestConfig = getConfigs("delete", "application/json", url, options)
 
+      /** 适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body */
+
+      console.warn("适配移动开发（iOS13 等版本），只有 POST、PUT 等请求允许带body")
+
       let data = params.body
 
       configs.data = data
@@ -2640,10 +2545,6 @@ export class FeatureFlagsService {
 
       const configs: IRequestConfig = getConfigs("post", "application/json", url, options)
 
-      let data = null
-
-      configs.data = data
-
       axios(configs, resolve, reject)
     })
   }
@@ -2662,8 +2563,6 @@ export class FeatureFlagsService {
       url = url.replace("{featureFlagId}", params["featureFlagId"] + "")
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -2717,8 +2616,6 @@ export class LotteryService {
         timeZone: params["timeZone"],
       }
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -2745,8 +2642,6 @@ export class LotteryService {
         includeDemographics: params["includeDemographics"],
         timeZone: params["timeZone"],
       }
-
-      /** 适配ios13，get请求不允许带body */
 
       axios(configs, resolve, reject)
     })
@@ -2789,8 +2684,6 @@ export class LotteryService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -2803,10 +2696,6 @@ export class LotteryService {
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
 
-      let data = null
-
-      configs.data = data
-
       axios(configs, resolve, reject)
     })
   }
@@ -2818,10 +2707,6 @@ export class LotteryService {
       let url = basePath + "/lottery/expireLotteries"
 
       const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
-
-      let data = null
-
-      configs.data = data
 
       axios(configs, resolve, reject)
     })
@@ -2842,8 +2727,6 @@ export class LotteryService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
-      /** 适配ios13，get请求不允许带body */
-
       axios(configs, resolve, reject)
     })
   }
@@ -2863,18 +2746,33 @@ export class LotteryService {
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
-      /** 适配ios13，get请求不允许带body */
+      axios(configs, resolve, reject)
+    })
+  }
+}
+
+export class ExternalListingsService {
+  /**
+   * Get an object of externalized system data details
+   */
+  externalize(options: IRequestOptions = {}): Promise<ExternalizedDetails> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/externalListings"
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
       axios(configs, resolve, reject)
     })
   }
 }
 
+/** SuccessDTO */
 export interface SuccessDTO {
   /**  */
   success: boolean
 }
 
+/** ListingFilterParams */
 export interface ListingFilterParams {
   /**  */
   $comparison: EnumListingFilterParamsComparison
@@ -2946,6 +2844,7 @@ export interface ListingFilterParams {
   zipCode?: string
 }
 
+/** ListingsQueryBody */
 export interface ListingsQueryBody {
   /**  */
   page?: number
@@ -2969,6 +2868,7 @@ export interface ListingsQueryBody {
   search?: string
 }
 
+/** ListingsQueryParams */
 export interface ListingsQueryParams {
   /**  */
   page?: number
@@ -2992,16 +2892,19 @@ export interface ListingsQueryParams {
   search?: string
 }
 
+/** ListingFilterKeyDTO */
 export interface ListingFilterKeyDTO {
   /**  */
   value?: ListingFilterKeys
 }
 
+/** ListingsRetrieveParams */
 export interface ListingsRetrieveParams {
   /**  */
   view?: ListingViews
 }
 
+/** PaginationAllowsAllQueryParams */
 export interface PaginationAllowsAllQueryParams {
   /**  */
   page?: number
@@ -3010,6 +2913,7 @@ export interface PaginationAllowsAllQueryParams {
   limit?: number | "all"
 }
 
+/** IdDTO */
 export interface IdDTO {
   /**  */
   id: string
@@ -3021,6 +2925,7 @@ export interface IdDTO {
   ordinal?: number
 }
 
+/** MultiselectLink */
 export interface MultiselectLink {
   /**  */
   title: string
@@ -3029,6 +2934,7 @@ export interface MultiselectLink {
   url: string
 }
 
+/** MultiselectOption */
 export interface MultiselectOption {
   /**  */
   text: string
@@ -3070,6 +2976,7 @@ export interface MultiselectOption {
   mapPinPosition?: string
 }
 
+/** MultiselectQuestion */
 export interface MultiselectQuestion {
   /**  */
   id: string
@@ -3114,6 +3021,7 @@ export interface MultiselectQuestion {
   applicationSection: MultiselectQuestionsApplicationSectionEnum
 }
 
+/** ListingMultiselectQuestion */
 export interface ListingMultiselectQuestion {
   /**  */
   multiselectQuestions: MultiselectQuestion
@@ -3122,6 +3030,7 @@ export interface ListingMultiselectQuestion {
   ordinal?: number
 }
 
+/** Asset */
 export interface Asset {
   /**  */
   id: string
@@ -3139,6 +3048,7 @@ export interface Asset {
   label: string
 }
 
+/** PaperApplication */
 export interface PaperApplication {
   /**  */
   id: string
@@ -3156,6 +3066,7 @@ export interface PaperApplication {
   assets: Asset
 }
 
+/** ApplicationMethod */
 export interface ApplicationMethod {
   /**  */
   id: string
@@ -3185,6 +3096,7 @@ export interface ApplicationMethod {
   paperApplications?: PaperApplication[]
 }
 
+/** ListingEvent */
 export interface ListingEvent {
   /**  */
   id: string
@@ -3220,6 +3132,7 @@ export interface ListingEvent {
   assets?: Asset
 }
 
+/** Address */
 export interface Address {
   /**  */
   id: string
@@ -3258,6 +3171,7 @@ export interface Address {
   longitude?: number
 }
 
+/** ListingImage */
 export interface ListingImage {
   /**  */
   assets: Asset
@@ -3266,6 +3180,7 @@ export interface ListingImage {
   ordinal?: number
 }
 
+/** ListingFeatures */
 export interface ListingFeatures {
   /**  */
   elevator?: boolean
@@ -3328,6 +3243,7 @@ export interface ListingFeatures {
   loweredCabinets?: boolean
 }
 
+/** ListingUtilities */
 export interface ListingUtilities {
   /**  */
   water?: boolean
@@ -3354,6 +3270,7 @@ export interface ListingUtilities {
   internet?: boolean
 }
 
+/** AmiChartItem */
 export interface AmiChartItem {
   /**  */
   percentOfAmi: number
@@ -3365,6 +3282,7 @@ export interface AmiChartItem {
   income: number
 }
 
+/** AmiChart */
 export interface AmiChart {
   /**  */
   id: string
@@ -3385,6 +3303,7 @@ export interface AmiChart {
   jurisdictions: IdDTO
 }
 
+/** UnitType */
 export interface UnitType {
   /**  */
   id: string
@@ -3402,6 +3321,7 @@ export interface UnitType {
   numBedrooms: number
 }
 
+/** UnitRentType */
 export interface UnitRentType {
   /**  */
   id: string
@@ -3416,6 +3336,7 @@ export interface UnitRentType {
   name: UnitRentTypeEnum
 }
 
+/** UnitAccessibilityPriorityType */
 export interface UnitAccessibilityPriorityType {
   /**  */
   id: string
@@ -3430,6 +3351,7 @@ export interface UnitAccessibilityPriorityType {
   name: string
 }
 
+/** UnitAmiChartOverride */
 export interface UnitAmiChartOverride {
   /**  */
   id: string
@@ -3444,6 +3366,7 @@ export interface UnitAmiChartOverride {
   items: AmiChartItem[]
 }
 
+/** Unit */
 export interface Unit {
   /**  */
   id: string
@@ -3512,6 +3435,7 @@ export interface Unit {
   unitAmiChartOverrides?: UnitAmiChartOverride
 }
 
+/** UnitGroupAmiLevel */
 export interface UnitGroupAmiLevel {
   /**  */
   id: string
@@ -3538,6 +3462,7 @@ export interface UnitGroupAmiLevel {
   amiChart?: AmiChart
 }
 
+/** UnitGroup */
 export interface UnitGroup {
   /**  */
   id: string
@@ -3591,6 +3516,7 @@ export interface UnitGroup {
   unitTypes?: UnitType[]
 }
 
+/** MinMaxCurrency */
 export interface MinMaxCurrency {
   /**  */
   min: string
@@ -3599,6 +3525,7 @@ export interface MinMaxCurrency {
   max: string
 }
 
+/** MinMax */
 export interface MinMax {
   /**  */
   min: number
@@ -3607,6 +3534,7 @@ export interface MinMax {
   max: number
 }
 
+/** UnitSummary */
 export interface UnitSummary {
   /**  */
   unitTypes: UnitType
@@ -3633,6 +3561,7 @@ export interface UnitSummary {
   floorRange?: MinMax
 }
 
+/** UnitSummaryByAMI */
 export interface UnitSummaryByAMI {
   /**  */
   percent: string
@@ -3641,6 +3570,7 @@ export interface UnitSummaryByAMI {
   byUnitType: UnitSummary[]
 }
 
+/** HMI */
 export interface HMI {
   /**  */
   columns: object
@@ -3649,6 +3579,7 @@ export interface HMI {
   rows: object[]
 }
 
+/** UnitsSummarized */
 export interface UnitsSummarized {
   /**  */
   unitTypes: UnitType[]
@@ -3672,6 +3603,7 @@ export interface UnitsSummarized {
   hmi: HMI
 }
 
+/** UnitGroupSummary */
 export interface UnitGroupSummary {
   /**  */
   unitTypes?: UnitType[]
@@ -3701,6 +3633,7 @@ export interface UnitGroupSummary {
   bathroomRange?: MinMax
 }
 
+/** HMIColumns */
 export interface HMIColumns {
   /**  */
   "20"?: number
@@ -3754,6 +3687,7 @@ export interface HMIColumns {
   householdSize: string
 }
 
+/** HouseholdMaxIncomeSummary */
 export interface HouseholdMaxIncomeSummary {
   /**  */
   columns: HMIColumns
@@ -3762,6 +3696,7 @@ export interface HouseholdMaxIncomeSummary {
   rows: HMIColumns[]
 }
 
+/** UnitGroupsSummarized */
 export interface UnitGroupsSummarized {
   /**  */
   unitGroupSummary: UnitGroupSummary[]
@@ -3770,6 +3705,7 @@ export interface UnitGroupsSummarized {
   householdMaxIncomeSummary: HouseholdMaxIncomeSummary
 }
 
+/** UnitsSummary */
 export interface UnitsSummary {
   /**  */
   id: string
@@ -3823,6 +3759,7 @@ export interface UnitsSummary {
   totalAvailable?: number
 }
 
+/** ApplicationLotteryTotal */
 export interface ApplicationLotteryTotal {
   /**  */
   listingId: string
@@ -3834,6 +3771,7 @@ export interface ApplicationLotteryTotal {
   total: number
 }
 
+/** ListingNeighborhoodAmenities */
 export interface ListingNeighborhoodAmenities {
   /**  */
   groceryStores?: string
@@ -3854,6 +3792,7 @@ export interface ListingNeighborhoodAmenities {
   healthCareResources?: string
 }
 
+/** Listing */
 export interface Listing {
   /**  */
   id: string
@@ -4192,6 +4131,7 @@ export interface Listing {
   listingNeighborhoodAmenities?: ListingNeighborhoodAmenities
 }
 
+/** PaginationMeta */
 export interface PaginationMeta {
   /**  */
   currentPage: number
@@ -4209,6 +4149,7 @@ export interface PaginationMeta {
   totalPages: number
 }
 
+/** PaginatedListing */
 export interface PaginatedListing {
   /**  */
   items: Listing[]
@@ -4217,6 +4158,7 @@ export interface PaginatedListing {
   meta: PaginationMeta
 }
 
+/** ListingMapMarker */
 export interface ListingMapMarker {
   /**  */
   id: string
@@ -4228,11 +4170,13 @@ export interface ListingMapMarker {
   lng: number
 }
 
+/** UnitAmiChartOverrideCreate */
 export interface UnitAmiChartOverrideCreate {
   /**  */
   items: AmiChartItem[]
 }
 
+/** UnitCreate */
 export interface UnitCreate {
   /**  */
   amiPercentage?: string
@@ -4292,6 +4236,7 @@ export interface UnitCreate {
   unitAmiChartOverrides?: UnitAmiChartOverrideCreate
 }
 
+/** UnitGroupAmiLevelCreate */
 export interface UnitGroupAmiLevelCreate {
   /**  */
   amiPercentage?: number
@@ -4309,6 +4254,7 @@ export interface UnitGroupAmiLevelCreate {
   amiChart?: IdDTO
 }
 
+/** UnitGroupCreate */
 export interface UnitGroupCreate {
   /**  */
   maxOccupancy?: number
@@ -4353,6 +4299,7 @@ export interface UnitGroupCreate {
   unitGroupAmiLevels?: UnitGroupAmiLevelCreate[]
 }
 
+/** AssetCreate */
 export interface AssetCreate {
   /**  */
   fileId: string
@@ -4364,6 +4311,7 @@ export interface AssetCreate {
   id?: string
 }
 
+/** PaperApplicationCreate */
 export interface PaperApplicationCreate {
   /**  */
   language: LanguagesEnum
@@ -4372,6 +4320,7 @@ export interface PaperApplicationCreate {
   assets?: AssetCreate
 }
 
+/** ApplicationMethodCreate */
 export interface ApplicationMethodCreate {
   /**  */
   type: ApplicationMethodsTypeEnum
@@ -4392,6 +4341,7 @@ export interface ApplicationMethodCreate {
   paperApplications?: PaperApplicationCreate[]
 }
 
+/** UnitsSummaryCreate */
 export interface UnitsSummaryCreate {
   /**  */
   unitTypes: IdDTO
@@ -4442,6 +4392,7 @@ export interface UnitsSummaryCreate {
   totalAvailable?: number
 }
 
+/** ListingImageCreate */
 export interface ListingImageCreate {
   /**  */
   ordinal?: number
@@ -4450,6 +4401,7 @@ export interface ListingImageCreate {
   assets: AssetCreate
 }
 
+/** AddressCreate */
 export interface AddressCreate {
   /**  */
   placeName?: string
@@ -4479,6 +4431,7 @@ export interface AddressCreate {
   longitude?: number
 }
 
+/** ListingEventCreate */
 export interface ListingEventCreate {
   /**  */
   type: ListingEventsTypeEnum
@@ -4505,6 +4458,7 @@ export interface ListingEventCreate {
   assets?: AssetCreate
 }
 
+/** ListingCreate */
 export interface ListingCreate {
   /**  */
   additionalApplicationSubmissionNotes?: string
@@ -4804,6 +4758,7 @@ export interface ListingCreate {
   requestedChangesUser?: IdDTO
 }
 
+/** ListingDuplicate */
 export interface ListingDuplicate {
   /**  */
   name: string
@@ -4815,6 +4770,7 @@ export interface ListingDuplicate {
   storedListing: IdDTO
 }
 
+/** ListingUpdate */
 export interface ListingUpdate {
   /**  */
   id: string
@@ -5117,6 +5073,7 @@ export interface ListingUpdate {
   requestedChangesUser?: IdDTO
 }
 
+/** Accessibility */
 export interface Accessibility {
   /**  */
   id: string
@@ -5140,6 +5097,7 @@ export interface Accessibility {
   other?: boolean
 }
 
+/** Demographic */
 export interface Demographic {
   /**  */
   id: string
@@ -5166,6 +5124,7 @@ export interface Demographic {
   race: string[]
 }
 
+/** Applicant */
 export interface Applicant {
   /**  */
   id: string
@@ -5222,6 +5181,7 @@ export interface Applicant {
   applicantAddress: Address
 }
 
+/** AlternateContact */
 export interface AlternateContact {
   /**  */
   id: string
@@ -5257,6 +5217,7 @@ export interface AlternateContact {
   address: Address
 }
 
+/** HouseholdMember */
 export interface HouseholdMember {
   /**  */
   id: string
@@ -5307,6 +5268,7 @@ export interface HouseholdMember {
   householdMemberAddress: Address
 }
 
+/** ApplicationMultiselectQuestionOption */
 export interface ApplicationMultiselectQuestionOption {
   /**  */
   key: string
@@ -5321,6 +5283,7 @@ export interface ApplicationMultiselectQuestionOption {
   extraData?: AllExtraDataTypes[]
 }
 
+/** ApplicationMultiselectQuestion */
 export interface ApplicationMultiselectQuestion {
   /**  */
   multiselectQuestionId: string
@@ -5335,6 +5298,7 @@ export interface ApplicationMultiselectQuestion {
   options: ApplicationMultiselectQuestionOption[]
 }
 
+/** ApplicationLotteryPosition */
 export interface ApplicationLotteryPosition {
   /**  */
   listingId: string
@@ -5349,6 +5313,7 @@ export interface ApplicationLotteryPosition {
   ordinal: number
 }
 
+/** Application */
 export interface Application {
   /**  */
   id: string
@@ -5465,6 +5430,7 @@ export interface Application {
   applicationLotteryPositions: ApplicationLotteryPosition[]
 }
 
+/** ApplicationFlaggedSet */
 export interface ApplicationFlaggedSet {
   /**  */
   id: string
@@ -5503,6 +5469,7 @@ export interface ApplicationFlaggedSet {
   applications: Application[]
 }
 
+/** ApplicationFlaggedSetPaginationMeta */
 export interface ApplicationFlaggedSetPaginationMeta {
   /**  */
   currentPage: number
@@ -5523,6 +5490,7 @@ export interface ApplicationFlaggedSetPaginationMeta {
   totalFlagged: number
 }
 
+/** PaginatedAfs */
 export interface PaginatedAfs {
   /**  */
   items: ApplicationFlaggedSet[]
@@ -5531,6 +5499,7 @@ export interface PaginatedAfs {
   meta: ApplicationFlaggedSetPaginationMeta
 }
 
+/** AfsMeta */
 export interface AfsMeta {
   /**  */
   totalCount?: number
@@ -5548,6 +5517,7 @@ export interface AfsMeta {
   totalEmailPendingCount?: number
 }
 
+/** AfsResolve */
 export interface AfsResolve {
   /**  */
   afsId: string
@@ -5559,11 +5529,13 @@ export interface AfsResolve {
   applications: IdDTO[]
 }
 
+/** AmiChartQueryParams */
 export interface AmiChartQueryParams {
   /**  */
   jurisdictionId?: string
 }
 
+/** AmiChartCreate */
 export interface AmiChartCreate {
   /**  */
   items: AmiChartItem[]
@@ -5575,6 +5547,7 @@ export interface AmiChartCreate {
   jurisdictions: IdDTO
 }
 
+/** AmiChartUpdate */
 export interface AmiChartUpdate {
   /**  */
   id: string
@@ -5586,11 +5559,13 @@ export interface AmiChartUpdate {
   name: string
 }
 
+/** ReservedCommunityTypeQueryParams */
 export interface ReservedCommunityTypeQueryParams {
   /**  */
   jurisdictionId?: string
 }
 
+/** ReservedCommunityType */
 export interface ReservedCommunityType {
   /**  */
   id: string
@@ -5611,6 +5586,7 @@ export interface ReservedCommunityType {
   jurisdictions: IdDTO
 }
 
+/** ReservedCommunityTypeCreate */
 export interface ReservedCommunityTypeCreate {
   /**  */
   name: string
@@ -5622,6 +5598,7 @@ export interface ReservedCommunityTypeCreate {
   jurisdictions: IdDTO
 }
 
+/** ReservedCommunityTypeUpdate */
 export interface ReservedCommunityTypeUpdate {
   /**  */
   id: string
@@ -5633,6 +5610,7 @@ export interface ReservedCommunityTypeUpdate {
   description?: string
 }
 
+/** UnitTypeCreate */
 export interface UnitTypeCreate {
   /**  */
   name: UnitTypeEnum
@@ -5641,6 +5619,7 @@ export interface UnitTypeCreate {
   numBedrooms: number
 }
 
+/** UnitTypeUpdate */
 export interface UnitTypeUpdate {
   /**  */
   id: string
@@ -5652,11 +5631,13 @@ export interface UnitTypeUpdate {
   numBedrooms: number
 }
 
+/** UnitAccessibilityPriorityTypeCreate */
 export interface UnitAccessibilityPriorityTypeCreate {
   /**  */
   name: string
 }
 
+/** UnitAccessibilityPriorityTypeUpdate */
 export interface UnitAccessibilityPriorityTypeUpdate {
   /**  */
   id: string
@@ -5665,11 +5646,13 @@ export interface UnitAccessibilityPriorityTypeUpdate {
   name: string
 }
 
+/** UnitRentTypeCreate */
 export interface UnitRentTypeCreate {
   /**  */
   name: UnitRentTypeEnum
 }
 
+/** UnitRentTypeUpdate */
 export interface UnitRentTypeUpdate {
   /**  */
   id: string
@@ -5678,6 +5661,7 @@ export interface UnitRentTypeUpdate {
   name: UnitRentTypeEnum
 }
 
+/** JurisdictionCreate */
 export interface JurisdictionCreate {
   /**  */
   name: string
@@ -5725,6 +5709,7 @@ export interface JurisdictionCreate {
   requiredListingFields: []
 }
 
+/** JurisdictionUpdate */
 export interface JurisdictionUpdate {
   /**  */
   id: string
@@ -5775,6 +5760,7 @@ export interface JurisdictionUpdate {
   requiredListingFields: []
 }
 
+/** FeatureFlag */
 export interface FeatureFlag {
   /**  */
   id: string
@@ -5798,6 +5784,7 @@ export interface FeatureFlag {
   jurisdictions: IdDTO[]
 }
 
+/** Jurisdiction */
 export interface Jurisdiction {
   /**  */
   id: string
@@ -5860,6 +5847,7 @@ export interface Jurisdiction {
   requiredListingFields: []
 }
 
+/** MultiselectQuestionCreate */
 export interface MultiselectQuestionCreate {
   /**  */
   text: string
@@ -5892,6 +5880,7 @@ export interface MultiselectQuestionCreate {
   applicationSection: MultiselectQuestionsApplicationSectionEnum
 }
 
+/** MultiselectQuestionUpdate */
 export interface MultiselectQuestionUpdate {
   /**  */
   id: string
@@ -5927,11 +5916,13 @@ export interface MultiselectQuestionUpdate {
   applicationSection: MultiselectQuestionsApplicationSectionEnum
 }
 
+/** MultiselectQuestionQueryParams */
 export interface MultiselectQuestionQueryParams {
   /**  */
   filter?: string[]
 }
 
+/** MultiselectQuestionFilterParams */
 export interface MultiselectQuestionFilterParams {
   /**  */
   $comparison: EnumMultiselectQuestionFilterParamsComparison
@@ -5943,6 +5934,7 @@ export interface MultiselectQuestionFilterParams {
   applicationSection?: MultiselectQuestionsApplicationSectionEnum
 }
 
+/** AddressInput */
 export interface AddressInput {
   /**  */
   type: InputType
@@ -5954,6 +5946,7 @@ export interface AddressInput {
   value: AddressCreate
 }
 
+/** BooleanInput */
 export interface BooleanInput {
   /**  */
   type: InputType
@@ -5965,6 +5958,7 @@ export interface BooleanInput {
   value: boolean
 }
 
+/** TextInput */
 export interface TextInput {
   /**  */
   type: InputType
@@ -5976,6 +5970,7 @@ export interface TextInput {
   value: string
 }
 
+/** PaginatedApplication */
 export interface PaginatedApplication {
   /**  */
   items: Application[]
@@ -5984,6 +5979,7 @@ export interface PaginatedApplication {
   meta: PaginationMeta
 }
 
+/** PublicAppsFiltered */
 export interface PublicAppsFiltered {
   /**  */
   id: string
@@ -6100,6 +6096,7 @@ export interface PublicAppsFiltered {
   listings: Listing
 }
 
+/** PublicAppsCount */
 export interface PublicAppsCount {
   /**  */
   total: number
@@ -6114,6 +6111,7 @@ export interface PublicAppsCount {
   open: number
 }
 
+/** PublicAppsViewResponse */
 export interface PublicAppsViewResponse {
   /**  */
   displayApplications: PublicAppsFiltered[]
@@ -6122,6 +6120,7 @@ export interface PublicAppsViewResponse {
   applicationsCount: PublicAppsCount
 }
 
+/** ApplicantUpdate */
 export interface ApplicantUpdate {
   /**  */
   firstName?: string
@@ -6169,6 +6168,7 @@ export interface ApplicantUpdate {
   applicantWorkAddress: AddressCreate
 }
 
+/** AlternateContactUpdate */
 export interface AlternateContactUpdate {
   /**  */
   type?: AlternateContactRelationship
@@ -6195,6 +6195,7 @@ export interface AlternateContactUpdate {
   address: AddressCreate
 }
 
+/** AccessibilityUpdate */
 export interface AccessibilityUpdate {
   /**  */
   mobility?: boolean
@@ -6209,6 +6210,7 @@ export interface AccessibilityUpdate {
   other?: boolean
 }
 
+/** DemographicUpdate */
 export interface DemographicUpdate {
   /**  */
   ethnicity?: string
@@ -6226,6 +6228,7 @@ export interface DemographicUpdate {
   race: string[]
 }
 
+/** HouseholdMemberUpdate */
 export interface HouseholdMemberUpdate {
   /**  */
   orderId?: number
@@ -6270,6 +6273,7 @@ export interface HouseholdMemberUpdate {
   householdMemberWorkAddress?: AddressCreate
 }
 
+/** ApplicationCreate */
 export interface ApplicationCreate {
   /**  */
   appUrl?: string
@@ -6362,6 +6366,7 @@ export interface ApplicationCreate {
   preferredUnitTypes: IdDTO[]
 }
 
+/** ApplicationUpdate */
 export interface ApplicationUpdate {
   /**  */
   id: string
@@ -6457,16 +6462,19 @@ export interface ApplicationUpdate {
   preferredUnitTypes: IdDTO[]
 }
 
+/** CreatePresignedUploadMetadata */
 export interface CreatePresignedUploadMetadata {
   /**  */
   parametersToSign: object
 }
 
+/** CreatePresignedUploadMetadataResponse */
 export interface CreatePresignedUploadMetadataResponse {
   /**  */
   signature: string
 }
 
+/** EmailAndAppUrl */
 export interface EmailAndAppUrl {
   /**  */
   email: string
@@ -6475,6 +6483,7 @@ export interface EmailAndAppUrl {
   appUrl?: string
 }
 
+/** UserRole */
 export interface UserRole {
   /**  */
   isAdmin?: boolean
@@ -6489,6 +6498,7 @@ export interface UserRole {
   isSuperAdmin?: boolean
 }
 
+/** User */
 export interface User {
   /**  */
   id: string
@@ -6566,11 +6576,13 @@ export interface User {
   favoriteListings?: IdDTO[]
 }
 
+/** UserFilterParams */
 export interface UserFilterParams {
   /**  */
   isPortalUser?: boolean
 }
 
+/** PaginatedUser */
 export interface PaginatedUser {
   /**  */
   items: User[]
@@ -6579,6 +6591,7 @@ export interface PaginatedUser {
   meta: PaginationMeta
 }
 
+/** UserCreate */
 export interface UserCreate {
   /**  */
   firstName: string
@@ -6629,6 +6642,7 @@ export interface UserCreate {
   jurisdictions?: IdDTO[]
 }
 
+/** UserInvite */
 export interface UserInvite {
   /**  */
   firstName: string
@@ -6670,16 +6684,19 @@ export interface UserInvite {
   jurisdictions: IdDTO[]
 }
 
+/** RequestSingleUseCode */
 export interface RequestSingleUseCode {
   /**  */
   email: string
 }
 
+/** ConfirmationRequest */
 export interface ConfirmationRequest {
   /**  */
   token: string
 }
 
+/** UserFavoriteListing */
 export interface UserFavoriteListing {
   /**  */
   id: string
@@ -6688,6 +6705,7 @@ export interface UserFavoriteListing {
   action: ModificationEnum
 }
 
+/** UserUpdate */
 export interface UserUpdate {
   /**  */
   id: string
@@ -6741,6 +6759,7 @@ export interface UserUpdate {
   jurisdictions?: IdDTO[]
 }
 
+/** Login */
 export interface Login {
   /**  */
   email: string
@@ -6758,6 +6777,7 @@ export interface Login {
   reCaptchaToken?: string
 }
 
+/** LoginViaSingleUseCode */
 export interface LoginViaSingleUseCode {
   /**  */
   email: string
@@ -6766,6 +6786,7 @@ export interface LoginViaSingleUseCode {
   singleUseCode: string
 }
 
+/** RequestMfaCode */
 export interface RequestMfaCode {
   /**  */
   email: string
@@ -6780,6 +6801,7 @@ export interface RequestMfaCode {
   phoneNumber?: string
 }
 
+/** RequestMfaCodeResponse */
 export interface RequestMfaCodeResponse {
   /**  */
   phoneNumber?: string
@@ -6791,6 +6813,7 @@ export interface RequestMfaCodeResponse {
   phoneNumberVerified?: boolean
 }
 
+/** UpdatePassword */
 export interface UpdatePassword {
   /**  */
   password: string
@@ -6802,6 +6825,7 @@ export interface UpdatePassword {
   token: string
 }
 
+/** Confirm */
 export interface Confirm {
   /**  */
   token: string
@@ -6810,6 +6834,7 @@ export interface Confirm {
   password?: string
 }
 
+/** MapLayer */
 export interface MapLayer {
   /**  */
   id: string
@@ -6821,11 +6846,13 @@ export interface MapLayer {
   jurisdictionId: string
 }
 
+/** BulkApplicationResendDTO */
 export interface BulkApplicationResendDTO {
   /**  */
   listingId: string
 }
 
+/** AmiChartImportDTO */
 export interface AmiChartImportDTO {
   /**  */
   values: string
@@ -6837,6 +6864,7 @@ export interface AmiChartImportDTO {
   jurisdictionId: string
 }
 
+/** AmiChartUpdateImportDTO */
 export interface AmiChartUpdateImportDTO {
   /**  */
   values: string
@@ -6845,6 +6873,7 @@ export interface AmiChartUpdateImportDTO {
   amiId: string
 }
 
+/** CommunityTypeDTO */
 export interface CommunityTypeDTO {
   /**  */
   id: string
@@ -6856,6 +6885,7 @@ export interface CommunityTypeDTO {
   description?: string
 }
 
+/** FeatureFlagAssociate */
 export interface FeatureFlagAssociate {
   /**  */
   id: string
@@ -6867,6 +6897,7 @@ export interface FeatureFlagAssociate {
   remove: string[]
 }
 
+/** FeatureFlagCreate */
 export interface FeatureFlagCreate {
   /**  */
   name: FeatureFlagEnum
@@ -6878,6 +6909,7 @@ export interface FeatureFlagCreate {
   active: boolean
 }
 
+/** FeatureFlagUpdate */
 export interface FeatureFlagUpdate {
   /**  */
   id: string
@@ -6889,6 +6921,7 @@ export interface FeatureFlagUpdate {
   active: boolean
 }
 
+/** ApplicationCsvQueryParams */
 export interface ApplicationCsvQueryParams {
   /**  */
   id: string
@@ -6900,6 +6933,7 @@ export interface ApplicationCsvQueryParams {
   timeZone?: string
 }
 
+/** ListingLotteryStatus */
 export interface ListingLotteryStatus {
   /**  */
   id: string
@@ -6908,6 +6942,7 @@ export interface ListingLotteryStatus {
   lotteryStatus: LotteryStatusEnum
 }
 
+/** LotteryActivityLogItem */
 export interface LotteryActivityLogItem {
   /**  */
   status: string
@@ -6919,6 +6954,7 @@ export interface LotteryActivityLogItem {
   logDate: Date
 }
 
+/** PublicLotteryResult */
 export interface PublicLotteryResult {
   /**  */
   ordinal: number
@@ -6927,12 +6963,49 @@ export interface PublicLotteryResult {
   multiselectQuestionId?: string
 }
 
+/** PublicLotteryTotal */
 export interface PublicLotteryTotal {
   /**  */
   total: number
 
   /**  */
   multiselectQuestionId?: string
+}
+
+/** ExternalizedListing */
+export interface ExternalizedListing {
+  /**  */
+  id: string
+
+  /**  */
+  name?: string
+
+  /**  */
+  ordinal?: number
+
+  /**  */
+  contentUpdatedAt: Date
+
+  /**  */
+  jurisdictionId: string
+}
+
+/** ExternalizedDetails */
+export interface ExternalizedDetails {
+  /**  */
+  jurisdictions: IdDTO[]
+
+  /**  */
+  listings: ExternalizedListing[]
+
+  /**  */
+  reservedCommunityTypes: IdDTO[]
+
+  /**  */
+  unitRentTypes: IdDTO[]
+
+  /**  */
+  unitTypes: IdDTO[]
 }
 
 export enum FilterAvailabilityEnum {

--- a/sites/partners/.env.template
+++ b/sites/partners/.env.template
@@ -18,7 +18,7 @@ API_PASS_KEY="some-key-here"
 
 # feature toggles
 SHOW_LOTTERY=FALSE
-# controls whethere the application export is a spreadsheet (TRUE) or a csv (FALSE)
+# controls whether the application export is a spreadsheet (TRUE) or a csv (FALSE)
 APPLICATION_EXPORT_AS_SPREADSHEET=FALSE
 # controls use of edit, republish, and reopen functionality when listing is closed
 LIMIT_CLOSED_LISTING_ACTIONS=FALSE

--- a/yarn.lock
+++ b/yarn.lock
@@ -3790,7 +3790,7 @@
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.12.tgz#b5d76568485b02a307238270bfe96cb51ee2a044"
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
 
-"@types/react@*", "@types/react@19.2.14", "@types/react@^19.1.1", "@types/react@^19.2.7":
+"@types/react@*", "@types/react@^19.1.1", "@types/react@^19.2.7":
   version "19.2.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.14.tgz#39604929b5e3957e3a6fa0001dafb17c7af70bad"
   integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==


### PR DESCRIPTION
This PR addresses [#(6365)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/6365)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Implements the externalize endpoints for the external listing service.
Pulls over parts of the following commints:
- [feat: implement external listing service](https://github.com/bloom-housing/bloom/commit/70d8f1e6a1b646934ec39afc6c8c7630417f5750)
- [feat: external listing migration and service](https://github.com/bloom-housing/bloom/commit/f6621c67324865dc650f814e7db4ef74b7a70bcb)

## How Can This Be Tested/Reviewed?

Through the API, call GET `/externalListings`
Should return an object that includes ids and names of jurisdictions, reservedCommunityTypes, unitRentTypes, unitTypes and ids, contentUpdatedAt and jurisdictionIds for all active listings.
Change data in the db or through partners portals and confirm changes are reflected in the data

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
